### PR TITLE
fix(vss): in-use files on other drives cannot be backuped

### DIFF
--- a/src/BSH.Service/VSS/VssBackup.cs
+++ b/src/BSH.Service/VSS/VssBackup.cs
@@ -1,5 +1,5 @@
-﻿using Alphaleonis.Win32.Vss;
-using System.Diagnostics;
+﻿using System.Diagnostics;
+using Alphaleonis.Win32.Vss;
 
 namespace BSH.Service.VSS
 {

--- a/src/BSH.Service/VSS/XCopy.cs
+++ b/src/BSH.Service/VSS/XCopy.cs
@@ -1,0 +1,147 @@
+﻿// Copyright 2022 Alexander Seeliger
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+namespace BSH.Service.VSS;
+
+
+/// <summary>
+/// PInvoke wrapper for CopyEx
+/// http://msdn.microsoft.com/en-us/library/windows/desktop/aa363852.aspx
+/// </summary>
+public class XCopy
+{
+    public static void Copy(string source, string destination, bool overwrite, bool nobuffering)
+    {
+        new XCopy().CopyInternal(source, destination, overwrite, nobuffering, null);
+    }
+
+    public static void Copy(string source, string destination, bool overwrite, bool nobuffering, EventHandler<ProgressChangedEventArgs> handler)
+    {
+        new XCopy().CopyInternal(source, destination, overwrite, nobuffering, handler);
+    }
+
+    private event EventHandler Completed;
+    private event EventHandler<ProgressChangedEventArgs> ProgressChanged;
+
+    private int IsCancelled;
+    private int FilePercentCompleted;
+    private string Source;
+    private string Destination;
+
+    private XCopy()
+    {
+        IsCancelled = 0;
+    }
+
+    private void CopyInternal(string source, string destination, bool overwrite, bool nobuffering, EventHandler<ProgressChangedEventArgs> handler)
+    {
+        try
+        {
+            CopyFileFlags copyFileFlags = CopyFileFlags.COPY_FILE_RESTARTABLE;
+            if (!overwrite)
+                copyFileFlags |= CopyFileFlags.COPY_FILE_FAIL_IF_EXISTS;
+
+            if (nobuffering)
+                copyFileFlags |= CopyFileFlags.COPY_FILE_NO_BUFFERING;
+
+            Source = source;
+            Destination = destination;
+
+            if (handler != null)
+                ProgressChanged += handler;
+
+            bool result = CopyFileEx(Source, Destination, new CopyProgressRoutine(CopyProgressHandler), IntPtr.Zero, ref IsCancelled, copyFileFlags);
+            if (!result)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+        catch (Exception)
+        {
+            if (handler != null)
+                ProgressChanged -= handler;
+
+            throw;
+        }
+    }
+
+    private void OnProgressChanged(double percent)
+    {
+        // only raise an event when progress has changed
+        if ((int)percent > FilePercentCompleted)
+        {
+            FilePercentCompleted = (int)percent;
+
+            var handler = ProgressChanged;
+            if (handler != null)
+                handler(this, new ProgressChangedEventArgs((int)FilePercentCompleted, null));
+        }
+    }
+
+    private void OnCompleted()
+    {
+        var handler = Completed;
+        if (handler != null)
+            handler(this, EventArgs.Empty);
+    }
+
+    #region PInvoke
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CopyFileEx(string lpExistingFileName, string lpNewFileName, CopyProgressRoutine lpProgressRoutine, IntPtr lpData, ref Int32 pbCancel, CopyFileFlags dwCopyFlags);
+
+    private delegate CopyProgressResult CopyProgressRoutine(long TotalFileSize, long TotalBytesTransferred, long StreamSize, long StreamBytesTransferred, uint dwStreamNumber, CopyProgressCallbackReason dwCallbackReason,
+                                                    IntPtr hSourceFile, IntPtr hDestinationFile, IntPtr lpData);
+
+    private enum CopyProgressResult : uint
+    {
+        PROGRESS_CONTINUE = 0,
+        PROGRESS_CANCEL = 1,
+        PROGRESS_STOP = 2,
+        PROGRESS_QUIET = 3
+    }
+
+    private enum CopyProgressCallbackReason : uint
+    {
+        CALLBACK_CHUNK_FINISHED = 0x00000000,
+        CALLBACK_STREAM_SWITCH = 0x00000001
+    }
+
+    [Flags]
+    private enum CopyFileFlags : uint
+    {
+        COPY_FILE_FAIL_IF_EXISTS = 0x00000001,
+        COPY_FILE_NO_BUFFERING = 0x00001000,
+        COPY_FILE_RESTARTABLE = 0x00000002,
+        COPY_FILE_OPEN_SOURCE_FOR_WRITE = 0x00000004,
+        COPY_FILE_ALLOW_DECRYPTED_DESTINATION = 0x00000008
+    }
+
+    private CopyProgressResult CopyProgressHandler(long total, long transferred, long streamSize, long streamByteTrans, uint dwStreamNumber,
+                                                   CopyProgressCallbackReason reason, IntPtr hSourceFile, IntPtr hDestinationFile, IntPtr lpData)
+    {
+        if (reason == CopyProgressCallbackReason.CALLBACK_CHUNK_FINISHED)
+            OnProgressChanged((transferred / (double)total) * 100.0);
+
+        if (transferred >= total)
+            OnCompleted();
+
+        return CopyProgressResult.PROGRESS_CONTINUE;
+    }
+
+    #endregion
+
+}

--- a/src/BSH.Service/VSS/XCopy.cs
+++ b/src/BSH.Service/VSS/XCopy.cs
@@ -53,25 +53,35 @@ public class XCopy
         {
             CopyFileFlags copyFileFlags = CopyFileFlags.COPY_FILE_RESTARTABLE;
             if (!overwrite)
+            {
                 copyFileFlags |= CopyFileFlags.COPY_FILE_FAIL_IF_EXISTS;
+            }
 
             if (nobuffering)
+            {
                 copyFileFlags |= CopyFileFlags.COPY_FILE_NO_BUFFERING;
+            }
 
             Source = source;
             Destination = destination;
 
             if (handler != null)
+            {
                 ProgressChanged += handler;
+            }
 
             bool result = CopyFileEx(Source, Destination, new CopyProgressRoutine(CopyProgressHandler), IntPtr.Zero, ref IsCancelled, copyFileFlags);
             if (!result)
+            {
                 throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
         }
         catch (Exception)
         {
             if (handler != null)
+            {
                 ProgressChanged -= handler;
+            }
 
             throw;
         }
@@ -86,7 +96,9 @@ public class XCopy
 
             var handler = ProgressChanged;
             if (handler != null)
+            {
                 handler(this, new ProgressChangedEventArgs((int)FilePercentCompleted, null));
+            }
         }
     }
 
@@ -94,7 +106,9 @@ public class XCopy
     {
         var handler = Completed;
         if (handler != null)
+        {
             handler(this, EventArgs.Empty);
+        }
     }
 
     #region PInvoke
@@ -134,10 +148,14 @@ public class XCopy
                                                    CopyProgressCallbackReason reason, IntPtr hSourceFile, IntPtr hDestinationFile, IntPtr lpData)
     {
         if (reason == CopyProgressCallbackReason.CALLBACK_CHUNK_FINISHED)
+        {
             OnProgressChanged((transferred / (double)total) * 100.0);
+        }
 
         if (transferred >= total)
+        {
             OnCompleted();
+        }
 
         return CopyProgressResult.PROGRESS_CONTINUE;
     }

--- a/src/BSH.Service/VSSService.cs
+++ b/src/BSH.Service/VSSService.cs
@@ -14,91 +14,37 @@
 
 using BSH.Service.Shared;
 using BSH.Service.VSS;
-using System.Runtime.InteropServices;
 
-namespace BSH.Service
+namespace BSH.Service;
+
+public class VSSService : IVSSRemoteObject
 {
-    public class VSSService : IVSSRemoteObject
+    private Exception exception;
+
+    public bool CopyFileWithVSS(string vssServiceFolder, string source, string destination)
     {
-        private Exception exception;
+        var fileInfo = new FileInfo(source);
 
-        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        static extern bool CopyFileEx(string lpExistingFileName, string lpNewFileName,
-           CopyProgressRoutine lpProgressRoutine, IntPtr lpData, ref Int32 pbCancel,
-           CopyFileFlags dwCopyFlags);
-
-        delegate CopyProgressResult CopyProgressRoutine(
-            long TotalFileSize,
-            long TotalBytesTransferred,
-            long StreamSize,
-            long StreamBytesTransferred,
-            uint dwStreamNumber,
-            CopyProgressCallbackReason dwCallbackReason,
-            IntPtr hSourceFile,
-            IntPtr hDestinationFile,
-            IntPtr lpData);
-
-        int pbCancel;
-
-        enum CopyProgressResult : uint
+        try
         {
-            PROGRESS_CONTINUE = 0,
-            PROGRESS_CANCEL = 1,
-            PROGRESS_STOP = 2,
-            PROGRESS_QUIET = 3
+            using var vss = new VssBackup();
+            vss.Setup(fileInfo.Directory.Root.Name);
+
+            var snapshotPath = vss.GetSnapshotPath(source);
+            XCopy.Copy(snapshotPath, destination, true, false);
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            this.exception = ex;
         }
 
-        enum CopyProgressCallbackReason : uint
-        {
-            CALLBACK_CHUNK_FINISHED = 0x00000000,
-            CALLBACK_STREAM_SWITCH = 0x00000001
-        }
+        return false;
+    }
 
-        [Flags]
-        enum CopyFileFlags : uint
-        {
-            COPY_FILE_FAIL_IF_EXISTS = 0x00000001,
-            COPY_FILE_RESTARTABLE = 0x00000002,
-            COPY_FILE_OPEN_SOURCE_FOR_WRITE = 0x00000004,
-            COPY_FILE_ALLOW_DECRYPTED_DESTINATION = 0x00000008
-        }
-
-        private void XCopy(string oldFile, string newFile)
-        {
-            CopyFileEx(oldFile, newFile, new CopyProgressRoutine(this.CopyProgressHandler), IntPtr.Zero, ref pbCancel, CopyFileFlags.COPY_FILE_RESTARTABLE);
-        }
-
-        private CopyProgressResult CopyProgressHandler(long total, long transferred, long streamSize, long StreamByteTrans, uint dwStreamNumber, CopyProgressCallbackReason reason, IntPtr hSourceFile, IntPtr hDestinationFile, IntPtr lpData)
-        {
-            return CopyProgressResult.PROGRESS_CONTINUE;
-        }
-
-        public bool CopyFileWithVSS(string vssServiceFolder, string source, string destination)
-        {
-            var fileInfo = new FileInfo(vssServiceFolder);
-
-            try
-            {
-                using var vss = new VssBackup();
-                vss.Setup(fileInfo.Directory.Root.Name);
-
-                var snapshotPath = vss.GetSnapshotPath(source);
-                XCopy(snapshotPath, destination);
-
-                return true;
-            }
-            catch (Exception ex)
-            {
-                this.exception = ex;
-            }
-
-            return false;
-        }
-
-        public Exception GetException()
-        {
-            return this.exception;
-        }
+    public Exception GetException()
+    {
+        return this.exception;
     }
 }


### PR DESCRIPTION
Due to passing the wrong path to the VSS controller, files on drives other than on BSH's install path cannot be copied.