### PR TITLE
chore: remove unnecessary dependencies

### DIFF
--- a/src/BSH.Controls/BSH.Controls.csproj
+++ b/src/BSH.Controls/BSH.Controls.csproj
@@ -41,7 +41,4 @@
   <ItemGroup>
     <ProjectReference Include="..\BSH.Engine\BSH.Engine.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.10" />
-  </ItemGroup>
 </Project>

--- a/src/BSH.Test/BSH.Test.csproj
+++ b/src/BSH.Test/BSH.Test.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.10" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BSH.Engine\BSH.Engine.csproj" />

--- a/src/PreviewHandlerFramework/PreviewHandlerFramework.csproj
+++ b/src/PreviewHandlerFramework/PreviewHandlerFramework.csproj
@@ -23,9 +23,6 @@
     <Service Include="{B4F97281-0DBD-4835-9ED8-7DFB966E87FF}" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.10" />
-  </ItemGroup>
-  <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
chore: remove unnecessary dependencies

#### PR Classification
Codebereinigung zur Entfernung einer nicht mehr benötigten Paketreferenz.

#### PR Summary
Entfernung der Paketreferenz `Microsoft.Windows.Compatibility` in der Version `8.0.10` aus mehreren Projektdateien.
- `BSH.Controls.csproj`: Paketreferenz entfernt
- `BSH.Test.csproj`: Paketreferenz entfernt
- `PreviewHandlerFramework.csproj`: Paketreferenz entfernt
