### PR TITLE
fix(browser): status handling of multiple files/versions can cause crash

### DIFF
--- a/src/BSH.Engine/Jobs/IJobReport.cs
+++ b/src/BSH.Engine/Jobs/IJobReport.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Brightbits.BSH.Engine.Models;
 
@@ -34,4 +36,60 @@ public interface IJobReport
     RequestOverwriteResult RequestOverwrite(FileTableRow localFile, FileTableRow remoteFile);
 
     void RequestShowErrorInsufficientDiskSpace();
+}
+
+public class ForwardJobReport : IJobReport
+{
+    private readonly IJobReport report;
+    private List<FileExceptionEntry> files = new();
+
+    public ForwardJobReport(IJobReport report)
+    {
+        this.report = report;
+    }
+
+    public void ReportAction(ActionType action, bool silent)
+    {
+        // not used
+    }
+
+    public void ReportState(JobState jobState)
+    {
+        // not used
+    }
+
+    public void ReportStatus(string title, string text)
+    {
+        // not used
+    }
+
+    public void ReportProgress(int total, int current)
+    {
+        // not used
+    }
+
+    public void ReportFileProgress(string file)
+    {
+        // not used
+    }
+
+    public void ReportExceptions(Collection<FileExceptionEntry> files, bool silent)
+    {
+        this.files.AddRange(files);
+    }
+
+    public RequestOverwriteResult RequestOverwrite(FileTableRow localFile, FileTableRow remoteFile)
+    {
+        return this.report.RequestOverwrite(localFile, remoteFile);
+    }
+
+    public void RequestShowErrorInsufficientDiskSpace()
+    {
+        this.report.RequestShowErrorInsufficientDiskSpace();
+    }
+
+    public void ForwardExceptions(bool silent)
+    {
+        this.report.ReportExceptions(new Collection<FileExceptionEntry>(this.files), silent);
+    }
 }

--- a/src/BSH.Engine/Jobs/IJobReport.cs
+++ b/src/BSH.Engine/Jobs/IJobReport.cs
@@ -59,7 +59,7 @@ public class ForwardJobReport : IJobReport
 
     public void ReportStatus(string title, string text)
     {
-        // not used
+        this.report.ReportStatus(title, text);
     }
 
     public void ReportProgress(int total, int current)
@@ -69,7 +69,7 @@ public class ForwardJobReport : IJobReport
 
     public void ReportFileProgress(string file)
     {
-        // not used
+        this.report.ReportFileProgress(file);
     }
 
     public void ReportExceptions(Collection<FileExceptionEntry> files, bool silent)

--- a/src/BSH.Engine/Jobs/IJobReport.cs
+++ b/src/BSH.Engine/Jobs/IJobReport.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Brightbits.BSH.Engine.Models;

--- a/src/BSH.Engine/Jobs/Job.cs
+++ b/src/BSH.Engine/Jobs/Job.cs
@@ -15,11 +15,9 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.IO;
 using System.Threading.Tasks;
 using Brightbits.BSH.Engine.Contracts;
 using Brightbits.BSH.Engine.Contracts.Database;
-using Brightbits.BSH.Engine.Database;
 using Brightbits.BSH.Engine.Exceptions;
 using Brightbits.BSH.Engine.Models;
 using Brightbits.BSH.Engine.Storage;

--- a/src/BSH.Main/Dialogs/frmBrowser.cs
+++ b/src/BSH.Main/Dialogs/frmBrowser.cs
@@ -1360,7 +1360,9 @@ public partial class frmBrowser : IStatusReport
     private void bgrWorkSearch_RunWorkerCompleted(object sender, System.ComponentModel.RunWorkerCompletedEventArgs e)
     {
         if (e.Result == null)
+        {
             return;
+        }
 
         // update UI
         lvFiles.BeginUpdate();

--- a/src/BSH.Main/Modules/BackupController.cs
+++ b/src/BSH.Main/Modules/BackupController.cs
@@ -356,7 +356,6 @@ public class BackupController
         {
             try
             {
-                jobReportCallback.ReportFileProgress(file);
                 jobReportCallback.ReportProgress(files.Count, files.IndexOf(file) + 1);
 
                 // restore file

--- a/src/BSH.MainApp/BSH.MainApp.csproj
+++ b/src/BSH.MainApp/BSH.MainApp.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="H.NotifyIcon.WinUI" Version="2.2.0" />
     <PackageReference Include="Humanizer.Core" Version="2.14.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.241114003" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />


### PR DESCRIPTION
This PR fixes an issue where multi status updates can cause the backup browser to crash.