### PR TITLE
build(deps): update to dotnet 9

### DIFF
--- a/.github/workflows/dotnet-desktop-build.yml
+++ b/.github/workflows/dotnet-desktop-build.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Setup dotnet
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.201
+        dotnet-version: 9.0.101
 
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/dotnet-desktop-release.yml
+++ b/.github/workflows/dotnet-desktop-release.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Setup dotnet
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.201
+        dotnet-version: 9.0.101
 
     - name: Checkout
       uses: actions/checkout@v4

--- a/src/BSH.Controls/BSH.Controls.csproj
+++ b/src/BSH.Controls/BSH.Controls.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows8.0</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>

--- a/src/BSH.Controls/UI/LoadingCircle.cs
+++ b/src/BSH.Controls/UI/LoadingCircle.cs
@@ -85,7 +85,8 @@ namespace MRG.Controls.UI
         /// <value>The lightest color of the circle.</value>
         [TypeConverter("System.Drawing.ColorConverter"),
          Category("LoadingCircle"),
-         Description("Sets the color of spoke.")]
+         Description("Sets the color of spoke."),
+        DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public Color Color
         {
             get
@@ -106,7 +107,8 @@ namespace MRG.Controls.UI
         /// </summary>
         /// <value>The outer circle radius.</value>
         [System.ComponentModel.Description("Gets or sets the radius of outer circle."),
-         System.ComponentModel.Category("LoadingCircle")]
+         System.ComponentModel.Category("LoadingCircle"),
+        DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public int OuterCircleRadius
         {
             get
@@ -130,7 +132,8 @@ namespace MRG.Controls.UI
         /// </summary>
         /// <value>The inner circle radius.</value>
         [System.ComponentModel.Description("Gets or sets the radius of inner circle."),
-         System.ComponentModel.Category("LoadingCircle")]
+         System.ComponentModel.Category("LoadingCircle"),
+        DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public int InnerCircleRadius
         {
             get
@@ -154,7 +157,8 @@ namespace MRG.Controls.UI
         /// </summary>
         /// <value>The number of spoke.</value>
         [System.ComponentModel.Description("Gets or sets the number of spoke."),
-        System.ComponentModel.Category("LoadingCircle")]
+        System.ComponentModel.Category("LoadingCircle"),
+        DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public int NumberSpoke
         {
             get
@@ -184,7 +188,8 @@ namespace MRG.Controls.UI
         /// </summary>
         /// <value><c>true</c> if active; otherwise, <c>false</c>.</value>
         [System.ComponentModel.Description("Gets or sets the number of spoke."),
-        System.ComponentModel.Category("LoadingCircle")]
+        System.ComponentModel.Category("LoadingCircle"),
+        DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public bool Active
         {
             get
@@ -203,7 +208,8 @@ namespace MRG.Controls.UI
         /// </summary>
         /// <value>The spoke thickness.</value>
         [System.ComponentModel.Description("Gets or sets the thickness of a spoke."),
-        System.ComponentModel.Category("LoadingCircle")]
+        System.ComponentModel.Category("LoadingCircle"),
+        DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public int SpokeThickness
         {
             get
@@ -227,7 +233,8 @@ namespace MRG.Controls.UI
         /// </summary>
         /// <value>The rotation speed.</value>
         [System.ComponentModel.Description("Gets or sets the rotation speed. Higher the slower."),
-        System.ComponentModel.Category("LoadingCircle")]
+        System.ComponentModel.Category("LoadingCircle"),
+        DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public int RotationSpeed
         {
             get

--- a/src/BSH.Controls/UI/aVersionList.cs
+++ b/src/BSH.Controls/UI/aVersionList.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 
@@ -22,6 +23,7 @@ namespace Brightbits.BSH.Main
     [Serializable()]
     public partial class aVersionList
     {
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public List<aVersionListItem> Items { get; set; } = new List<aVersionListItem>();
 
         public event ItemClickEventHandler ItemClick;

--- a/src/BSH.Controls/UI/aVersionListItem.cs
+++ b/src/BSH.Controls/UI/aVersionListItem.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.ComponentModel;
 using System.Drawing;
 using Brightbits.BSH.Engine.Models;
 
@@ -29,6 +30,7 @@ namespace Brightbits.BSH.Main
 
         public delegate void ItemClickEventHandler(aVersionListItem sender);
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public bool VersionStable
         {
             get
@@ -41,11 +43,13 @@ namespace Brightbits.BSH.Main
             }
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public VersionDetails Version
         {
             get; set;
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public string ToolTipTitle
         {
             get
@@ -58,6 +62,7 @@ namespace Brightbits.BSH.Main
             }
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public string ToolTip
         {
             get
@@ -79,6 +84,7 @@ namespace Brightbits.BSH.Main
             }
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public string VersionID
         {
             get
@@ -91,6 +97,7 @@ namespace Brightbits.BSH.Main
             }
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public string VersionDate
         {
             get

--- a/src/BSH.Controls/UI/ucNavigation.cs
+++ b/src/BSH.Controls/UI/ucNavigation.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.ComponentModel;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -86,6 +87,7 @@ namespace Brightbits.BSH.Main
             ItemClick?.Invoke(sPath);
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public string Path
         {
             get
@@ -99,6 +101,7 @@ namespace Brightbits.BSH.Main
             }
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public string PathLocalized
         {
             get; set;

--- a/src/BSH.Engine/BSH.Engine.csproj
+++ b/src/BSH.Engine/BSH.Engine.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows8.0</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <RootNamespace>Brightbits.BSH.Engine</RootNamespace>
     <StartupObject></StartupObject>
@@ -44,12 +44,12 @@
     <PackageReference Include="FluentFTP">
       <Version>52.0.0</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
-      <Version>8.0.2</Version>
+      <Version>9.0.0</Version>
     </PackageReference>
     <PackageReference Include="Quartz">
       <Version>3.13.1</Version>
@@ -58,12 +58,12 @@
       <Version>4.2.0</Version>
     </PackageReference>
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" />
-    <PackageReference Include="System.Management" Version="8.0.0" />
+    <PackageReference Include="System.Management" Version="9.0.0" />
     <PackageReference Include="System.Net.Primitives">
       <Version>4.3.1</Version>
     </PackageReference>
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.1" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.0" />
     <PackageReference Include="ServiceWire" Version="5.6.0" />
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/src/BSH.Main/BSH.Main.csproj
+++ b/src/BSH.Main/BSH.Main.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows8.0</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <OutputType>WinExe</OutputType>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <PublishUrl>publish\</PublishUrl>
@@ -84,7 +84,7 @@
     <PackageReference Include="Humanizer.Core.de">
       <Version>2.14.1</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/BSH.Main/Dialogs/frmFileProperties.cs
+++ b/src/BSH.Main/Dialogs/frmFileProperties.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Windows.Forms;
 using Brightbits.BSH.Engine;
@@ -28,11 +29,14 @@ public partial class frmFileProperties
         InitializeComponent();
     }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public frmBrowser BrowserWindow
     {
         get;
         set;
     }
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public string CurrentFileFolder
     {
         get;

--- a/src/BSH.Main/Dialogs/frmMain.cs
+++ b/src/BSH.Main/Dialogs/frmMain.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
 using System.Windows.Forms;
@@ -45,6 +46,7 @@ public partial class frmMain
     private IMainTabs _iMTCurrentTab;
     private AvailableTabs _aCurrentTab;
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public AvailableTabs CurrentTab
     {
         get

--- a/src/BSH.Main/Dialogs/frmMainTabs/ucConfig.cs
+++ b/src/BSH.Main/Dialogs/frmMainTabs/ucConfig.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -78,6 +79,7 @@ public partial class ucConfig : IMainTabs
 
     private frmMain SuperBase;
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public frmMain Super
     {
         set

--- a/src/BSH.Main/Dialogs/frmMainTabs/ucDoConfigure.cs
+++ b/src/BSH.Main/Dialogs/frmMainTabs/ucDoConfigure.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -54,6 +55,7 @@ public partial class ucDoConfigure : IMainTabs
 
     private frmMain SuperBase;
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public frmMain Super
     {
         set

--- a/src/BSH.Main/Dialogs/frmMainTabs/ucOverview.cs
+++ b/src/BSH.Main/Dialogs/frmMainTabs/ucOverview.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.ComponentModel;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -64,6 +65,7 @@ public partial class ucOverview : IMainTabs, IStatusReport
 
     private frmMain SuperBase;
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public frmMain Super
     {
         set

--- a/src/BSH.MainApp/BSH.MainApp.csproj
+++ b/src/BSH.MainApp/BSH.MainApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-	<TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
+	<TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
 	<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
 	<WindowsSdkPackageVersion>10.0.22621.38</WindowsSdkPackageVersion>
     <RootNamespace>BSH.MainApp</RootNamespace>
@@ -33,7 +33,7 @@
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="H.NotifyIcon.WinUI" Version="2.2.0" />
     <PackageReference Include="Humanizer.Core" Version="2.14.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.241114003" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/src/BSH.Service.Shared/BSH.Service.Shared.csproj
+++ b/src/BSH.Service.Shared/BSH.Service.Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows8.0</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <PlatformTarget>x64</PlatformTarget>
     <Authors>Alexander Seeliger</Authors>

--- a/src/BSH.Service/BSH.Service.csproj
+++ b/src/BSH.Service/BSH.Service.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows8.0</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>dotnet-BSH.Service-3e0461bd-41b4-4b3f-8540-d22ccc314554</UserSecretsId>
@@ -16,9 +16,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AlphaVSS" Version="2.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageReference Include="Serilog" Version="4.2.0" />
     <PackageReference Include="ServiceWire" Version="5.6.0" />
   </ItemGroup>

--- a/src/BSH.Test/BSH.Test.csproj
+++ b/src/BSH.Test/BSH.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows8.0</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <IsPackable>false</IsPackable>
     <PlatformTarget>x64</PlatformTarget>
     <Platforms>x64</Platforms>
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/PreviewHandlerFramework/PreviewHandlerFramework.csproj
+++ b/src/PreviewHandlerFramework/PreviewHandlerFramework.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows8.0</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <RootNamespace>C4F.DevKit.PreviewHandler.PreviewHandlerFramework</RootNamespace>
     <AssemblyName>C4F.DevKit.PreviewHandler.PreviewHandlerFramework</AssemblyName>

--- a/src/PreviewHandlerHost/PreviewHandlerHost.csproj
+++ b/src/PreviewHandlerHost/PreviewHandlerHost.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows8.0</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <RootNamespace>C4F.DevKit.PreviewHandler.PreviewHandlerHost</RootNamespace>
     <AssemblyName>C4F.DevKit.PreviewHandler.PreviewHandlerHost</AssemblyName>

--- a/src/PreviewHandlerHost/PreviewHandlerHostControl.cs
+++ b/src/PreviewHandlerHost/PreviewHandlerHostControl.cs
@@ -35,6 +35,7 @@ namespace C4F.DevKit.PreviewHandler.PreviewHandlerHost
         /// 
         /// Whenever a new path is set, the preview is generated
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public string FilePath
         {
             get

--- a/src/SmartPreview/SmartPreview.csproj
+++ b/src/SmartPreview/SmartPreview.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows8.0</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <OutputType>WinExe</OutputType>
     <StartupObject>SmartPreview.Program</StartupObject>
     <MyType>WindowsFormsWithCustomSubMain</MyType>


### PR DESCRIPTION
#### PR Classification
Upgrade and enhancement of project dependencies and design-time serialization.

#### PR Summary
This pull request upgrades the .NET version and updates package references, along with adding design-time serialization attributes.
- Upgraded .NET version from 8.0 to 9.0 in project files and YAML configurations.
- Added `DesignerSerializationVisibility` attribute to properties in `LoadingCircle.cs`, `aVersionList.cs`, `aVersionListItem.cs`, `ucNavigation.cs`, `frmFileProperties.cs`, `frmMain.cs`, `ucConfig.cs`, `ucDoConfigure.cs`, `ucOverview.cs`, and `PreviewHandlerHostControl.cs`.
- Updated package references in `.csproj` files, including `Microsoft.CodeAnalysis.NetAnalyzers` and `Microsoft.Extensions.Logging.Abstractions`.
- Changed `TargetFramework` to `net9.0-windows` in multiple projects.
- Added `using System.ComponentModel;` statements to support new attributes.
