### PR TITLE
fix(backup): rename directory issue

### DIFF
--- a/src/BSH.Engine/Jobs/BackupJob.cs
+++ b/src/BSH.Engine/Jobs/BackupJob.cs
@@ -383,9 +383,8 @@ public class BackupJob : Job
                 {
                     var lastVersion = await queryManager.GetLastBackupAsync();
 
-                    if (lastVersion != null)
+                    if (lastVersion != null && storage.RenameDirectory(lastVersion.CreationDate.ToString("dd-MM-yyyy HH-mm-ss"), newVersionDate))
                     {
-                        storage.RenameDirectory(lastVersion.CreationDate.ToString("dd-MM-yyyy HH-mm-ss"), newVersionDate);
                         await dbClient.ExecuteNonQueryAsync("UPDATE versiontable SET versionDate = '" + newVersionDate + "' WHERE versionID = " + lastVersion.Id);
                     }
                 }

--- a/src/BSH.Engine/Storage/FTPStorage.cs
+++ b/src/BSH.Engine/Storage/FTPStorage.cs
@@ -434,14 +434,8 @@ public class FtpStorage : Storage, IStorage
 
     public bool RenameDirectory(string remoteDirectorySource, string remoteDirectoryTarget)
     {
-        if (ftpClient.DirectoryExists(Combine(folderPath, remoteDirectoryTarget).GetFtpPath()))
-        {
-            ftpClient.DeleteDirectory(Combine(folderPath, remoteDirectoryTarget).GetFtpPath(), FtpListOption.AllFiles);
-        }
-
-        ftpClient.Rename(Combine(folderPath, remoteDirectorySource).GetFtpPath(),
+        return ftpClient.MoveDirectory(Combine(folderPath, remoteDirectorySource).GetFtpPath(),
             Combine(folderPath, remoteDirectoryTarget).GetFtpPath());
-        return true;
     }
 
     public bool DecryptOnStorage(string remoteFile, string password)


### PR DESCRIPTION
fix(backup): rename directory issue

#### PR Classification
Code cleanup to improve logic and efficiency.

#### PR Summary
Refactored `BackupJob` and `FtpStorage` classes to streamline directory renaming logic.
- `BackupJob.cs`: Added condition to `if` statement to check `lastVersion` and `RenameDirectory` result; removed redundant `RenameDirectory` call.
- `FTPStorage.cs`: Simplified `RenameDirectory` method to directly call `ftpClient.MoveDirectory` and return its result.
