### PR TITLE
feat(dlg): add wait for media window

### DIFF
--- a/src/BSH.MainApp/BSH.MainApp.csproj
+++ b/src/BSH.MainApp/BSH.MainApp.csproj
@@ -27,6 +27,7 @@
     <None Remove="Windows\NewBackupWindow.xaml" />
     <None Remove="Windows\RequestFileOverwriteWindow.xaml" />
     <None Remove="Windows\RequestPasswordWindow.xaml" />
+    <None Remove="Windows\WaitForMediumWindow.xaml" />
   </ItemGroup>
   <ItemGroup>
     <Manifest Include="$(ApplicationManifest)" />
@@ -55,6 +56,9 @@
     <None Update="appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <Page Update="Windows\WaitForMediumWindow.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Update="Windows\RequestFileOverwriteWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/BSH.MainApp/Services/WaitForMediaService.cs
+++ b/src/BSH.MainApp/Services/WaitForMediaService.cs
@@ -3,6 +3,8 @@
 
 using Brightbits.BSH.Engine.Contracts.Services;
 using BSH.MainApp.Contracts.Services;
+using BSH.MainApp.Windows;
+using WinUIEx;
 
 namespace BSH.MainApp.Services;
 
@@ -16,6 +18,8 @@ public class WaitForMediaService : IWaitForMediaService
 
     private long currentWaitingTime = 0L;
 
+    private WaitForMediumWindow? window;
+
     public WaitForMediaService(IBackupService backupService)
     {
         this.backupService = backupService;
@@ -23,16 +27,17 @@ public class WaitForMediaService : IWaitForMediaService
 
     public async Task<bool> ExecuteAsync(bool silent, CancellationTokenSource cancellationTokenSource)
     {
-        //// show window?
-        //if (!silent)
-        //{
-        //    window = new frmWaitForMedia();
-        //    window.OnAbort_Click += cancellationTokenSource.Cancel;
-        //    window.Show();
-        //}
+        // show window?
+        if (!silent)
+        {
+            window = new WaitForMediumWindow();
+            window.ViewModel.OnCancelRequested += cancellationTokenSource.Cancel;
+            window.CenterOnScreen();
+            window.Activate();
+        }
 
         // wait for media
-        bool result = await Task.Run(() =>
+        var result = await Task.Run(() =>
         {
             while (true)
             {
@@ -65,12 +70,12 @@ public class WaitForMediaService : IWaitForMediaService
             return false;
         });
 
-        //// close window
-        //if (!silent)
-        //{
-        //    window.Hide();
-        //    window.Dispose();
-        //}
+        // close window
+        if (!silent)
+        {
+            window?.Close();
+            window = null;
+        }
 
         return result;
     }

--- a/src/BSH.MainApp/ViewModels/Windows/WaitForMediumViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/Windows/WaitForMediumViewModel.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using CommunityToolkit.Mvvm.Input;
+
+namespace BSH.MainApp.ViewModels.Windows;
+
+public partial class WaitForMediumViewModel
+{
+    public event EventHandler? OnCancelRequested;
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        OnCancelRequested?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/src/BSH.MainApp/ViewModels/Windows/WaitForMediumViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/Windows/WaitForMediumViewModel.cs
@@ -7,11 +7,13 @@ namespace BSH.MainApp.ViewModels.Windows;
 
 public partial class WaitForMediumViewModel
 {
-    public event EventHandler? OnCancelRequested;
+    public event OnCancelRequestedEventHandler OnCancelRequested;
+
+    public delegate void OnCancelRequestedEventHandler();
 
     [RelayCommand]
     private void Cancel()
     {
-        OnCancelRequested?.Invoke(this, EventArgs.Empty);
+        OnCancelRequested?.Invoke();
     }
 }

--- a/src/BSH.MainApp/Windows/WaitForMediumWindow.xaml
+++ b/src/BSH.MainApp/Windows/WaitForMediumWindow.xaml
@@ -8,12 +8,13 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     Title="Backup Service Home is waiting for medium"
-    Width="500"
-    Height="400"
+    Width="600"
+    Height="350"
     IsMaximizable="False"
     IsMinimizable="False"
     IsResizable="False"
-    IsAlwaysOnTop="True">
+    IsAlwaysOnTop="True"
+    Closed="WindowEx_Closed">
 
     <Grid>
         <Grid.RowDefinitions>
@@ -39,7 +40,7 @@ The medium will be automatically detected."
         <!-- Cancel Button -->
         <Grid Grid.Row="2" Background="#fafafa" Padding="30,15" BorderBrush="#f0f0f0" BorderThickness="0,1,0,0">
             <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Right">
-                <Button>Cancel</Button>
+                <Button Command="{x:Bind ViewModel.CancelCommand}">Cancel</Button>
             </StackPanel>
         </Grid>
     </Grid>

--- a/src/BSH.MainApp/Windows/WaitForMediumWindow.xaml
+++ b/src/BSH.MainApp/Windows/WaitForMediumWindow.xaml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<winex:WindowEx xmlns:winex="using:WinUIEx"
+    x:Class="BSH.MainApp.Windows.WaitForMediumWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:BSH.MainApp.Windows"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Title="Backup Service Home is waiting for medium"
+    Width="500"
+    Height="400"
+    IsMaximizable="False"
+    IsMinimizable="False"
+    IsResizable="False"
+    IsAlwaysOnTop="True">
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <!-- Progress Ring -->
+        <StackPanel Margin="30" Orientation="Horizontal" VerticalAlignment="Center">
+            <ProgressRing Width="30" Height="30" IsActive="True" Margin="0,0,20,0" />
+            <TextBlock Text="Backup Service Home is waiting for medium..." Style="{StaticResource SubtitleTextBlockStyle}"
+                       VerticalAlignment="Center" />
+        </StackPanel>
+
+        <!-- Description -->
+        <TextBlock Grid.Row="1"
+                   Text="Backup Service Home 3 is waiting for the backup medium to continue with the planned action. Connect this medium to your computer now.
+The medium will be automatically detected."
+                   TextWrapping="Wrap"
+                   Margin="30,0,30,0" />
+
+        <!-- Cancel Button -->
+        <Grid Grid.Row="2" Background="#fafafa" Padding="30,15" BorderBrush="#f0f0f0" BorderThickness="0,1,0,0">
+            <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Right">
+                <Button>Cancel</Button>
+            </StackPanel>
+        </Grid>
+    </Grid>
+</winex:WindowEx>

--- a/src/BSH.MainApp/Windows/WaitForMediumWindow.xaml
+++ b/src/BSH.MainApp/Windows/WaitForMediumWindow.xaml
@@ -9,7 +9,7 @@
     mc:Ignorable="d"
     Title="Backup Service Home is waiting for medium"
     Width="600"
-    Height="350"
+    Height="300"
     IsMaximizable="False"
     IsMinimizable="False"
     IsResizable="False"

--- a/src/BSH.MainApp/Windows/WaitForMediumWindow.xaml.cs
+++ b/src/BSH.MainApp/Windows/WaitForMediumWindow.xaml.cs
@@ -13,4 +13,9 @@ public sealed partial class WaitForMediumWindow : WinUIEx.WindowEx
     {
         this.InitializeComponent();
     }
+
+    private void WindowEx_Closed(object sender, Microsoft.UI.Xaml.WindowEventArgs args)
+    {
+        ViewModel.CancelCommand.Execute(null);
+    }
 }

--- a/src/BSH.MainApp/Windows/WaitForMediumWindow.xaml.cs
+++ b/src/BSH.MainApp/Windows/WaitForMediumWindow.xaml.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using BSH.MainApp.ViewModels.Windows;
+
+namespace BSH.MainApp.Windows;
+
+public sealed partial class WaitForMediumWindow : WinUIEx.WindowEx
+{
+    public WaitForMediumViewModel ViewModel { get; } = new WaitForMediumViewModel();
+
+    public WaitForMediumWindow()
+    {
+        this.InitializeComponent();
+    }
+}


### PR DESCRIPTION
#### PR Classification
New feature to introduce a window for waiting for a backup medium.

#### PR Summary
Introduced a new `WaitForMediumWindow` to display progress and allow cancellation while waiting for a backup medium.
- `BSH.MainApp.csproj`: Updated to include the new XAML file with the appropriate build actions.
- `WaitForMediaService.cs`: Integrated the `WaitForMediumWindow` class to show the window when not in silent mode.
- Added `WaitForMediumViewModel.cs`: Defines the view model with a cancel command and event handler.
- Added `WaitForMediumWindow.xaml`: Defines the XAML layout for the new window.
- Added `WaitForMediumWindow.xaml.cs`: Code-behind for initializing the view model and handling the window's closed event.
