### PR TITLE
feat(dlg): wire up new create backup window

### DIFF
--- a/src/BSH.MainApp/Contracts/Services/IPresentationService.cs
+++ b/src/BSH.MainApp/Contracts/Services/IPresentationService.cs
@@ -4,6 +4,7 @@
 using Brightbits.BSH.Engine.Jobs;
 using Brightbits.BSH.Engine.Models;
 using BSH.MainApp.Models;
+using BSH.MainApp.ViewModels.Windows;
 using Microsoft.UI.Xaml.Controls;
 using Windows.UI.Popups;
 
@@ -18,7 +19,7 @@ public interface IPresentationService
     Task<RequestOverwriteResult> RequestOverwrite(FileTableRow localFile, FileTableRow remoteFile);
     void ShowAboutWindow();
     void ShowBackupBrowserWindow();
-    Task ShowCreateBackupWindow();
+    Task<(bool, NewBackupViewModel)> ShowCreateBackupWindow();
     void ShowErrorInsufficientDiskSpace();
     void ShowMainWindow();
     void ShowStatusWindow();

--- a/src/BSH.MainApp/Services/PresentationService.cs
+++ b/src/BSH.MainApp/Services/PresentationService.cs
@@ -5,6 +5,7 @@ using Brightbits.BSH.Engine.Jobs;
 using Brightbits.BSH.Engine.Models;
 using BSH.MainApp.Contracts.Services;
 using BSH.MainApp.Models;
+using BSH.MainApp.ViewModels.Windows;
 using BSH.MainApp.Windows;
 using Microsoft.UI.Xaml.Controls;
 using Windows.UI.Popups;
@@ -67,10 +68,10 @@ public class PresentationService : IPresentationService
     {
     }
 
-    public async Task ShowCreateBackupWindow()
+    public async Task<(bool, NewBackupViewModel)> ShowCreateBackupWindow()
     {
-        var newBackupWindow = new NewBackupWindow();
-        newBackupWindow.AppWindow.Show();
+        var dialog = new NewBackupWindow();
+        return (await dialog.ShowDialogAsync(), dialog.ViewModel);
     }
 
     public async Task<ContentDialogResult> ShowMessageBoxAsync(string title, string content, IList<IUICommand>? commands, uint defaultCommandIndex = 0, uint cancelCommandIndex = 1)

--- a/src/BSH.MainApp/ViewModels/MainViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/MainViewModel.cs
@@ -67,11 +67,6 @@ public partial class MainViewModel : ObservableRecipient, INavigationAware, ISta
     [ObservableProperty]
     private int? currentProgressMax;
 
-    public ICommand StartManualBackupCommand
-    {
-        get;
-    }
-
     public MainViewModel(
         IPresentationService presentationService,
         IStatusService statusService,
@@ -89,9 +84,6 @@ public partial class MainViewModel : ObservableRecipient, INavigationAware, ISta
         this.dispatcherQueue = dispatcherQueue;
         this.statusService.AddObserver(this, true);
         this.configurationManager = configurationManager;
-
-        // init commands
-        StartManualBackupCommand = new AsyncRelayCommand(StartManualBackupCommandAsync);
     }
 
     public async void OnNavigatedTo(object parameter)
@@ -133,7 +125,8 @@ public partial class MainViewModel : ObservableRecipient, INavigationAware, ISta
         TotalBackups = (await queryManager.GetNumberOfVersionsAsync()).ToString("g");
     }
 
-    private async Task StartManualBackupCommandAsync()
+    [RelayCommand]
+    private async Task StartManualBackup()
     {
         var (result, backup) = await this.presentationService.ShowCreateBackupWindow();
         if (result)

--- a/src/BSH.MainApp/ViewModels/MainViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/MainViewModel.cs
@@ -112,12 +112,12 @@ public partial class MainViewModel : ObservableRecipient, INavigationAware, ISta
         // set configuration
         if (configurationManager.TaskType == TaskType.Auto)
         {
-            NextBackupDate = scheduledBackupService.GetNextBackupDate().ToString("DATETIME_FORMAT".GetLocalized());
+            NextBackupDate = scheduledBackupService.GetNextBackupDate().HumanizeDate();
             BackupMode = "MainView_BackupMode_Automatic".GetLocalized();
         }
         else if (configurationManager.TaskType == TaskType.Schedule)
         {
-            NextBackupDate = scheduledBackupService.GetNextBackupDate().ToString("DATETIME_FORMAT".GetLocalized());
+            NextBackupDate = scheduledBackupService.GetNextBackupDate().HumanizeDate();
             BackupMode = "MainView_BackupMode_Scheduled".GetLocalized();
         }
         else

--- a/src/BSH.MainApp/ViewModels/Windows/NewBackupViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/Windows/NewBackupViewModel.cs
@@ -2,10 +2,14 @@
 // Licensed under the Apache License, Version 2.0.
 
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 
 namespace BSH.MainApp.ViewModels.Windows;
+
 public partial class NewBackupViewModel : ObservableRecipient
 {
+    public TaskCompletionSource<bool> TaskCompletionSource { get; } = new TaskCompletionSource<bool>();
+
     [ObservableProperty]
     private string? title;
 
@@ -13,8 +17,20 @@ public partial class NewBackupViewModel : ObservableRecipient
     private string? description;
 
     [ObservableProperty]
-    private bool? isFullBackup;
+    private bool isFullBackup = false;
 
     [ObservableProperty]
-    private bool? isShutdownPc;
+    private bool isShutdownPc = false;
+
+    [RelayCommand]
+    private void StartBackup()
+    {
+        TaskCompletionSource.SetResult(true);
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        TaskCompletionSource.SetResult(false);
+    }
 }

--- a/src/BSH.MainApp/ViewModels/Windows/RequestFileOverwriteViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/Windows/RequestFileOverwriteViewModel.cs
@@ -8,10 +8,7 @@ using CommunityToolkit.Mvvm.Input;
 namespace BSH.MainApp.ViewModels.Windows;
 public partial class RequestFileOverwriteViewModel : ObservableRecipient
 {
-    public TaskCompletionSource<RequestOverwriteResult> TaskCompletionSource
-    {
-        get; set;
-    }
+    public TaskCompletionSource<RequestOverwriteResult> TaskCompletionSource { get; } = new TaskCompletionSource<RequestOverwriteResult>();
 
     [ObservableProperty]
     private string fileName;

--- a/src/BSH.MainApp/Windows/NewBackupWindow.xaml
+++ b/src/BSH.MainApp/Windows/NewBackupWindow.xaml
@@ -41,8 +41,8 @@
 
         <Grid Grid.Row="1" Background="#fafafa" Padding="30,20" BorderBrush="#f0f0f0" BorderThickness="0,1,0,0">
             <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Right">
-                <Button>Cancel</Button>
-                <Button Style="{StaticResource AccentButtonStyle}">Create Backup</Button>
+                <Button Command="{x:Bind ViewModel.CancelCommand}">Cancel</Button>
+                <Button Command="{x:Bind ViewModel.StartBackupCommand}" Style="{StaticResource AccentButtonStyle}">Create Backup</Button>
             </StackPanel>
         </Grid>
     </Grid>

--- a/src/BSH.MainApp/Windows/NewBackupWindow.xaml
+++ b/src/BSH.MainApp/Windows/NewBackupWindow.xaml
@@ -39,7 +39,7 @@
             </StackPanel>
         </Grid>
 
-        <Grid Grid.Row="1" Background="#fafafa" Padding="30,20" BorderBrush="#f0f0f0" BorderThickness="0,1,0,0">
+        <Grid Grid.Row="1" Background="#fafafa" Padding="30,10" BorderBrush="#f0f0f0" BorderThickness="0,1,0,0">
             <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Right">
                 <Button Command="{x:Bind ViewModel.CancelCommand}">Cancel</Button>
                 <Button Command="{x:Bind ViewModel.StartBackupCommand}" Style="{StaticResource AccentButtonStyle}">Create Backup</Button>

--- a/src/BSH.MainApp/Windows/NewBackupWindow.xaml.cs
+++ b/src/BSH.MainApp/Windows/NewBackupWindow.xaml.cs
@@ -13,4 +13,13 @@ public sealed partial class NewBackupWindow : WinUIEx.WindowEx
     {
         this.InitializeComponent();
     }
+
+    public async Task<bool> ShowDialogAsync()
+    {
+        this.Activate();
+        var result = await ViewModel.TaskCompletionSource.Task;
+
+        this.Close();
+        return result;
+    }
 }

--- a/src/BSH.MainApp/Windows/RequestFileOverwriteWindow.xaml
+++ b/src/BSH.MainApp/Windows/RequestFileOverwriteWindow.xaml
@@ -73,7 +73,7 @@
                 </toolkit:SettingsCard.HeaderIcon>
             </toolkit:SettingsCard>
         </StackPanel>
-        <Grid Grid.Row="1" Background="#fafafa" Padding="30,20" BorderBrush="#f0f0f0" BorderThickness="0,1,0,0">
+        <Grid Grid.Row="1" Background="#fafafa" Padding="30,10" BorderBrush="#f0f0f0" BorderThickness="0,1,0,0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"></ColumnDefinition>
                 <ColumnDefinition Width="Auto"></ColumnDefinition>

--- a/src/BSH.MainApp/Windows/RequestFileOverwriteWindow.xaml.cs
+++ b/src/BSH.MainApp/Windows/RequestFileOverwriteWindow.xaml.cs
@@ -5,13 +5,7 @@ using Brightbits.BSH.Engine.Jobs;
 using Brightbits.BSH.Engine.Models;
 using BSH.MainApp.ViewModels.Windows;
 
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
-
 namespace BSH.MainApp.Windows;
-/// <summary>
-/// An empty window that can be used on its own or navigated to within a Frame.
-/// </summary>
 public sealed partial class RequestFileOverwriteWindow : WinUIEx.WindowEx
 {
     private RequestFileOverwriteViewModel ViewModel { get; } = new RequestFileOverwriteViewModel();
@@ -23,8 +17,6 @@ public sealed partial class RequestFileOverwriteWindow : WinUIEx.WindowEx
 
     public async Task<RequestOverwriteResult> ShowDialogAsync(FileTableRow localFile, FileTableRow remoteFile)
     {
-        this.ViewModel.TaskCompletionSource = new TaskCompletionSource<RequestOverwriteResult>();
-
         this.ViewModel.FileName = localFile.FileName;
         this.ViewModel.SourceFileSize = localFile.FileSize;
         this.ViewModel.SourceLastModified = localFile.FileDateModified;


### PR DESCRIPTION
#### PR Classification
New feature to enhance the backup creation process and improve asynchronous handling.

#### PR Summary
Introduces `NewBackupViewModel` and updates `ShowCreateBackupWindow` to return a tuple for better backup handling.
- `IPresentationService.cs` and `PresentationService.cs`: Updated `ShowCreateBackupWindow` to return a tuple.
- `MainViewModel`: Added navigation event handlers and replaced `StartManualBackupCommandAsync` with `[RelayCommand]` decorated method.
- `NewBackupViewModel`: Added properties and commands for backup details.
- `NewBackupWindow.xaml`: Bound buttons to `NewBackupViewModel` commands.
- `RequestFileOverwriteViewModel`: Initialized `TaskCompletionSource` directly.
