### PR TITLE
feat(browser): add file icons to backup browser

### DIFF
--- a/src/BSH.MainApp/Constants.cs
+++ b/src/BSH.MainApp/Constants.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace BSH.Main;
+public static class Constants
+{
+    public static class Filesystem
+    {
+        public const string CachedEmptyItemName = "fileicon_cache";
+    }
+}

--- a/src/BSH.MainApp/Models/FileOrFolderItem.cs
+++ b/src/BSH.MainApp/Models/FileOrFolderItem.cs
@@ -9,6 +9,11 @@ namespace BSH.MainApp.Models;
 
 public class FileOrFolderItem : INotifyPropertyChanged
 {
+    public string FileNameOnDrive
+    {
+        get; set;
+    }
+
     public string Name
     {
         get; set;
@@ -40,7 +45,7 @@ public class FileOrFolderItem : INotifyPropertyChanged
     }
 
     private BitmapSource _icon;
-    public BitmapSource Icon
+    public BitmapSource Icon16
     {
         get => _icon;
         set
@@ -48,6 +53,12 @@ public class FileOrFolderItem : INotifyPropertyChanged
             _icon = value;
             this.OnPropertyChanged();
         }
+    }
+
+    public BitmapSource Icon64
+    {
+        get;
+        set;
     }
 
     public event PropertyChangedEventHandler PropertyChanged;

--- a/src/BSH.MainApp/Models/FileOrFolderItem.cs
+++ b/src/BSH.MainApp/Models/FileOrFolderItem.cs
@@ -44,18 +44,13 @@ public class FileOrFolderItem : INotifyPropertyChanged
         get; set;
     }
 
-    private BitmapSource _icon;
-    public BitmapSource Icon16
+    public BitmapSource? Icon16
     {
-        get => _icon;
-        set
-        {
-            _icon = value;
-            this.OnPropertyChanged();
-        }
+        get;
+        set;
     }
 
-    public BitmapSource Icon64
+    public BitmapSource? Icon64
     {
         get;
         set;

--- a/src/BSH.MainApp/Utils/FileSystemIconHelpers.cs
+++ b/src/BSH.MainApp/Utils/FileSystemIconHelpers.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Microsoft.UI.Xaml.Media.Imaging;
+using Windows.Storage.FileProperties;
+using Windows.Storage;
+using BSH.Main;
+
+namespace BSH.MainApp.Utils;
+public static class FileSystemIconHelpers
+{
+    private static readonly Dictionary<string, BitmapImage> cachedIcons = [];
+
+    /// <summary>
+    /// Get the icon of a file
+    /// </summary>
+    /// <param name="fileName"></param>
+    /// <param name="requestedSize"></param>
+    /// <returns></returns>
+    public static async Task<BitmapSource?> GetFileIconAsync(string fileName, uint requestedSize = 16)
+    {
+        try
+        {
+            var fileExtension = Path.GetExtension(fileName);
+
+            // cache?
+            if (!string.IsNullOrEmpty(fileExtension) && cachedIcons.TryGetValue($"{fileExtension}_{requestedSize}", out var cachedIcon))
+            {
+                return cachedIcon;
+            }
+
+            var applicationData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            var localFolder = await StorageFolder.GetFolderFromPathAsync(applicationData);
+
+            StorageItemThumbnail icon;
+
+            if (string.IsNullOrEmpty(fileExtension))
+            {
+                icon = await localFolder.GetThumbnailAsync(ThumbnailMode.ListView, requestedSize, ThumbnailOptions.UseCurrentScale);
+            }
+            else
+            {
+                var emptyFile = await localFolder.CreateFileAsync(string.Join(Constants.Filesystem.CachedEmptyItemName, fileExtension), CreationCollisionOption.OpenIfExists);
+                icon = await emptyFile.GetThumbnailAsync(ThumbnailMode.SingleItem, requestedSize, ThumbnailOptions.UseCurrentScale);
+                await emptyFile.DeleteAsync(StorageDeleteOption.PermanentDelete);
+            }
+
+            if (icon == null)
+            {
+                return null;
+            }
+
+            var bitmap = new BitmapImage();
+            await bitmap.SetSourceAsync(icon);
+
+            // cache!
+            if (!string.IsNullOrEmpty(fileExtension))
+            {
+                cachedIcons.Add($"{fileExtension}_{requestedSize}", bitmap);
+            }
+
+            return bitmap;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Clear the icon cache
+    /// </summary>
+    public static void ClearIconCache()
+    {
+        cachedIcons.Clear();
+    }
+}

--- a/src/BSH.MainApp/Utils/FileSystemIconHelpers.cs
+++ b/src/BSH.MainApp/Utils/FileSystemIconHelpers.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Alexander Seeliger. All Rights Reserved.
 // Licensed under the Apache License, Version 2.0.
 
-using Microsoft.UI.Xaml.Media.Imaging;
-using Windows.Storage.FileProperties;
-using Windows.Storage;
 using BSH.Main;
+using Microsoft.UI.Xaml.Media.Imaging;
+using Windows.Storage;
+using Windows.Storage.FileProperties;
 
 namespace BSH.MainApp.Utils;
 public static class FileSystemIconHelpers

--- a/src/BSH.MainApp/ViewModels/BrowserViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/BrowserViewModel.cs
@@ -277,6 +277,8 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
             })
             .ToList();
 
+        // TODO: load icons when backup medium not available
+        // TODO: load icons when file is remote
         foreach (var file in fileList)
         {
             file.Icon16 = await GetFileIconAsync(file.FileNameOnDrive);

--- a/src/BSH.MainApp/ViewModels/BrowserViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/BrowserViewModel.cs
@@ -4,17 +4,12 @@
 using System.Collections.ObjectModel;
 using Brightbits.BSH.Engine.Contracts;
 using Brightbits.BSH.Engine.Models;
-using BSH.Main;
 using BSH.MainApp.Contracts.Services;
 using BSH.MainApp.Contracts.ViewModels;
 using BSH.MainApp.Models;
 using BSH.MainApp.Utils;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using Microsoft.UI.Xaml.Media.Imaging;
-using Microsoft.Windows.Management.Deployment;
-using Windows.Storage;
-using Windows.Storage.FileProperties;
 
 namespace BSH.MainApp.ViewModels;
 

--- a/src/BSH.MainApp/Views/BrowserPage.xaml
+++ b/src/BSH.MainApp/Views/BrowserPage.xaml
@@ -277,7 +277,7 @@
                                     </Grid.ColumnDefinitions>
                                     <StackPanel Orientation="Horizontal">
                                         <FontIcon Visibility="{x:Bind IsFile, Mode=OneWay, Converter={StaticResource VisibilityInvertConverter}}" VerticalAlignment="Center" FontSize="16" FontFamily="Segoe MDL2 Assets" Glyph="&#xE8B7;" Margin="0,0,10,0" />
-                                        <Image Visibility="{x:Bind IsFile, Mode=OneWay}" Source="{x:Bind Icon, Mode=OneWay}" Height="16" Width="16" Margin="0,0,10,0" />
+                                        <Image Visibility="{x:Bind IsFile, Mode=OneWay}" Source="{x:Bind Icon16, Mode=OneWay}" Height="16" Width="16" Margin="0,0,10,0" />
                                         <TextBlock Grid.Column="0" VerticalAlignment="Center" Text="{x:Bind Name, Mode=OneWay}" />
                                     </StackPanel>
                                     <TextBlock Visibility="{x:Bind IsFile, Mode=OneWay}" Grid.Column="1" VerticalAlignment="Center" Text="{x:Bind FileDateModified, Mode=OneWay}"/>
@@ -302,6 +302,9 @@
                     <StackPanel
                         Orientation="Vertical"
                         Spacing="8">
+                        <Image Visibility="{x:Bind ViewModel.CurrentItem.IsFile, Mode=OneWay}" Source="{x:Bind ViewModel.CurrentItem.Icon64, Mode=OneWay}" Width="64" Height="64" HorizontalAlignment="Center" />
+                        <FontIcon Visibility="{x:Bind ViewModel.CurrentItem.IsFile, Mode=OneWay, Converter={StaticResource VisibilityInvertConverter}}" VerticalAlignment="Center" FontSize="64" FontFamily="Segoe MDL2 Assets" Glyph="&#xE8B7;" />
+
                         <TextBlock HorizontalAlignment="Center" FontWeight="Bold" Text="{x:Bind ViewModel.CurrentItem.Name, Mode=OneWay}" />
 
                         <TextBlock Style="{StaticResource InfoPaneTitleStyle}">Path</TextBlock>


### PR DESCRIPTION
#### PR Classification
New feature and code enhancement to support multiple icon sizes and improve file handling.

#### PR Summary
Updated file handling to support multiple icon sizes and improved property accessibility.
- `FileOrFolderItem.cs`: Added `FileNameOnDrive` property, renamed `Icon` to `Icon16`, and added `Icon64`.
- `BrowserViewModel.cs`: Changed several `ObservableCollection` properties to public, added `GetFileIconAsync` method, and updated `LoadFolderAsync` to set `FileNameOnDrive` and load icons.
- `BrowserPage.xaml`: Updated `Image` element to use `Icon16` and added a new `Image` element for `Icon64`.
