### PR TITLE
feat(schedule): add logic to wait for device when backup was in the past

### DIFF
--- a/src/BSH.Main/Modules/BackupLogic.cs
+++ b/src/BSH.Main/Modules/BackupLogic.cs
@@ -501,6 +501,9 @@ static class BackupLogic
                 if (DateTime.Now.TimeOfDay > scheduleDate.TimeOfDay && DoPastBackup(DateTime.Now.Date.Add(scheduleDate.TimeOfDay), true))
                 {
                     schedulerService.ScheduleOnce(async () => await thScheduleSysRunBackup(), DateTime.Now.AddMinutes(1));
+
+                    // start backup when device is connected
+                    DoBackupWhenDriveIsAvailable(RunBackupMethod.Schedule);
                 }
 
                 schedulerService.ScheduleDaily(async () => await thScheduleSysRunBackup(), scheduleDate);
@@ -516,6 +519,9 @@ static class BackupLogic
                     if (DateTime.Now.TimeOfDay > scheduleDate.TimeOfDay && DoPastBackup(DateTime.Now.Date.Add(scheduleDate.TimeOfDay), true))
                     {
                         schedulerService.ScheduleOnce(async () => await thScheduleSysRunBackup(), DateTime.Now.AddMinutes(1));
+
+                        // start backup when device is connected
+                        DoBackupWhenDriveIsAvailable(RunBackupMethod.Schedule);
                     }
                 }
                 else
@@ -532,6 +538,9 @@ static class BackupLogic
                             if (DoPastBackup(DateTime.Now.Date.Add(scheduleDate.TimeOfDay), true))
                             {
                                 schedulerService.ScheduleOnce(async () => await thScheduleSysRunBackup(), DateTime.Now.AddMinutes(1));
+
+                                // start backup when device is connected
+                                DoBackupWhenDriveIsAvailable(RunBackupMethod.Schedule);
                             }
 
                             break;
@@ -557,6 +566,9 @@ static class BackupLogic
                     if (DateTime.Now.TimeOfDay > scheduleDate.TimeOfDay && DoPastBackup(DateTime.Now.Date.Add(scheduleDate.TimeOfDay), true))
                     {
                         schedulerService.ScheduleOnce(async () => await thScheduleSysRunBackup(), DateTime.Now.AddMinutes(1));
+
+                        // start backup when device is connected
+                        DoBackupWhenDriveIsAvailable(RunBackupMethod.Schedule);
                     }
                 }
                 else
@@ -573,6 +585,9 @@ static class BackupLogic
                             if (DoPastBackup(DateTime.Now.Date.Add(scheduleDate.TimeOfDay), true))
                             {
                                 schedulerService.ScheduleOnce(async () => await thScheduleSysRunBackup(), DateTime.Now.AddMinutes(1));
+
+                                // start backup when device is connected
+                                DoBackupWhenDriveIsAvailable(RunBackupMethod.Schedule);
                             }
 
                             break;


### PR DESCRIPTION
feat(schedule): add logic to wait for device when backup was in the past

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The backup scheduler now automatically initiates backups when the device becomes available. This update enhances the reliability of backups across various schedules (one-time, hourly, daily, weekly, and monthly) by ensuring tasks are executed promptly upon device connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->