### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-desktop-build.yml
+++ b/.github/workflows/dotnet-desktop-build.yml
@@ -1,5 +1,9 @@
 name: Build pull requests
 
+permissions:
+  contents: read
+  pull-requests: write
+
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/alexsee/bsh3/security/code-scanning/8](https://github.com/alexsee/bsh3/security/code-scanning/8)

To fix the issue, the `permissions` key should be added to either the root of the workflow or the specific `jobs` block. Since the workflow likely requires limited `write` permissions (e.g., for interacting with pull requests or uploading coverage data), the permissions should be explicitly scoped to only the necessary operations. Based on the workflow steps, the following permissions are appropriate:
- `contents: read`: For reading repository contents.
- `pull-requests: write`: If the workflow interacts with pull requests.
- `actions: read`: For accessing workflow artifacts or related metadata.

The `permissions` key will be added at the root level to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
