### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-desktop-release.yml
+++ b/.github/workflows/dotnet-desktop-release.yml
@@ -7,6 +7,10 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+-beta[0-9]+'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
 
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/alexsee/bsh3/security/code-scanning/7](https://github.com/alexsee/bsh3/security/code-scanning/7)

The issue can be resolved by explicitly defining a `permissions` block in the workflow file. This block should specify the least privileges required by the workflow. For this particular workflow:
- `contents: read` allows the workflow to read repository contents.
- `packages: write` or `contents: write` may be required for creating a release or publishing artifacts, depending on the specific needs of the `softprops/action-gh-release` action.

The `permissions` block should be added at the root of the workflow to apply to all jobs unless overridden at the job level.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
