### PR TITLE
fix: standby in win11

### DIFF
--- a/src/BSH.Engine/Win32.cs
+++ b/src/BSH.Engine/Win32.cs
@@ -176,7 +176,7 @@ public class Win32Stuff
 
     static void tmr_Elapsed(object sender, System.Timers.ElapsedEventArgs e)
     {
-        SetThreadExecutionState(EXECUTION_STATE.ES_SYSTEM_REQUIRED);
+        SetThreadExecutionState(EXECUTION_STATE.ES_SYSTEM_REQUIRED | EXECUTION_STATE.ES_CONTINUOUS);
     }
 
     public static void AllowSystemSleep()


### PR DESCRIPTION
fix: standby in win11

#### PR Classification
Enhancement to thread execution state management.

#### PR Summary
This pull request modifies the `tmr_Elapsed` method in the `Win32Stuff` class to include the `ES_CONTINUOUS` flag in the `SetThreadExecutionState` function call, ensuring the system remains in the required state continuously. 
- `Win32.cs`: Updated `SetThreadExecutionState` to include `ES_CONTINUOUS` flag.

Fixes #404