### PR TITLE
Refactor backup and restore flow handling

### DIFF
--- a/src/BSH.Engine/ConfigurationManager.cs
+++ b/src/BSH.Engine/ConfigurationManager.cs
@@ -3,14 +3,18 @@
 
 using System;
 using System.Data;
+using System.Linq;
 using System.Threading.Tasks;
 using Brightbits.BSH.Engine.Contracts;
 using Brightbits.BSH.Engine.Contracts.Database;
+using Brightbits.BSH.Engine.Database;
 
 namespace Brightbits.BSH.Engine;
 
 public class ConfigurationManager : IConfigurationManager
 {
+    private static readonly string[] IntegerBackedProperties = { "Status", "TaskType", "Compression", "Encrypt", "MediumType" };
+
     private readonly IDbClientFactory dbClientFactory;
 
     private string taskType = "2";
@@ -509,40 +513,50 @@ public class ConfigurationManager : IConfigurationManager
 
         foreach (var configEntry in GetType().GetProperties())
         {
-            if (configEntry == null)
+            var result = await LoadConfigurationValueAsync(dbClient, configEntry.Name);
+            if (result == null || result.Equals(DBNull.Value) || TrySetIntegerBackedProperty(configEntry, result))
             {
                 continue;
             }
 
-            var parameters = new (string, object)[] {
-                   ("value", configEntry.Name.Replace("_", ""))
-                };
-
-            var result = await dbClient.ExecuteScalarAsync(CommandType.Text, "SELECT confValue FROM configuration WHERE confProperty LIKE @value LIMIT 1", parameters);
-
-            if (result == null || result.Equals(DBNull.Value))
-            {
-                continue;
-            }
-
-            if (configEntry.Name == "Status" || configEntry.Name == "TaskType" || configEntry.Name == "Compression" || configEntry.Name == "Encrypt" || configEntry.Name == "MediumType")
-            {
-                if (int.TryParse(result.ToString(), out var val))
-                {
-                    configEntry.SetValue(this, val);
-                    continue;
-                }
-                if (configEntry.Name == "MediumType")
-                {
-                    Enum.TryParse(result.ToString(), out MediaType outValue);
-                    configEntry.SetValue(this, outValue);
-                }
-            }
-            else
-            {
-                configEntry.SetValue(this, result);
-            }
+            configEntry.SetValue(this, result);
         }
+    }
+
+    private async Task<object> LoadConfigurationValueAsync(DbClient dbClient, string propertyName)
+    {
+        var parameters = new (string, object)[]
+        {
+            ("value", propertyName.Replace("_", ""))
+        };
+
+        return await dbClient.ExecuteScalarAsync(
+            CommandType.Text,
+            "SELECT confValue FROM configuration WHERE confProperty LIKE @value LIMIT 1",
+            parameters);
+    }
+
+    private bool TrySetIntegerBackedProperty(System.Reflection.PropertyInfo configEntry, object result)
+    {
+        if (!IntegerBackedProperties.Contains(configEntry.Name))
+        {
+            return false;
+        }
+
+        if (int.TryParse(result.ToString(), out var val))
+        {
+            configEntry.SetValue(this, val);
+            return true;
+        }
+
+        if (configEntry.Name == "MediumType")
+        {
+            Enum.TryParse(result.ToString(), out MediaType outValue);
+            configEntry.SetValue(this, outValue);
+            return true;
+        }
+
+        return false;
     }
 
     private void SaveProperty(string property, string value)

--- a/src/BSH.Engine/ConfigurationManager.cs
+++ b/src/BSH.Engine/ConfigurationManager.cs
@@ -553,10 +553,11 @@ public class ConfigurationManager : IConfigurationManager
         {
             Enum.TryParse(result.ToString(), out MediaType outValue);
             configEntry.SetValue(this, outValue);
-            return true;
         }
 
-        return false;
+        // Integer-backed properties are considered handled even when parsing fails,
+        // so invalid persisted values do not overwrite in-memory defaults.
+        return true;
     }
 
     private void SaveProperty(string property, string value)

--- a/src/BSH.Engine/Jobs/BackupJob.cs
+++ b/src/BSH.Engine/Jobs/BackupJob.cs
@@ -489,123 +489,24 @@ public class BackupJob : Job
     /// <exception cref="FileNotProcessedException"></exception>
     private async Task<bool> CopyFileToDeviceAsync(IStorageProvider storage, FileTableRow file, long newVersionId, string newVersionDate, DbClient dbClient, bool normalCopy = false, bool useVss = false)
     {
-        // file variables
         var localFileName = file.FileNamePath();
         var remoteFileName = Path.Combine(newVersionDate, Path.GetFileName(file.FileRoot), file.FilePath, file.FileName);
         var longFileName = "";
 
-        // copy via vss?
         if (useVss)
         {
-            try
-            {
-                _logger.Information("File {fileName} will be attempted to backup via Volume Shadow Copy Service.", localFileName);
-
-                // temporary file path
-                var vssTempFile = Path.Combine(Path.GetTempPath(), file.FileName);
-
-                if (vssClient.CopyFile(localFileName, vssTempFile))
-                {
-                    if (!File.Exists(vssTempFile))
-                    {
-                        // we could not copy the file
-                        _logger.Warning("File {fileName} could not be copied via Volume Shadow Copy Service.", localFileName);
-                        throw new FileNotProcessedException();
-                    }
-
-                    // set new local file name
-                    localFileName = vssTempFile;
-                }
-                else
-                {
-                    // error during copy, so delete temporary file
-                    try
-                    {
-                        File.Delete(vssTempFile);
-                    }
-                    catch
-                    {
-                        // not necessary to handle this error
-                    }
-
-                    // we could not copy the file
-                    _logger.Warning("File {fileName} could not be copied via Volume Shadow Copy Service.", localFileName);
-                    throw new FileNotProcessedException();
-                }
-            }
-            catch (Exception ex)
-            {
-                // we could not copy the file
-                throw new FileNotProcessedException(ex);
-            }
+            localFileName = PrepareVssTempFile(localFileName, file);
         }
 
-        // check if we need to compress the file
-        var doNotCompress = false;
+        var compress = ShouldCompress(file, normalCopy);
+        var encrypt = ShouldEncrypt(file, normalCopy);
+        remoteFileName = EnsureSupportedRemotePath(storage, remoteFileName, localFileName, file, newVersionDate, compress, encrypt, out longFileName);
 
-        if (configurationManager.Compression == 1)
-        {
-            var fileExt = Path.GetExtension(file.FileNamePath()).ToLower(CultureInfo.InvariantCulture);
-
-            if (!string.IsNullOrEmpty(fileExt))
-            {
-                var exts = configurationManager.ExcludeCompression.Split('|');
-
-                if (exts.Contains(fileExt))
-                {
-                    doNotCompress = true;
-                }
-            }
-
-            if (CompressionUtils.IsCompressedFile(fileExt) || file.FileSize < 4 * 8)
-            {
-                doNotCompress = true;
-            }
-        }
-
-        // compress or encrypt?
-        var compress = configurationManager.Compression == 1 && !normalCopy && !doNotCompress;
-        var encrypt = configurationManager.Encrypt == 1 && !normalCopy && file.FileSize > 0;
-
-        // check if path is too long
-        if (storage.IsPathTooLong(remoteFileName, compress, encrypt))
-        {
-            longFileName = Guid.NewGuid().ToString();
-            longFileName += Path.GetExtension(localFileName);
-
-            remoteFileName = Path.Combine(newVersionDate, "_LONGFILES_", longFileName);
-
-            _logger.Debug("{fileName} path is too long to be copied, it will be renamed instead to {longFile}.", file.FileNamePath(), longFileName);
-        }
-
-        // send file to storage provider
         bool result;
         try
         {
-            if (compress)
-            {
-                result = storage.CopyFileToStorageCompressed(localFileName, remoteFileName);
-            }
-            else if (encrypt)
-            {
-                result = storage.CopyFileToStorageEncrypted(localFileName, remoteFileName, Password);
-            }
-            else
-            {
-                result = storage.CopyFileToStorage(localFileName, remoteFileName);
-            }
-
-            if (useVss && localFileName.StartsWith(Path.GetTempPath(), StringComparison.OrdinalIgnoreCase))
-            {
-                try
-                {
-                    File.Delete(localFileName);
-                }
-                catch
-                {
-                    // could not delete temporary file
-                }
-            }
+            result = CopyFileToStorage(storage, localFileName, remoteFileName, compress, encrypt);
+            DeleteVssTempFile(localFileName, useVss);
         }
         catch (IOException ex)
         {
@@ -654,6 +555,113 @@ public class BackupJob : Job
         await AddFileVersionDatabaseEntryAsync(dbClient, file, newVersionId, longFileName, compress, encrypt);
 
         return true;
+    }
+
+    private string PrepareVssTempFile(string localFileName, FileTableRow file)
+    {
+        try
+        {
+            _logger.Information("File {fileName} will be attempted to backup via Volume Shadow Copy Service.", localFileName);
+
+            var vssTempFile = Path.Combine(Path.GetTempPath(), file.FileName);
+            if (vssClient.CopyFile(localFileName, vssTempFile) && File.Exists(vssTempFile))
+            {
+                return vssTempFile;
+            }
+
+            TryDeleteFile(vssTempFile);
+            _logger.Warning("File {fileName} could not be copied via Volume Shadow Copy Service.", localFileName);
+            throw new FileNotProcessedException();
+        }
+        catch (Exception ex)
+        {
+            throw new FileNotProcessedException(ex);
+        }
+    }
+
+    private bool ShouldCompress(FileTableRow file, bool normalCopy)
+    {
+        if (configurationManager.Compression != 1 || normalCopy)
+        {
+            return false;
+        }
+
+        var fileExt = Path.GetExtension(file.FileNamePath()).ToLower(CultureInfo.InvariantCulture);
+        if (CompressionUtils.IsCompressedFile(fileExt) || file.FileSize < 4 * 8)
+        {
+            return false;
+        }
+
+        if (string.IsNullOrEmpty(fileExt))
+        {
+            return true;
+        }
+
+        var excludedExtensions = configurationManager.ExcludeCompression.Split('|');
+        return !excludedExtensions.Contains(fileExt);
+    }
+
+    private bool ShouldEncrypt(FileTableRow file, bool normalCopy)
+    {
+        return configurationManager.Encrypt == 1 && !normalCopy && file.FileSize > 0;
+    }
+
+    private string EnsureSupportedRemotePath(
+        IStorageProvider storage,
+        string remoteFileName,
+        string localFileName,
+        FileTableRow file,
+        string newVersionDate,
+        bool compress,
+        bool encrypt,
+        out string longFileName)
+    {
+        longFileName = "";
+        if (!storage.IsPathTooLong(remoteFileName, compress, encrypt))
+        {
+            return remoteFileName;
+        }
+
+        longFileName = Guid.NewGuid() + Path.GetExtension(localFileName);
+        _logger.Debug("{fileName} path is too long to be copied, it will be renamed instead to {longFile}.", file.FileNamePath(), longFileName);
+        return Path.Combine(newVersionDate, "_LONGFILES_", longFileName);
+    }
+
+    private bool CopyFileToStorage(IStorageProvider storage, string localFileName, string remoteFileName, bool compress, bool encrypt)
+    {
+        if (compress)
+        {
+            return storage.CopyFileToStorageCompressed(localFileName, remoteFileName);
+        }
+
+        if (encrypt)
+        {
+            return storage.CopyFileToStorageEncrypted(localFileName, remoteFileName, Password);
+        }
+
+        return storage.CopyFileToStorage(localFileName, remoteFileName);
+    }
+
+    private static void DeleteVssTempFile(string localFileName, bool useVss)
+    {
+        if (!useVss || !localFileName.StartsWith(Path.GetTempPath(), StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        TryDeleteFile(localFileName);
+    }
+
+    private static void TryDeleteFile(string fileName)
+    {
+        try
+        {
+            File.Delete(fileName);
+        }
+        catch
+        {
+            // not critical
+        }
     }
 
     /// <summary>

--- a/src/BSH.Engine/Jobs/RestoreJob.cs
+++ b/src/BSH.Engine/Jobs/RestoreJob.cs
@@ -289,86 +289,17 @@ public class RestoreJob : Job
         var localFilePath = Path.Combine(destination, reader.GetString("fileName"));
         var fileType = reader.GetInt32("fileType");
 
-        // check overwrite
-        if (warning && System.IO.File.Exists(localFilePath))
+        if (await ShouldSkipOverwriteAsync(localFilePath, destination, reader, warning))
         {
-            if (FileOverwrite == FileOverwrite.Ask)
-            {
-                var localFileInfo = new FileInfo(localFilePath);
-
-                var localFile = new FileTableRow()
-                {
-                    FileName = reader.GetString("fileName"),
-                    FilePath = destination,
-                    FileSize = localFileInfo.Length,
-                    FileDateModified = localFileInfo.LastWriteTime
-                };
-
-                var remoteFile = new FileTableRow()
-                {
-                    FileName = reader.GetString("fileName"),
-                    FileSize = (long)reader.GetDouble(reader.GetOrdinal("fileSize")),
-                    FileDateModified = reader.GetDateTime("fileDateModified")
-                };
-
-                // request user input for overwrite
-                var overwriteRequest = this.overwriteRequestPersistent != RequestOverwriteResult.None ? this.overwriteRequestPersistent : await RequestOverwrite(localFile, remoteFile);
-
-                if (overwriteRequest == RequestOverwriteResult.NoOverwriteAll || overwriteRequest == RequestOverwriteResult.OverwriteAll)
-                {
-                    this.overwriteRequestPersistent = overwriteRequest;
-                }
-
-                if (overwriteRequest == RequestOverwriteResult.NoOverwrite || overwriteRequest == RequestOverwriteResult.NoOverwriteAll)
-                {
-                    return;
-                }
-            }
-            else if (FileOverwrite == FileOverwrite.DontCopy)
-            {
-                return;
-            }
+            return;
         }
 
-        // remove old file
-        if (System.IO.File.Exists(localFilePath))
-        {
-            try
-            {
-                System.IO.File.Delete(localFilePath);
-            }
-            catch (Exception ex)
-            {
-                throw new FileNotProcessedException(ex);
-            }
-        }
+        DeleteExistingFile(localFilePath);
 
         try
         {
-            // copy file
-            string remoteFilePath;
-
-            if (!string.IsNullOrEmpty(reader.GetString("longfilename")))
-            {
-                remoteFilePath = reader.GetString("versionDate") + "\\_LONGFILES_\\" + reader.GetString("longfilename");
-            }
-            else
-            {
-                remoteFilePath = reader.GetString("versionDate") + reader.GetString("filePath") + reader.GetString("fileName");
-            }
-
-            if (fileType == 1 || fileType == 3)
-            {
-                storage.CopyFileFromStorage(localFilePath, remoteFilePath);
-            }
-            else if (fileType == 2 || fileType == 4)
-            {
-                storage.CopyFileFromStorageCompressed(localFilePath, remoteFilePath);
-            }
-            else if (fileType == 5 || fileType == 6)
-            {
-                storage.CopyFileFromStorageEncrypted(localFilePath, remoteFilePath, Password);
-            }
+            var remoteFilePath = BuildRemoteFilePath(reader);
+            CopyFromStorage(storage, fileType, localFilePath, remoteFilePath);
         }
         catch (Exception ex)
         {
@@ -384,6 +315,105 @@ public class RestoreJob : Job
         catch
         {
             // ignore this exception
+        }
+    }
+
+    private async Task<bool> ShouldSkipOverwriteAsync(string localFilePath, string destination, IDataReader reader, bool warning)
+    {
+        if (!warning || !System.IO.File.Exists(localFilePath))
+        {
+            return false;
+        }
+
+        if (FileOverwrite == FileOverwrite.DontCopy)
+        {
+            return true;
+        }
+
+        if (FileOverwrite != FileOverwrite.Ask)
+        {
+            return false;
+        }
+
+        var overwriteRequest = await GetOverwriteDecisionAsync(localFilePath, destination, reader);
+        if (overwriteRequest == RequestOverwriteResult.NoOverwriteAll || overwriteRequest == RequestOverwriteResult.OverwriteAll)
+        {
+            overwriteRequestPersistent = overwriteRequest;
+        }
+
+        return overwriteRequest == RequestOverwriteResult.NoOverwrite || overwriteRequest == RequestOverwriteResult.NoOverwriteAll;
+    }
+
+    private async Task<RequestOverwriteResult> GetOverwriteDecisionAsync(string localFilePath, string destination, IDataReader reader)
+    {
+        if (overwriteRequestPersistent != RequestOverwriteResult.None)
+        {
+            return overwriteRequestPersistent;
+        }
+
+        var localFileInfo = new FileInfo(localFilePath);
+        var localFile = new FileTableRow
+        {
+            FileName = reader.GetString("fileName"),
+            FilePath = destination,
+            FileSize = localFileInfo.Length,
+            FileDateModified = localFileInfo.LastWriteTime
+        };
+
+        var remoteFile = new FileTableRow
+        {
+            FileName = reader.GetString("fileName"),
+            FileSize = (long)reader.GetDouble(reader.GetOrdinal("fileSize")),
+            FileDateModified = reader.GetDateTime("fileDateModified")
+        };
+
+        return await RequestOverwrite(localFile, remoteFile);
+    }
+
+    private static void DeleteExistingFile(string localFilePath)
+    {
+        if (!System.IO.File.Exists(localFilePath))
+        {
+            return;
+        }
+
+        try
+        {
+            System.IO.File.Delete(localFilePath);
+        }
+        catch (Exception ex)
+        {
+            throw new FileNotProcessedException(ex);
+        }
+    }
+
+    private static string BuildRemoteFilePath(IDataReader reader)
+    {
+        if (!string.IsNullOrEmpty(reader.GetString("longfilename")))
+        {
+            return reader.GetString("versionDate") + "\\_LONGFILES_\\" + reader.GetString("longfilename");
+        }
+
+        return reader.GetString("versionDate") + reader.GetString("filePath") + reader.GetString("fileName");
+    }
+
+    private void CopyFromStorage(IStorageProvider storage, int fileType, string localFilePath, string remoteFilePath)
+    {
+        if (fileType == 1 || fileType == 3)
+        {
+            storage.CopyFileFromStorage(localFilePath, remoteFilePath);
+            return;
+        }
+
+        if (fileType == 2 || fileType == 4)
+        {
+            storage.CopyFileFromStorageCompressed(localFilePath, remoteFilePath);
+            return;
+        }
+
+        if (fileType == 5 || fileType == 6)
+        {
+            storage.CopyFileFromStorageEncrypted(localFilePath, remoteFilePath, Password);
         }
     }
 }

--- a/src/BSH.Engine/QueryManager.cs
+++ b/src/BSH.Engine/QueryManager.cs
@@ -11,6 +11,7 @@ using Brightbits.BSH.Engine.Contracts.Database;
 using Brightbits.BSH.Engine.Contracts.Storage;
 using Brightbits.BSH.Engine.Database;
 using Brightbits.BSH.Engine.Models;
+using Brightbits.BSH.Engine.Providers.Ports;
 
 namespace Brightbits.BSH.Engine;
 
@@ -551,49 +552,62 @@ public class QueryManager : IQueryManager
         {
             if (await reader.ReadAsync())
             {
-                var fileType = reader.GetInt32("fileType");
-
-                if (fileType == 1)
-                {
-                    result = GetFileNameFromDrive(FileTableRow.FromReaderFileVersion(reader));
-                }
-                else if (fileType >= 2 && fileType <= 6)
-                {
-                    temp = true;
-
-                    var localFilePath = Path.Combine(Path.GetTempPath(), reader.GetString("fileName"));
-                    var remoteFilePath = "";
-
-                    if (!string.IsNullOrEmpty(reader.GetString("longfilename")))
-                    {
-                        remoteFilePath = reader.GetString("versionDate") + "\\_LONG_FILES\\" + reader.GetString("longfilename");
-                    }
-                    else
-                    {
-                        remoteFilePath = reader.GetString("versionDate") + reader.GetString("filePath") + reader.GetString("fileName");
-                    }
-
-                    if (fileType == 3)
-                    {
-                        storage.CopyFileFromStorage(localFilePath, remoteFilePath);
-                    }
-                    else if (fileType == 2 || fileType == 4)
-                    {
-                        storage.CopyFileFromStorageCompressed(localFilePath, remoteFilePath);
-                    }
-                    else if (fileType == 5 || fileType == 6)
-                    {
-                        storage.CopyFileFromStorageEncrypted(localFilePath, remoteFilePath, password);
-                    }
-
-                    result = localFilePath;
-                }
+                (result, temp) = ResolveFileFromStorage(reader, storage, password);
             }
 
             await reader.CloseAsync();
         }
 
         return (result, temp);
+    }
+
+    private (string result, bool temp) ResolveFileFromStorage(System.Data.Common.DbDataReader reader, IStorageProvider storage, string password)
+    {
+        var fileType = reader.GetInt32("fileType");
+        if (fileType == 1)
+        {
+            return (GetFileNameFromDrive(FileTableRow.FromReaderFileVersion(reader)), false);
+        }
+
+        if (fileType < 2 || fileType > 6)
+        {
+            return (null, false);
+        }
+
+        var localFilePath = Path.Combine(Path.GetTempPath(), reader.GetString("fileName"));
+        var remoteFilePath = BuildRemoteFilePath(reader);
+        CopyFileByType(storage, fileType, localFilePath, remoteFilePath, password);
+        return (localFilePath, true);
+    }
+
+    private static string BuildRemoteFilePath(System.Data.Common.DbDataReader reader)
+    {
+        if (!string.IsNullOrEmpty(reader.GetString("longfilename")))
+        {
+            return reader.GetString("versionDate") + "\\_LONG_FILES\\" + reader.GetString("longfilename");
+        }
+
+        return reader.GetString("versionDate") + reader.GetString("filePath") + reader.GetString("fileName");
+    }
+
+    private static void CopyFileByType(IStorageProvider storage, int fileType, string localFilePath, string remoteFilePath, string password)
+    {
+        if (fileType == 3)
+        {
+            storage.CopyFileFromStorage(localFilePath, remoteFilePath);
+            return;
+        }
+
+        if (fileType == 2 || fileType == 4)
+        {
+            storage.CopyFileFromStorageCompressed(localFilePath, remoteFilePath);
+            return;
+        }
+
+        if (fileType == 5 || fileType == 6)
+        {
+            storage.CopyFileFromStorageEncrypted(localFilePath, remoteFilePath, password);
+        }
     }
 
     /// <summary>

--- a/src/BSH.Engine/Storage/FileSystemStorage.cs
+++ b/src/BSH.Engine/Storage/FileSystemStorage.cs
@@ -77,97 +77,115 @@ public class FileSystemStorage : Storage, IStorage
             // connect to network
             using var networkConn = new NetworkConnection(backupFolder, networkUserName, networkPassword);
 
-            // check path
             if (Directory.Exists(backupFolder))
             {
-                // check if we can write to the folder
-                if (!CanWriteToStorage(backupFolder))
-                {
-                    return false;
-                }
-
-                // store volume serial if not present
-                var volumeSerial = Win32Stuff.GetVolumeSerial(backupFolder[..3]);
-
-                if (string.IsNullOrEmpty(volumeSerialNumber) && volumeSerial != null)
-                {
-                    configurationManager.MediaVolumeSerial = volumeSerial;
-                }
-
-                // check serial
-                if (!string.IsNullOrEmpty(volumeSerial) && !string.IsNullOrEmpty(volumeSerialNumber))
-                {
-                    if (volumeSerial == volumeSerialNumber)
-                    {
-                        return await IsValidStorage();
-                    }
-                    else
-                    {
-                        _logger.Information("Storage device serial number is not equal to the stored id. We are not sure if that is the same device.");
-                        return false;
-                    }
-                }
-            }
-            else
-            {
-                _logger.Information("Medium directory {directoryName} not found; searching for device with corresponding serial number.", backupFolder);
-
-                // search for medium (maybe the drive letter has changed)
-                if (string.IsNullOrEmpty(volumeSerialNumber))
-                {
-                    return false;
-                }
-
-                foreach (var drive in DriveInfo.GetDrives())
-                {
-                    if (drive.DriveType != DriveType.Fixed && drive.DriveType != DriveType.Removable)
-                    {
-                        continue;
-                    }
-
-                    try
-                    {
-                        // get serial id
-                        var volumeSerial = Win32Stuff.GetVolumeSerial(drive.RootDirectory.FullName[..3]);
-
-                        if (!string.IsNullOrEmpty(volumeSerial) && volumeSerial == volumeSerialNumber)
-                        {
-                            // drive found
-                            _logger.Information("Drive letter updated with the serial number {volumeSerialNumber} at {driveLetter}.",
-                                volumeSerialNumber, drive.RootDirectory.FullName);
-
-                            var newBackupFolder = drive.RootDirectory.FullName[..1] + configurationManager.BackupFolder[1..];
-
-                            if (Directory.Exists(newBackupFolder) && CanWriteToStorage(newBackupFolder))
-                            {
-                                // update folder path
-                                configurationManager.BackupFolder = newBackupFolder;
-                                backupFolder = newBackupFolder;
-
-                                return await IsValidStorage();
-                            }
-                        }
-                    }
-                    catch (DeviceContainsWrongStateException)
-                    {
-                        throw;
-                    }
-                    catch (Exception)
-                    {
-                        // could not access device, ignore that
-                    }
-                }
-
-                return false;
+                return await CheckExistingMediumAsync();
             }
 
-            // check storage version
-            return await IsValidStorage();
+            return await TryFindMovedMediumAsync();
         }
         catch (Win32Exception)
         {
             return false;
         }
+    }
+
+    private async Task<bool> CheckExistingMediumAsync()
+    {
+        if (!CanWriteToStorage(backupFolder))
+        {
+            return false;
+        }
+
+        var volumeSerial = Win32Stuff.GetVolumeSerial(backupFolder[..3]);
+        StoreSerialNumberIfMissing(volumeSerial);
+
+        if (HasSerialMismatch(volumeSerial))
+        {
+            _logger.Information("Storage device serial number is not equal to the stored id. We are not sure if that is the same device.");
+            return false;
+        }
+
+        return await IsValidStorage();
+    }
+
+    private async Task<bool> TryFindMovedMediumAsync()
+    {
+        _logger.Information("Medium directory {directoryName} not found; searching for device with corresponding serial number.", backupFolder);
+
+        if (string.IsNullOrEmpty(volumeSerialNumber))
+        {
+            return false;
+        }
+
+        foreach (var drive in DriveInfo.GetDrives())
+        {
+            if (!IsCandidateBackupDrive(drive))
+            {
+                continue;
+            }
+
+            if (await TrySwitchBackupFolderToDriveAsync(drive))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsCandidateBackupDrive(DriveInfo drive)
+    {
+        return drive.DriveType == DriveType.Fixed || drive.DriveType == DriveType.Removable;
+    }
+
+    private async Task<bool> TrySwitchBackupFolderToDriveAsync(DriveInfo drive)
+    {
+        try
+        {
+            var volumeSerial = Win32Stuff.GetVolumeSerial(drive.RootDirectory.FullName[..3]);
+            if (string.IsNullOrEmpty(volumeSerial) || volumeSerial != volumeSerialNumber)
+            {
+                return false;
+            }
+
+            _logger.Information("Drive letter updated with the serial number {volumeSerialNumber} at {driveLetter}.",
+                volumeSerialNumber, drive.RootDirectory.FullName);
+
+            var newBackupFolder = drive.RootDirectory.FullName[..1] + configurationManager.BackupFolder[1..];
+            if (!Directory.Exists(newBackupFolder) || !CanWriteToStorage(newBackupFolder))
+            {
+                return false;
+            }
+
+            configurationManager.BackupFolder = newBackupFolder;
+            backupFolder = newBackupFolder;
+            return await IsValidStorage();
+        }
+        catch (DeviceContainsWrongStateException)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            // could not access device, ignore that
+            return false;
+        }
+    }
+
+    private void StoreSerialNumberIfMissing(string volumeSerial)
+    {
+        if (string.IsNullOrEmpty(volumeSerialNumber) && volumeSerial != null)
+        {
+            configurationManager.MediaVolumeSerial = volumeSerial;
+        }
+    }
+
+    private bool HasSerialMismatch(string volumeSerial)
+    {
+        return !string.IsNullOrEmpty(volumeSerial) &&
+               !string.IsNullOrEmpty(volumeSerialNumber) &&
+               volumeSerial != volumeSerialNumber;
     }
 
     /// <summary>

--- a/src/BSH.Main/Modules/BackupLogic.cs
+++ b/src/BSH.Main/Modules/BackupLogic.cs
@@ -706,59 +706,7 @@ static class BackupLogic
 
         try
         {
-            if (ConfigurationManager.IntervallDelete == "auto")
-            {
-                // automatic deletion
-                listDelete.AddRange(GetAutomaticVersionsToDelete());
-            }
-            else if (string.IsNullOrEmpty(ConfigurationManager.IntervallDelete))
-            {
-                // don't delete anything
-            }
-            else
-            {
-                // custom intervals
-                var intervals = ConfigurationManager.IntervallDelete.Split('|');
-                var listVersions = QueryManager.GetVersions();
-
-                foreach (var version in listVersions)
-                {
-                    // ignore fixed versions
-                    if (version.Stable)
-                    {
-                        continue;
-                    }
-
-                    // Löschung
-                    switch (intervals[0] ?? "")
-                    {
-                        case "hour":
-                            if (DateTime.Now.Subtract(version.CreationDate) > new TimeSpan(Convert.ToInt32(intervals[1]), 0, 0) && !listDelete.Contains(version))
-                            {
-                                listDelete.Add(version);
-                            }
-
-                            break;
-
-                        case "day":
-                            if (DateTime.Now.Subtract(version.CreationDate) > new TimeSpan(Convert.ToInt32(intervals[1]), 0, 0, 0) && !listDelete.Contains(version))
-                            {
-                                listDelete.Add(version);
-                            }
-
-                            break;
-
-                        case "week":
-
-                            if (DateTime.Now.Subtract(version.CreationDate) > new TimeSpan((int)Math.Round(Convert.ToDouble(intervals[1]) * 7d), 0, 0, 0) && !listDelete.Contains(version))
-                            {
-                                listDelete.Add(version);
-                            }
-
-                            break;
-                    }
-                }
-            }
+            listDelete.AddRange(GetScheduledVersionsToDelete());
         }
         catch (Exception ex)
         {
@@ -771,6 +719,59 @@ static class BackupLogic
         {
             await BackupController.DeleteBackupAsync(version.Id, false);
         }
+    }
+
+    private static List<VersionDetails> GetScheduledVersionsToDelete()
+    {
+        if (ConfigurationManager.IntervallDelete == "auto")
+        {
+            return GetAutomaticVersionsToDelete();
+        }
+
+        if (string.IsNullOrEmpty(ConfigurationManager.IntervallDelete))
+        {
+            return new List<VersionDetails>();
+        }
+
+        return GetCustomVersionsToDelete(ConfigurationManager.IntervallDelete);
+    }
+
+    private static List<VersionDetails> GetCustomVersionsToDelete(string intervalConfig)
+    {
+        var listDelete = new List<VersionDetails>();
+        var intervals = intervalConfig.Split('|');
+        var listVersions = QueryManager.GetVersions();
+
+        foreach (var version in listVersions)
+        {
+            if (version.Stable || listDelete.Contains(version))
+            {
+                continue;
+            }
+
+            if (ShouldDeleteVersion(version, intervals))
+            {
+                listDelete.Add(version);
+            }
+        }
+
+        return listDelete;
+    }
+
+    private static bool ShouldDeleteVersion(VersionDetails version, string[] intervals)
+    {
+        if (intervals.Length < 2)
+        {
+            return false;
+        }
+
+        return intervals[0] switch
+        {
+            "hour" => DateTime.Now.Subtract(version.CreationDate) > new TimeSpan(Convert.ToInt32(intervals[1]), 0, 0),
+            "day" => DateTime.Now.Subtract(version.CreationDate) > new TimeSpan(Convert.ToInt32(intervals[1]), 0, 0, 0),
+            "week" => DateTime.Now.Subtract(version.CreationDate) > new TimeSpan((int)Math.Round(Convert.ToDouble(intervals[1]) * 7d), 0, 0, 0),
+            _ => false
+        };
     }
 
     #endregion

--- a/src/BSH.MainApp/Activation/AppNotificationActivationHandler.cs
+++ b/src/BSH.MainApp/Activation/AppNotificationActivationHandler.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Alexander Seeliger. All Rights Reserved.
 // Licensed under the Apache License, Version 2.0.
 
-using BSH.MainApp.Contracts.Services;
 using Microsoft.UI.Xaml;
 using Microsoft.Windows.AppLifecycle;
 
@@ -9,13 +8,8 @@ namespace BSH.MainApp.Activation;
 
 public class AppNotificationActivationHandler : ActivationHandler<LaunchActivatedEventArgs>
 {
-    private readonly INavigationService _navigationService;
-    private readonly IAppNotificationService _notificationService;
-
-    public AppNotificationActivationHandler(INavigationService navigationService, IAppNotificationService notificationService)
+    public AppNotificationActivationHandler()
     {
-        _navigationService = navigationService;
-        _notificationService = notificationService;
     }
 
     protected override bool CanHandleInternal(LaunchActivatedEventArgs args)

--- a/src/BSH.MainApp/Services/PresentationService.cs
+++ b/src/BSH.MainApp/Services/PresentationService.cs
@@ -126,35 +126,72 @@ public class PresentationService : IPresentationService
     {
         return await App.MainWindow.DispatcherQueue.EnqueueAsync(async () =>
         {
-            if (commands != null && commands.Count > 3)
-            {
-                throw new InvalidOperationException("A maximum of 3 commands can be specified");
-            }
-
-            IUICommand defaultCommand = new UICommand("OK");
-            IUICommand? secondaryCommand = null;
-            IUICommand? cancelCommand = null;
-            if (commands != null)
-            {
-                defaultCommand = commands.Count > defaultCommandIndex ? commands[(int)defaultCommandIndex] : commands.FirstOrDefault() ?? defaultCommand;
-                cancelCommand = commands.Count > cancelCommandIndex ? commands[(int)cancelCommandIndex] : null;
-                secondaryCommand = commands.FirstOrDefault(c => c != defaultCommand && c != cancelCommand);
-            }
-            var dialog = new ContentDialog();
-            dialog.XamlRoot = App.MainWindow.Content.XamlRoot;
-            dialog.Content = new TextBlock() { Text = content };
-            dialog.Title = title;
-            dialog.PrimaryButtonText = defaultCommand.Label;
-            if (secondaryCommand != null)
-            {
-                dialog.SecondaryButtonText = secondaryCommand.Label;
-            }
-            if (cancelCommand != null)
-            {
-                dialog.CloseButtonText = cancelCommand.Label;
-            }
+            ValidateCommands(commands);
+            var (defaultCommand, secondaryCommand, cancelCommand) = ResolveCommands(commands, defaultCommandIndex, cancelCommandIndex);
+            var dialog = BuildDialog(title, content, defaultCommand, secondaryCommand, cancelCommand);
             return await dialog.ShowAsync();
         });
+    }
+
+    private static void ValidateCommands(IList<IUICommand>? commands)
+    {
+        if (commands != null && commands.Count > 3)
+        {
+            throw new InvalidOperationException("A maximum of 3 commands can be specified");
+        }
+    }
+
+    private static (IUICommand defaultCommand, IUICommand? secondaryCommand, IUICommand? cancelCommand) ResolveCommands(
+        IList<IUICommand>? commands,
+        uint defaultCommandIndex,
+        uint cancelCommandIndex)
+    {
+        IUICommand defaultCommand = new UICommand("OK");
+        IUICommand? cancelCommand = null;
+
+        if (commands == null)
+        {
+            return (defaultCommand, null, cancelCommand);
+        }
+
+        defaultCommand = commands.Count > defaultCommandIndex
+            ? commands[(int)defaultCommandIndex]
+            : commands.FirstOrDefault() ?? defaultCommand;
+
+        cancelCommand = commands.Count > cancelCommandIndex
+            ? commands[(int)cancelCommandIndex]
+            : null;
+
+        var secondaryCommand = commands.FirstOrDefault(c => c != defaultCommand && c != cancelCommand);
+        return (defaultCommand, secondaryCommand, cancelCommand);
+    }
+
+    private static ContentDialog BuildDialog(
+        string title,
+        string content,
+        IUICommand defaultCommand,
+        IUICommand? secondaryCommand,
+        IUICommand? cancelCommand)
+    {
+        var dialog = new ContentDialog
+        {
+            XamlRoot = App.MainWindow.Content.XamlRoot,
+            Content = new TextBlock { Text = content },
+            Title = title,
+            PrimaryButtonText = defaultCommand.Label
+        };
+
+        if (secondaryCommand != null)
+        {
+            dialog.SecondaryButtonText = secondaryCommand.Label;
+        }
+
+        if (cancelCommand != null)
+        {
+            dialog.CloseButtonText = cancelCommand.Label;
+        }
+
+        return dialog;
     }
 
     public async Task ShowExcludeFileFolderWindowAsync()

--- a/src/BSH.MainApp/Services/WaitForMediaService.cs
+++ b/src/BSH.MainApp/Services/WaitForMediaService.cs
@@ -28,28 +28,34 @@ public class WaitForMediaService : IWaitForMediaService
 
     public async Task<bool> ExecuteAsync(bool silent, CancellationTokenSource cancellationTokenSource)
     {
-        // show window?
-        if (!silent)
+        await ShowWindowAsync(silent, cancellationTokenSource);
+        var result = await WaitForMediaAvailabilityAsync(silent, cancellationTokenSource);
+        await CloseWindowAsync(silent, cancellationTokenSource);
+        return result;
+    }
+
+    private async Task ShowWindowAsync(bool silent, CancellationTokenSource cancellationTokenSource)
+    {
+        if (silent)
         {
-            await App.MainWindow.DispatcherQueue.EnqueueAsync(() =>
-            {
-                window = new WaitForMediumWindow();
-                window.ViewModel.OnCancelRequested += cancellationTokenSource.Cancel;
-                window.CenterOnScreen();
-                window.Activate();
-            });
+            return;
         }
 
-        // wait for media
-        var result = await Task.Run(async () =>
+        await App.MainWindow.DispatcherQueue.EnqueueAsync(() =>
         {
-            while (true)
-            {
-                if (cancellationTokenSource.Token.IsCancellationRequested)
-                {
-                    break;
-                }
+            window = new WaitForMediumWindow();
+            window.ViewModel.OnCancelRequested += cancellationTokenSource.Cancel;
+            window.CenterOnScreen();
+            window.Activate();
+        });
+    }
 
+    private async Task<bool> WaitForMediaAvailabilityAsync(bool silent, CancellationTokenSource cancellationTokenSource)
+    {
+        return await Task.Run(async () =>
+        {
+            while (!cancellationTokenSource.Token.IsCancellationRequested)
+            {
                 try
                 {
                     await Task.Delay(THREAD_SLEEP_SECONDS);
@@ -57,7 +63,7 @@ public class WaitForMediaService : IWaitForMediaService
 
                     if (silent && currentWaitingTime > MAX_WAITING_SECONDS)
                     {
-                        break;
+                        return false;
                     }
 
                     if (await backupService.CheckMedia())
@@ -67,24 +73,26 @@ public class WaitForMediaService : IWaitForMediaService
                 }
                 catch
                 {
-                    break;
+                    return false;
                 }
             }
 
             return false;
         });
+    }
 
-        // close window
-        if (!silent && window != null)
+    private async Task CloseWindowAsync(bool silent, CancellationTokenSource cancellationTokenSource)
+    {
+        if (silent || window == null)
         {
-            await App.MainWindow.DispatcherQueue.EnqueueAsync(() =>
-            {
-                window.ViewModel.OnCancelRequested -= cancellationTokenSource.Cancel;
-                window.Close();
-                window = null;
-            });
+            return;
         }
 
-        return result;
+        await App.MainWindow.DispatcherQueue.EnqueueAsync(() =>
+        {
+            window.ViewModel.OnCancelRequested -= cancellationTokenSource.Cancel;
+            window.Close();
+            window = null;
+        });
     }
 }

--- a/src/BSH.Test/BackupTests.cs
+++ b/src/BSH.Test/BackupTests.cs
@@ -335,8 +335,12 @@ public class BackupTests
 
     private static string CreateTempFile(string extension)
     {
-        var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}{extension}");
-        File.WriteAllText(tempFile, "backup-test-content");
-        return tempFile;
+        var testFilesDir = Path.Combine(Environment.CurrentDirectory, "testfiles");
+        Directory.CreateDirectory(testFilesDir);
+
+        var testFile = Path.Combine(testFilesDir, $"{Guid.NewGuid()}{extension}");
+        var content = new string('a', 256);
+        File.WriteAllText(testFile, content);
+        return testFile;
     }
 }

--- a/src/BSH.Test/BackupTests.cs
+++ b/src/BSH.Test/BackupTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,6 +14,7 @@ using Brightbits.BSH.Engine.Contracts.Services;
 using Brightbits.BSH.Engine.Database;
 using Brightbits.BSH.Engine.Exceptions;
 using Brightbits.BSH.Engine.Jobs;
+using Brightbits.BSH.Engine.Models;
 using Brightbits.BSH.Engine.Repo;
 using Brightbits.BSH.Engine.Services;
 using Brightbits.BSH.Engine.Storage;
@@ -156,6 +158,65 @@ public class BackupTests
     }
 
     [Test]
+    public async Task TestUsesCompressedCopyWhenCompressionIsEnabled()
+    {
+        configurationManager.Compression = 1;
+
+        var fs = new StorageMock();
+        var backupJob = CreateBackupJobForSingleTempFile(fs, new VssClientMock(), ".txt");
+
+        var token = new CancellationTokenSource().Token;
+        await backupJob.BackupAsync(token);
+
+        Assert.That(fs.CopyFileToStorageCompressedCalls, Is.EqualTo(1));
+        Assert.That(fs.CopyFileToStorageEncryptedCalls, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task TestUsesEncryptedCopyWhenEncryptionIsEnabled()
+    {
+        configurationManager.Encrypt = 1;
+        configurationManager.EncryptPassMD5 = "cc03e747a6afbbcbf8be7668acfebee5";
+
+        var fs = new StorageMock();
+        var backupJob = CreateBackupJobForSingleTempFile(fs, new VssClientMock(), ".txt");
+        backupJob.Password = "test123";
+
+        var token = new CancellationTokenSource().Token;
+        await backupJob.BackupAsync(token);
+
+        Assert.That(fs.CopyFileToStorageEncryptedCalls, Is.EqualTo(1));
+        Assert.That(fs.CopyFileToStorageCompressedCalls, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task TestUsesLongFilePathFallbackWhenPathIsTooLong()
+    {
+        var fs = new StorageMock(pathTooLong: true);
+        var backupJob = CreateBackupJobForSingleTempFile(fs, new VssClientMock(), ".txt");
+
+        var token = new CancellationTokenSource().Token;
+        await backupJob.BackupAsync(token);
+
+        Assert.That(fs.LastRemoteFile, Does.Contain("_LONGFILES_"));
+    }
+
+    [Test]
+    public async Task TestRetriesWithVssAfterIoException()
+    {
+        var vss = new VssClientMock(shouldCopy: true);
+        var fs = new StorageMock(throwIoOnFirstRegularCopy: true);
+        var backupJob = CreateBackupJobForSingleTempFile(fs, vss, ".txt");
+
+        var token = new CancellationTokenSource().Token;
+        await backupJob.BackupAsync(token);
+
+        Assert.That(vss.CopyCalls, Is.EqualTo(1));
+        Assert.That(fs.CopyFileToStorageCalls, Is.EqualTo(2));
+        Assert.That(backupJob.FileErrorList, Is.Empty);
+    }
+
+    [Test]
     public async Task TestEncryptedFull()
     {
         // set compressed state
@@ -240,5 +301,42 @@ public class BackupTests
         // check version
         var version = await this.queryManager.GetLastBackupAsync();
         Assert.That(version, Is.Null);
+    }
+
+    private BackupJob CreateBackupJobForSingleTempFile(StorageMock storage, VssClientMock vss, string extension)
+    {
+        var filePath = CreateTempFile(extension);
+        var fileInfo = new FileInfo(filePath);
+
+        fileCollectorServiceFactory = new FileCollectorServiceFactoryMock(
+            new List<FolderTableRow>(),
+            new List<FileTableRow>
+            {
+                new FileTableRow
+                {
+                    FileName = fileInfo.Name,
+                    FilePath = "",
+                    FileRoot = fileInfo.DirectoryName,
+                    FileSize = fileInfo.Length,
+                    FileDateCreated = fileInfo.CreationTime,
+                    FileDateModified = fileInfo.LastWriteTime,
+                }
+            });
+
+        var backupJob = new BackupJob(storage, dbClientFactory, queryManager, configurationManager, fileCollectorServiceFactory, vss, versionQueryRepository, backupMutationRepository)
+        {
+            SourceFolder = fileInfo.DirectoryName,
+            Title = "Blub",
+            Description = "",
+        };
+
+        return backupJob;
+    }
+
+    private static string CreateTempFile(string extension)
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}{extension}");
+        File.WriteAllText(tempFile, "backup-test-content");
+        return tempFile;
     }
 }

--- a/src/BSH.Test/ConfigurationManagerTests.cs
+++ b/src/BSH.Test/ConfigurationManagerTests.cs
@@ -66,4 +66,19 @@ public class ConfigurationManagerTests
         await configurationManager.InitializeAsync();
         Assert.That(configurationManager.MediumType, Is.EqualTo(MediaType.FileTransferServer));
     }
+
+    [Test]
+    public async Task LoadConfigurationInvalidIntegerBackedValuesKeepDefaults()
+    {
+        await dbClientFactory.ExecuteNonQueryAsync("INSERT INTO configuration (confValue, confProperty) VALUES ('invalid-task', 'tasktype');");
+        await dbClientFactory.ExecuteNonQueryAsync("INSERT INTO configuration (confValue, confProperty) VALUES ('invalid-compression', 'compression');");
+        await dbClientFactory.ExecuteNonQueryAsync("INSERT INTO configuration (confValue, confProperty) VALUES ('invalid-encrypt', 'encrypt');");
+
+        var configurationManager = new ConfigurationManager(dbClientFactory);
+        Assert.DoesNotThrowAsync(async () => await configurationManager.InitializeAsync());
+
+        Assert.That(configurationManager.TaskType, Is.EqualTo(TaskType.Auto));
+        Assert.That(configurationManager.Compression, Is.EqualTo(0));
+        Assert.That(configurationManager.Encrypt, Is.EqualTo(0));
+    }
 }

--- a/src/BSH.Test/Mocks/StorageMock.cs
+++ b/src/BSH.Test/Mocks/StorageMock.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Alexander Seeliger. All Rights Reserved.
 // Licensed under the Apache License, Version 2.0.
 
+using System.IO;
 using System.Threading.Tasks;
 using Brightbits.BSH.Engine.Providers.Ports;
 using Brightbits.BSH.Engine.Storage;
@@ -11,14 +12,27 @@ namespace BSH.Test.Mocks
     {
         private readonly bool failCheckMedium;
         private readonly bool failAllCopies;
+        private readonly bool pathTooLong;
+        private readonly bool throwIoOnFirstRegularCopy;
+        private int regularCopyAttempts;
 
-        public StorageMock(bool failCheckMedium = false, bool failAllCopies = false)
+        public StorageMock(
+            bool failCheckMedium = false,
+            bool failAllCopies = false,
+            bool pathTooLong = false,
+            bool throwIoOnFirstRegularCopy = false)
         {
             this.failCheckMedium = failCheckMedium;
             this.failAllCopies = failAllCopies;
+            this.pathTooLong = pathTooLong;
+            this.throwIoOnFirstRegularCopy = throwIoOnFirstRegularCopy;
         }
 
         public StorageProviderKind Kind => StorageProviderKind.LocalFileSystem;
+        public int CopyFileToStorageCalls { get; private set; }
+        public int CopyFileToStorageCompressedCalls { get; private set; }
+        public int CopyFileToStorageEncryptedCalls { get; private set; }
+        public string LastRemoteFile { get; private set; }
 
         public bool CanWriteToStorage()
         {
@@ -47,16 +61,29 @@ namespace BSH.Test.Mocks
 
         public bool CopyFileToStorage(string localFile, string remoteFile)
         {
+            CopyFileToStorageCalls++;
+            LastRemoteFile = remoteFile;
+            regularCopyAttempts++;
+
+            if (throwIoOnFirstRegularCopy && regularCopyAttempts == 1)
+            {
+                throw new IOException("Simulated IO failure");
+            }
+
             return !failAllCopies;
         }
 
         public bool CopyFileToStorageCompressed(string localFile, string remoteFile)
         {
+            CopyFileToStorageCompressedCalls++;
+            LastRemoteFile = remoteFile;
             return !failAllCopies;
         }
 
         public bool CopyFileToStorageEncrypted(string localFile, string remoteFile, string password)
         {
+            CopyFileToStorageEncryptedCalls++;
+            LastRemoteFile = remoteFile;
             return !failAllCopies;
         }
 
@@ -96,7 +123,7 @@ namespace BSH.Test.Mocks
 
         public bool IsPathTooLong(string path, bool compression, bool encryption)
         {
-            return false;
+            return pathTooLong;
         }
 
         public void Open()

--- a/src/BSH.Test/Mocks/VssClientMock.cs
+++ b/src/BSH.Test/Mocks/VssClientMock.cs
@@ -2,13 +2,31 @@
 // Licensed under the Apache License, Version 2.0.
 
 using Brightbits.BSH.Engine.Providers.Ports;
+using System.IO;
 
 namespace BSH.Test.Mocks;
 
 public class VssClientMock : IVssClient
 {
+    private readonly bool shouldCopy;
+
+    public int CopyCalls { get; private set; }
+
+    public VssClientMock(bool shouldCopy = false)
+    {
+        this.shouldCopy = shouldCopy;
+    }
+
     public bool CopyFile(string fileName, string destFileName)
     {
+        CopyCalls++;
+
+        if (shouldCopy && File.Exists(fileName))
+        {
+            File.Copy(fileName, destFileName, true);
+            return true;
+        }
+
         return false;
     }
 }


### PR DESCRIPTION
## Summary
- Split backup and restore file handling into smaller helpers to make compression, encryption, VSS copy, overwrite checks, and cleanup paths easier to follow.
- Simplified configuration loading by centralizing scalar reads and integer-backed property parsing.
- Refactored storage medium detection to separate existing-medium validation from drive re-discovery when the backup folder moves.
- Cleaned up scheduled backup deletion logic by isolating auto and custom interval handling.
- Reduced UI activation and presentation/service branching by moving command validation and resolution into dedicated helpers.

## Testing
- Not run
- Reviewed refactored control flow in backup and restore jobs for compression, encryption, and long-path handling.
- Reviewed storage medium detection and moved-drive fallback logic for unchanged behavior.
- Reviewed scheduled deletion path for `auto`, empty, and custom interval configurations.