### PR TITLE
feat: Move WinForms password resolution behind runner and stored-password adapter

### DIFF
--- a/src/BSH.Engine/Runtime/JobRuntime.cs
+++ b/src/BSH.Engine/Runtime/JobRuntime.cs
@@ -110,7 +110,7 @@ public sealed class JobRuntime : IDisposable
         return false;
     }
 
-    public async Task<CancellationToken> PrepareAsync(ActionType action, bool statusDialog)
+    public async Task<CancellationToken> PrepareAsync(ActionType action, bool statusDialog, bool requirePassword = true)
     {
         var newCancellationToken = GetNewCancellationToken();
 
@@ -124,7 +124,7 @@ public sealed class JobRuntime : IDisposable
             throw new DeviceNotReadyException();
         }
 
-        if (!await requestPasswordAsync())
+        if (requirePassword && !await requestPasswordAsync())
         {
             throw new PasswordRequiredException();
         }

--- a/src/BSH.Engine/Runtime/JobSessionRunner.cs
+++ b/src/BSH.Engine/Runtime/JobSessionRunner.cs
@@ -7,6 +7,7 @@ using Brightbits.BSH.Engine.Contracts.Services;
 using Brightbits.BSH.Engine.Exceptions;
 using Brightbits.BSH.Engine.Jobs;
 using Brightbits.BSH.Engine.Runtime.Ports;
+using Brightbits.BSH.Engine.Security;
 
 namespace Brightbits.BSH.Engine.Runtime;
 
@@ -47,19 +48,25 @@ public sealed class JobSessionRunner
 {
     private readonly IBackupService backupService;
     private readonly JobRuntime jobRuntime;
+    private readonly Func<bool> shouldResolvePassword;
+    private readonly string expectedPasswordHash;
+    private readonly IStoredPasswordAdapter storedPasswordAdapter;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="JobSessionRunner"/> class.
     /// </summary>
     /// <param name="backupService">Backup engine service used to execute backup operations.</param>
     /// <param name="jobRuntime">Shared runtime responsible for session preparation and cancellation lifecycle.</param>
-    public JobSessionRunner(IBackupService backupService, JobRuntime jobRuntime)
+    public JobSessionRunner(IBackupService backupService, JobRuntime jobRuntime, Func<bool> shouldResolvePassword = null, string expectedPasswordHash = "", IStoredPasswordAdapter storedPasswordAdapter = null)
     {
         ArgumentNullException.ThrowIfNull(backupService);
         ArgumentNullException.ThrowIfNull(jobRuntime);
 
         this.backupService = backupService;
         this.jobRuntime = jobRuntime;
+        this.shouldResolvePassword = shouldResolvePassword ?? (() => false);
+        this.expectedPasswordHash = expectedPasswordHash ?? string.Empty;
+        this.storedPasswordAdapter = storedPasswordAdapter;
     }
 
     /// <summary>
@@ -84,7 +91,9 @@ public sealed class JobSessionRunner
                 await presenter.ShowStatusWindowAsync();
             }
 
-            var cancellationToken = await jobRuntime.PrepareAsync(ActionType.Backup, statusDialog);
+            await ResolvePasswordAsync(presenter);
+
+            var cancellationToken = await jobRuntime.PrepareAsync(ActionType.Backup, statusDialog, requirePassword: false);
             presenter.SetCancellationToken(cancellationToken);
 
             try
@@ -129,5 +138,47 @@ public sealed class JobSessionRunner
 
             return new SingleBackupSessionResult() { Failure = JobSessionStartFailure.PasswordRequired };
         }
+    }
+
+    private async Task ResolvePasswordAsync(IJobSessionPresenter presenter)
+    {
+        if (backupService.HasPassword() || !shouldResolvePassword())
+        {
+            return;
+        }
+
+        var storedPassword = storedPasswordAdapter?.GetPassword();
+        if (IsValidPassword(storedPassword))
+        {
+            backupService.SetPassword(storedPassword);
+            return;
+        }
+
+        var request = await presenter.RequestPasswordAsync();
+        while (!string.IsNullOrEmpty(request.Password))
+        {
+            if (IsValidPassword(request.Password))
+            {
+                backupService.SetPassword(request.Password);
+
+                if (request.Persist)
+                {
+                    storedPasswordAdapter?.StorePassword(request.Password);
+                }
+
+                return;
+            }
+
+            await presenter.ShowErrorPasswordWrongAsync();
+            request = await presenter.RequestPasswordAsync();
+        }
+
+        throw new PasswordRequiredException();
+    }
+
+    private bool IsValidPassword(string password)
+    {
+        return !string.IsNullOrEmpty(password) &&
+            string.Equals(Hash.GetMD5Hash(password) ?? string.Empty, expectedPasswordHash ?? string.Empty, StringComparison.Ordinal);
     }
 }

--- a/src/BSH.Engine/Runtime/JobSessionRunner.cs
+++ b/src/BSH.Engine/Runtime/JobSessionRunner.cs
@@ -49,7 +49,7 @@ public sealed class JobSessionRunner
     private readonly IBackupService backupService;
     private readonly JobRuntime jobRuntime;
     private readonly Func<bool> shouldResolvePassword;
-    private readonly string expectedPasswordHash;
+    private readonly Func<string> expectedPasswordHashProvider;
     private readonly IStoredPasswordAdapter storedPasswordAdapter;
 
     /// <summary>
@@ -57,7 +57,7 @@ public sealed class JobSessionRunner
     /// </summary>
     /// <param name="backupService">Backup engine service used to execute backup operations.</param>
     /// <param name="jobRuntime">Shared runtime responsible for session preparation and cancellation lifecycle.</param>
-    public JobSessionRunner(IBackupService backupService, JobRuntime jobRuntime, Func<bool> shouldResolvePassword = null, string expectedPasswordHash = "", IStoredPasswordAdapter storedPasswordAdapter = null)
+    public JobSessionRunner(IBackupService backupService, JobRuntime jobRuntime, Func<bool> shouldResolvePassword = null, Func<string> expectedPasswordHashProvider = null, IStoredPasswordAdapter storedPasswordAdapter = null)
     {
         ArgumentNullException.ThrowIfNull(backupService);
         ArgumentNullException.ThrowIfNull(jobRuntime);
@@ -65,7 +65,7 @@ public sealed class JobSessionRunner
         this.backupService = backupService;
         this.jobRuntime = jobRuntime;
         this.shouldResolvePassword = shouldResolvePassword ?? (() => false);
-        this.expectedPasswordHash = expectedPasswordHash ?? string.Empty;
+        this.expectedPasswordHashProvider = expectedPasswordHashProvider ?? (() => string.Empty);
         this.storedPasswordAdapter = storedPasswordAdapter;
     }
 
@@ -178,7 +178,8 @@ public sealed class JobSessionRunner
 
     private bool IsValidPassword(string password)
     {
+        var expectedPasswordHash = expectedPasswordHashProvider() ?? string.Empty;
         return !string.IsNullOrEmpty(password) &&
-            string.Equals(Hash.GetMD5Hash(password) ?? string.Empty, expectedPasswordHash ?? string.Empty, StringComparison.Ordinal);
+            string.Equals(Hash.GetMD5Hash(password) ?? string.Empty, expectedPasswordHash, StringComparison.Ordinal);
     }
 }

--- a/src/BSH.Engine/Runtime/Ports/IJobSessionPresenter.cs
+++ b/src/BSH.Engine/Runtime/Ports/IJobSessionPresenter.cs
@@ -40,6 +40,16 @@ public interface IJobSessionPresenter : IJobReport
     Task ShowErrorPasswordRequiredAsync();
 
     /// <summary>
+    /// Requests the password from the user for the current live session.
+    /// </summary>
+    Task<JobSessionPasswordRequest> RequestPasswordAsync();
+
+    /// <summary>
+    /// Shows an error when the entered password is incorrect.
+    /// </summary>
+    Task ShowErrorPasswordWrongAsync();
+
+    /// <summary>
     /// Cancels the running job session.
     /// </summary>
     Task CancelAsync();

--- a/src/BSH.Engine/Runtime/Ports/IStoredPasswordAdapter.cs
+++ b/src/BSH.Engine/Runtime/Ports/IStoredPasswordAdapter.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Brightbits.BSH.Engine.Runtime.Ports;
+
+/// <summary>
+/// Provides access to durable password storage for a specific product.
+/// </summary>
+public interface IStoredPasswordAdapter
+{
+    /// <summary>
+    /// Gets a stored password if one is available.
+    /// </summary>
+    string GetPassword();
+
+    /// <summary>
+    /// Persists the provided password for later use.
+    /// </summary>
+    void StorePassword(string password);
+}

--- a/src/BSH.Engine/Runtime/Ports/JobSessionPasswordRequest.cs
+++ b/src/BSH.Engine/Runtime/Ports/JobSessionPasswordRequest.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Brightbits.BSH.Engine.Runtime.Ports;
+
+/// <summary>
+/// Represents a password entered during a live job-session prompt.
+/// </summary>
+public readonly record struct JobSessionPasswordRequest(string Password, bool Persist);

--- a/src/BSH.Main/Modules/BackupController.cs
+++ b/src/BSH.Main/Modules/BackupController.cs
@@ -79,7 +79,7 @@ public class BackupController : IDisposable
             backupService,
             this.jobRuntime,
             () => this.configurationManager.Encrypt == 1,
-            this.configurationManager.EncryptPassMD5,
+            () => this.configurationManager.EncryptPassMD5,
             this.storedPasswordAdapter);
 
         jobReportCallback = StatusController.Current;

--- a/src/BSH.Main/Modules/BackupController.cs
+++ b/src/BSH.Main/Modules/BackupController.cs
@@ -15,8 +15,8 @@ using Brightbits.BSH.Engine.Jobs;
 using Brightbits.BSH.Engine.Runtime;
 using Brightbits.BSH.Engine.Runtime.Ports;
 using Brightbits.BSH.Engine.Security;
-using BSH.Main.Properties;
 using Serilog;
+using Resources = BSH.Main.Properties.Resources;
 
 namespace Brightbits.BSH.Main;
 
@@ -39,6 +39,7 @@ public class BackupController : IDisposable
     private readonly JobRuntime jobRuntime;
     private readonly JobSessionRunner jobSessionRunner;
     private readonly IJobSessionPresenter presenter;
+    private readonly IStoredPasswordAdapter storedPasswordAdapter;
 
     private CancellationToken cancellationToken;
 
@@ -73,7 +74,13 @@ public class BackupController : IDisposable
             waitForMediaAsync,
             requestPasswordAsync);
         this.presenter = new WinFormsJobSessionPresenter(backupService, configurationManager);
-        this.jobSessionRunner = new JobSessionRunner(backupService, this.jobRuntime);
+        this.storedPasswordAdapter = new WinFormsStoredPasswordAdapter();
+        this.jobSessionRunner = new JobSessionRunner(
+            backupService,
+            this.jobRuntime,
+            () => this.configurationManager.Encrypt == 1,
+            this.configurationManager.EncryptPassMD5,
+            this.storedPasswordAdapter);
 
         jobReportCallback = StatusController.Current;
 
@@ -489,40 +496,32 @@ public class BackupController : IDisposable
             return true;
         }
 
-        // password stored
-        if (!string.IsNullOrEmpty(Settings.Default.BackupPwd))
+        var storedPassword = storedPasswordAdapter.GetPassword();
+        if (!string.IsNullOrEmpty(storedPassword))
         {
-            var storedPassword = Crypto.DecryptString(Settings.Default.BackupPwd);
-            if (storedPassword.Length > 0)
-            {
-                backupService.SetPassword(storedPassword);
-                return true;
-            }
+            backupService.SetPassword(storedPassword);
+            return true;
         }
 
-        // request password from user
-        var request = PresentationController.Current.RequestPassword();
-        while (!string.IsNullOrEmpty(request.password))
+        var request = presenter.RequestPasswordAsync().GetAwaiter().GetResult();
+        while (!string.IsNullOrEmpty(request.Password))
         {
-            if ((Hash.GetMD5Hash(request.password) ?? "") == (configurationManager.EncryptPassMD5 ?? ""))
+            if ((Hash.GetMD5Hash(request.Password) ?? string.Empty) == (configurationManager.EncryptPassMD5 ?? string.Empty))
             {
-                backupService.SetPassword(request.password);
+                backupService.SetPassword(request.Password);
 
-                // persist password?
-                if (request.persist)
+                if (request.Persist)
                 {
-                    Settings.Default.BackupPwd = Crypto.EncryptString(request.password);
-                    Settings.Default.Save();
+                    storedPasswordAdapter.StorePassword(request.Password);
                 }
 
                 return true;
             }
 
-            // report back to user
             _logger.Debug("Password given by user is not correct. Request retry.");
 
-            MessageBox.Show(Resources.MSG_PASSWORD_WRONG_TEXT, Resources.MSG_PASSWORD_WRONG_TITLE, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
-            request = PresentationController.Current.RequestPassword();
+            presenter.ShowErrorPasswordWrongAsync().GetAwaiter().GetResult();
+            request = presenter.RequestPasswordAsync().GetAwaiter().GetResult();
         }
 
         return false;

--- a/src/BSH.Main/WinFormsJobSessionPresenter.cs
+++ b/src/BSH.Main/WinFormsJobSessionPresenter.cs
@@ -86,6 +86,18 @@ public class WinFormsJobSessionPresenter : IJobSessionPresenter
         return Task.CompletedTask;
     }
 
+    public Task<JobSessionPasswordRequest> RequestPasswordAsync()
+    {
+        var request = PresentationController.Current.RequestPassword();
+        return Task.FromResult(new JobSessionPasswordRequest(request.password, request.persist));
+    }
+
+    public Task ShowErrorPasswordWrongAsync()
+    {
+        MessageBox.Show(Resources.MSG_PASSWORD_WRONG_TEXT, Resources.MSG_PASSWORD_WRONG_TITLE, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+        return Task.CompletedTask;
+    }
+
     public Task CancelAsync()
     {
         BackupLogic.BackupController.Cancel();

--- a/src/BSH.Main/WinFormsStoredPasswordAdapter.cs
+++ b/src/BSH.Main/WinFormsStoredPasswordAdapter.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Brightbits.BSH.Engine.Runtime.Ports;
+using Brightbits.BSH.Engine.Security;
+using BSH.Main.Properties;
+
+namespace Brightbits.BSH.Main;
+
+/// <summary>
+/// WinForms adapter for durable backup password storage.
+/// </summary>
+public sealed class WinFormsStoredPasswordAdapter : IStoredPasswordAdapter
+{
+    public string GetPassword()
+    {
+        if (string.IsNullOrEmpty(Settings.Default.BackupPwd))
+        {
+            return string.Empty;
+        }
+
+        return Crypto.DecryptString(Settings.Default.BackupPwd);
+    }
+
+    public void StorePassword(string password)
+    {
+        Settings.Default.BackupPwd = Crypto.EncryptString(password);
+        Settings.Default.Save();
+    }
+}

--- a/src/BSH.Test/Runtime/JobSessionRunnerTests.cs
+++ b/src/BSH.Test/Runtime/JobSessionRunnerTests.cs
@@ -11,6 +11,7 @@ using Brightbits.BSH.Engine.Jobs;
 using Brightbits.BSH.Engine.Models;
 using Brightbits.BSH.Engine.Runtime;
 using Brightbits.BSH.Engine.Runtime.Ports;
+using Brightbits.BSH.Engine.Security;
 using NUnit.Framework;
 
 namespace BSH.Test.Runtime;
@@ -69,10 +70,10 @@ public class JobSessionRunnerTests
     [Test]
     public async Task RunSingleBackupAsync_ReturnsPasswordRequired_WhenPasswordRequestFails()
     {
-        var backupService = new BackupServiceStub { CheckMediaResult = true };
+        var backupService = new BackupServiceStub { CheckMediaResult = true, HasPasswordResult = false };
         using var jobRuntime = new JobRuntime(backupService, () => false, () => false, (_, _, _) => Task.FromResult(false), () => Task.FromResult(false));
         var presenter = new JobReportStub();
-        var runner = new JobSessionRunner(backupService, jobRuntime);
+        var runner = new JobSessionRunner(backupService, jobRuntime, () => true, Hash.GetMD5Hash("secret"), new StoredPasswordAdapterStub());
 
         var result = await runner.RunSingleBackupAsync("title", "description", presenter, statusDialog: true);
 
@@ -102,20 +103,74 @@ public class JobSessionRunnerTests
         Assert.That(backupService.LastSilent, Is.False);
     }
 
+    [Test]
+    public async Task RunSingleBackupAsync_UsesStoredPasswordBeforePrompting()
+    {
+        var backupService = new BackupServiceStub { CheckMediaResult = true, HasPasswordResult = false };
+        using var jobRuntime = new JobRuntime(backupService, () => false, () => false, (_, _, _) => Task.FromResult(false), () => Task.FromResult(false));
+        var presenter = new JobReportStub();
+        var storedPasswordAdapter = new StoredPasswordAdapterStub { StoredPassword = "secret" };
+        var runner = new JobSessionRunner(backupService, jobRuntime, () => true, Hash.GetMD5Hash("secret"), storedPasswordAdapter);
+
+        var result = await runner.RunSingleBackupAsync("title", "description", presenter, statusDialog: true);
+
+        Assert.That(result.Started, Is.True);
+        Assert.That(backupService.LastPasswordSet, Is.EqualTo("secret"));
+        Assert.That(presenter.RequestPasswordCalls, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task RunSingleBackupAsync_PromptsAndPersistsPassword_WhenStoredPasswordIsUnavailable()
+    {
+        var backupService = new BackupServiceStub { CheckMediaResult = true, HasPasswordResult = false };
+        using var jobRuntime = new JobRuntime(backupService, () => false, () => false, (_, _, _) => Task.FromResult(false), () => Task.FromResult(false));
+        var presenter = new JobReportStub
+        {
+            NextPasswordRequest = new JobSessionPasswordRequest("secret", true)
+        };
+        var storedPasswordAdapter = new StoredPasswordAdapterStub();
+        var runner = new JobSessionRunner(backupService, jobRuntime, () => true, Hash.GetMD5Hash("secret"), storedPasswordAdapter);
+
+        var result = await runner.RunSingleBackupAsync("title", "description", presenter, statusDialog: true);
+
+        Assert.That(result.Started, Is.True);
+        Assert.That(backupService.LastPasswordSet, Is.EqualTo("secret"));
+        Assert.That(storedPasswordAdapter.StoredPassword, Is.EqualTo("secret"));
+    }
+
+    [Test]
+    public async Task RunSingleBackupAsync_RetriesPrompt_WhenPasswordIsWrong()
+    {
+        var backupService = new BackupServiceStub { CheckMediaResult = true, HasPasswordResult = false };
+        using var jobRuntime = new JobRuntime(backupService, () => false, () => false, (_, _, _) => Task.FromResult(false), () => Task.FromResult(false));
+        var presenter = new JobReportStub();
+        presenter.PasswordRequests.Enqueue(new JobSessionPasswordRequest("wrong", false));
+        presenter.PasswordRequests.Enqueue(new JobSessionPasswordRequest("secret", false));
+        var runner = new JobSessionRunner(backupService, jobRuntime, () => true, Hash.GetMD5Hash("secret"), new StoredPasswordAdapterStub());
+
+        var result = await runner.RunSingleBackupAsync("title", "description", presenter, statusDialog: true);
+
+        Assert.That(result.Started, Is.True);
+        Assert.That(presenter.ShowErrorPasswordWrongCalls, Is.EqualTo(1));
+        Assert.That(presenter.RequestPasswordCalls, Is.EqualTo(2));
+    }
+
     private sealed class BackupServiceStub : IBackupService
     {
         public bool CheckMediaResult { get; set; } = true;
+        public bool HasPasswordResult { get; set; } = true;
         public int StartBackupCalls { get; private set; }
         public string LastTitle { get; private set; }
         public string LastDescription { get; private set; }
         public bool LastFullBackup { get; private set; }
         public string LastSources { get; private set; }
         public bool LastSilent { get; private set; }
+        public string LastPasswordSet { get; private set; }
 
         public Task<bool> CheckMedia(bool quickCheck = false) => Task.FromResult(CheckMediaResult);
         public string GetPassword() => string.Empty;
-        public bool HasPassword() => true;
-        public void SetPassword(string password) { }
+        public bool HasPassword() => HasPasswordResult;
+        public void SetPassword(string password) => LastPasswordSet = password;
         public Task SetStableAsync(string version, bool stable) => Task.CompletedTask;
         public Task UpdateVersionAsync(string version, VersionDetails versionDetails) => Task.CompletedTask;
 
@@ -152,6 +207,10 @@ public class JobSessionRunnerTests
         public int ShowErrorTaskRunningCalls { get; private set; }
         public int ShowErrorDeviceNotReadyCalls { get; private set; }
         public int ShowErrorPasswordRequiredCalls { get; private set; }
+        public int ShowErrorPasswordWrongCalls { get; private set; }
+        public int RequestPasswordCalls { get; private set; }
+        public JobSessionPasswordRequest NextPasswordRequest { get; set; }
+        public System.Collections.Generic.Queue<JobSessionPasswordRequest> PasswordRequests { get; } = new();
 
         public Task ShowStatusWindowAsync()
         {
@@ -178,8 +237,35 @@ public class JobSessionRunnerTests
             ShowErrorPasswordRequiredCalls++;
             return Task.CompletedTask;
         }
+
+        public Task<JobSessionPasswordRequest> RequestPasswordAsync()
+        {
+            RequestPasswordCalls++;
+            if (PasswordRequests.Count > 0)
+            {
+                return Task.FromResult(PasswordRequests.Dequeue());
+            }
+
+            return Task.FromResult(NextPasswordRequest);
+        }
+
+        public Task ShowErrorPasswordWrongAsync()
+        {
+            ShowErrorPasswordWrongCalls++;
+            return Task.CompletedTask;
+        }
+
         public Task CancelAsync() => Task.CompletedTask;
         public CancellationToken GetCancellationToken() => CancellationToken.None;
         public void SetCancellationToken(CancellationToken cancellationToken) { }
+    }
+
+    private sealed class StoredPasswordAdapterStub : IStoredPasswordAdapter
+    {
+        public string StoredPassword { get; set; } = string.Empty;
+
+        public string GetPassword() => StoredPassword;
+
+        public void StorePassword(string password) => StoredPassword = password;
     }
 }

--- a/src/BSH.Test/Runtime/JobSessionRunnerTests.cs
+++ b/src/BSH.Test/Runtime/JobSessionRunnerTests.cs
@@ -73,7 +73,7 @@ public class JobSessionRunnerTests
         var backupService = new BackupServiceStub { CheckMediaResult = true, HasPasswordResult = false };
         using var jobRuntime = new JobRuntime(backupService, () => false, () => false, (_, _, _) => Task.FromResult(false), () => Task.FromResult(false));
         var presenter = new JobReportStub();
-        var runner = new JobSessionRunner(backupService, jobRuntime, () => true, Hash.GetMD5Hash("secret"), new StoredPasswordAdapterStub());
+        var runner = new JobSessionRunner(backupService, jobRuntime, () => true, () => Hash.GetMD5Hash("secret"), new StoredPasswordAdapterStub());
 
         var result = await runner.RunSingleBackupAsync("title", "description", presenter, statusDialog: true);
 
@@ -110,7 +110,7 @@ public class JobSessionRunnerTests
         using var jobRuntime = new JobRuntime(backupService, () => false, () => false, (_, _, _) => Task.FromResult(false), () => Task.FromResult(false));
         var presenter = new JobReportStub();
         var storedPasswordAdapter = new StoredPasswordAdapterStub { StoredPassword = "secret" };
-        var runner = new JobSessionRunner(backupService, jobRuntime, () => true, Hash.GetMD5Hash("secret"), storedPasswordAdapter);
+        var runner = new JobSessionRunner(backupService, jobRuntime, () => true, () => Hash.GetMD5Hash("secret"), storedPasswordAdapter);
 
         var result = await runner.RunSingleBackupAsync("title", "description", presenter, statusDialog: true);
 
@@ -129,7 +129,7 @@ public class JobSessionRunnerTests
             NextPasswordRequest = new JobSessionPasswordRequest("secret", true)
         };
         var storedPasswordAdapter = new StoredPasswordAdapterStub();
-        var runner = new JobSessionRunner(backupService, jobRuntime, () => true, Hash.GetMD5Hash("secret"), storedPasswordAdapter);
+        var runner = new JobSessionRunner(backupService, jobRuntime, () => true, () => Hash.GetMD5Hash("secret"), storedPasswordAdapter);
 
         var result = await runner.RunSingleBackupAsync("title", "description", presenter, statusDialog: true);
 
@@ -146,13 +146,35 @@ public class JobSessionRunnerTests
         var presenter = new JobReportStub();
         presenter.PasswordRequests.Enqueue(new JobSessionPasswordRequest("wrong", false));
         presenter.PasswordRequests.Enqueue(new JobSessionPasswordRequest("secret", false));
-        var runner = new JobSessionRunner(backupService, jobRuntime, () => true, Hash.GetMD5Hash("secret"), new StoredPasswordAdapterStub());
+        var runner = new JobSessionRunner(backupService, jobRuntime, () => true, () => Hash.GetMD5Hash("secret"), new StoredPasswordAdapterStub());
 
         var result = await runner.RunSingleBackupAsync("title", "description", presenter, statusDialog: true);
 
         Assert.That(result.Started, Is.True);
         Assert.That(presenter.ShowErrorPasswordWrongCalls, Is.EqualTo(1));
         Assert.That(presenter.RequestPasswordCalls, Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task RunSingleBackupAsync_UsesLatestPasswordHash_WhenConfigurationChangesAfterConstruction()
+    {
+        var backupService = new BackupServiceStub { CheckMediaResult = true, HasPasswordResult = false };
+        using var jobRuntime = new JobRuntime(backupService, () => false, () => false, (_, _, _) => Task.FromResult(false), () => Task.FromResult(false));
+        var presenter = new JobReportStub
+        {
+            NextPasswordRequest = new JobSessionPasswordRequest("new-secret", false)
+        };
+        var currentHash = Hash.GetMD5Hash("old-secret");
+        var runner = new JobSessionRunner(backupService, jobRuntime, () => true, () => currentHash, new StoredPasswordAdapterStub());
+
+        currentHash = Hash.GetMD5Hash("new-secret");
+
+        var result = await runner.RunSingleBackupAsync("title", "description", presenter, statusDialog: true);
+
+        Assert.That(result.Started, Is.True);
+        Assert.That(backupService.LastPasswordSet, Is.EqualTo("new-secret"));
+        Assert.That(presenter.ShowErrorPasswordWrongCalls, Is.EqualTo(0));
+        Assert.That(presenter.RequestPasswordCalls, Is.EqualTo(1));
     }
 
     private sealed class BackupServiceStub : IBackupService


### PR DESCRIPTION
## What to build

Move WinForms password resolution for job sessions behind the shared `JobSessionRunner` and a separate stored-password adapter. This slice should make password lookup and prompting follow one shared path: use an already available password if present, otherwise try stored credentials, otherwise prompt through the live job-session presenter seam.

This should preserve current user-visible credential behavior while separating durable password storage from live session interaction.

## Acceptance criteria

- [ ] A separate stored-password adapter exists for the WinForms product and is used by the shared runner.
- [ ] WinForms job-session password resolution is performed by `JobSessionRunner` in a consistent order: current password, stored password, then live prompt.
- [ ] Password persistence concerns are no longer mixed directly into the live WinForms job-session presentation seam.
