### PR TITLE
feat: Route WinForms restore, delete, and modify through shared job sessions

### DIFF
--- a/src/BSH.Engine/Runtime/JobSessionRunner.cs
+++ b/src/BSH.Engine/Runtime/JobSessionRunner.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Brightbits.BSH.Engine.Contracts.Services;
 using Brightbits.BSH.Engine.Exceptions;
@@ -80,7 +81,105 @@ public sealed class JobSessionRunner
         bool fullBackup = false,
         string sourceFolders = "")
     {
+        return await RunSingleOperationAsync(
+            ActionType.Backup,
+            presenter,
+            statusDialog,
+            requirePassword: true,
+            async (jobReport, cancellationToken) =>
+            {
+                await backupService.StartBackup(title, description, ref jobReport, cancellationToken, fullBackup, sourceFolders, !statusDialog);
+            });
+    }
+
+    /// <summary>
+    /// Runs a single restore session with shared session preparation and error handling.
+    /// </summary>
+    public async Task<SingleBackupSessionResult> RunSingleRestoreAsync(
+        string version,
+        string file,
+        string destination,
+        IJobSessionPresenter presenter,
+        bool statusDialog = true,
+        FileOverwrite overwrite = FileOverwrite.Ask)
+    {
+        return await RunSingleOperationAsync(
+            ActionType.Restore,
+            presenter,
+            statusDialog,
+            requirePassword: true,
+            async (jobReport, cancellationToken) =>
+            {
+                await backupService.StartRestore(version, file, destination, ref jobReport, cancellationToken, overwrite, !statusDialog);
+            });
+    }
+
+    /// <summary>
+    /// Runs a single delete session with shared session preparation and error handling.
+    /// </summary>
+    public async Task<SingleBackupSessionResult> RunSingleDeleteAsync(
+        string version,
+        IJobSessionPresenter presenter,
+        bool statusDialog = true)
+    {
+        return await RunSingleOperationAsync(
+            ActionType.Delete,
+            presenter,
+            statusDialog,
+            requirePassword: false,
+            async (jobReport, cancellationToken) =>
+            {
+                await backupService.StartDelete(version, ref jobReport, cancellationToken, !statusDialog);
+            });
+    }
+
+    /// <summary>
+    /// Runs a single delete-single-file session with shared session preparation and error handling.
+    /// </summary>
+    public async Task<SingleBackupSessionResult> RunSingleDeleteSingleAsync(
+        string fileFilter,
+        string pathFilter,
+        IJobSessionPresenter presenter,
+        bool statusDialog = true)
+    {
+        return await RunSingleOperationAsync(
+            ActionType.Delete,
+            presenter,
+            statusDialog,
+            requirePassword: false,
+            async (jobReport, cancellationToken) =>
+            {
+                await backupService.StartDeleteSingle(fileFilter, pathFilter, ref jobReport, cancellationToken, !statusDialog);
+            });
+    }
+
+    /// <summary>
+    /// Runs a single modify session with shared session preparation and error handling.
+    /// </summary>
+    public async Task<SingleBackupSessionResult> RunSingleModifyAsync(
+        IJobSessionPresenter presenter,
+        bool statusDialog = true)
+    {
+        return await RunSingleOperationAsync(
+            ActionType.Modify,
+            presenter,
+            statusDialog,
+            requirePassword: true,
+            async (jobReport, cancellationToken) =>
+            {
+                await backupService.StartEdit(ref jobReport, cancellationToken, !statusDialog);
+            });
+    }
+
+    private async Task<SingleBackupSessionResult> RunSingleOperationAsync(
+        ActionType action,
+        IJobSessionPresenter presenter,
+        bool statusDialog,
+        bool requirePassword,
+        Func<IJobReport, CancellationToken, Task> startAsync)
+    {
         ArgumentNullException.ThrowIfNull(presenter);
+        ArgumentNullException.ThrowIfNull(startAsync);
 
         IJobReport jobReport = presenter;
 
@@ -91,14 +190,17 @@ public sealed class JobSessionRunner
                 await presenter.ShowStatusWindowAsync();
             }
 
-            await ResolvePasswordAsync(presenter);
+            if (requirePassword)
+            {
+                await ResolvePasswordAsync(presenter);
+            }
 
-            var cancellationToken = await jobRuntime.PrepareAsync(ActionType.Backup, statusDialog, requirePassword: false);
+            var cancellationToken = await jobRuntime.PrepareAsync(action, statusDialog, requirePassword: false);
             presenter.SetCancellationToken(cancellationToken);
 
             try
             {
-                await backupService.StartBackup(title, description, ref jobReport, cancellationToken, fullBackup, sourceFolders, !statusDialog);
+                await startAsync(jobReport, cancellationToken);
             }
             catch
             {

--- a/src/BSH.Main/Modules/BackupController.cs
+++ b/src/BSH.Main/Modules/BackupController.cs
@@ -285,24 +285,28 @@ public class BackupController : IDisposable
         _logger.Debug("Restore task for version {version} and file \"{file}\" to \"{destination}\" started.",
             version, file, destination);
 
-        // check job requirements
-        if (!await PrepareJobAndHandleExceptions(ActionType.Restore, statusDialog))
+        var result = await jobSessionRunner.RunSingleRestoreAsync(version, file, destination, presenter, statusDialog);
+
+        if (!result.Started)
         {
+            switch (result.Failure)
+            {
+                case JobSessionStartFailure.TaskRunning:
+                    _logger.Error("Another task is running, so the restore task will not be started.");
+                    break;
+                case JobSessionStartFailure.DeviceNotReady:
+                    _logger.Error("Device is not ready, so the restore task will not be started.");
+                    break;
+                case JobSessionStartFailure.PasswordRequired:
+                    _logger.Error("Password request was cancelled, so the restore task will not be started.");
+                    break;
+            }
+
+            await presenter.CompleteAsync(honorCompletionActions: false);
             return;
         }
 
-        try
-        {
-            // run restore job
-            await backupService.StartRestore(version, file, destination, ref jobReportCallback, cancellationToken, FileOverwrite.Ask, !statusDialog);
-        }
-        catch
-        {
-            // exception already handled
-        }
-
-        // finish
-        HandleFinishedStatusDialog(statusDialog);
+        await presenter.CompleteAsync();
     }
 
     /// <summary>
@@ -378,25 +382,28 @@ public class BackupController : IDisposable
     {
         _logger.Debug("Delete task started for version {version}.", version);
 
-        // check job requirements
-        if (!await PrepareJobAndHandleExceptions(ActionType.Delete, statusDialog))
+        var result = await jobSessionRunner.RunSingleDeleteAsync(version, presenter, statusDialog);
+
+        if (!result.Started)
         {
+            switch (result.Failure)
+            {
+                case JobSessionStartFailure.TaskRunning:
+                    _logger.Error("Another task is running, so the delete task will not be started.");
+                    break;
+                case JobSessionStartFailure.DeviceNotReady:
+                    _logger.Error("Device is not ready, so the delete task will not be started.");
+                    break;
+                case JobSessionStartFailure.PasswordRequired:
+                    _logger.Error("Password request was cancelled, so the delete task will not be started.");
+                    break;
+            }
+
+            await presenter.CompleteAsync(honorCompletionActions: false);
             return;
         }
 
-        // run delete job
-
-        try
-        {
-            await backupService.StartDelete(version, ref jobReportCallback, cancellationToken, !statusDialog);
-        }
-        catch
-        {
-            // exception already handled
-        }
-
-        // finish
-        HandleFinishedStatusDialog(statusDialog);
+        await presenter.CompleteAsync();
     }
 
     /// <summary>
@@ -457,24 +464,61 @@ public class BackupController : IDisposable
     {
         _logger.Debug("Delete task started for file and folder filter.");
 
-        // check job requirements
-        if (!await PrepareJobAndHandleExceptions(ActionType.Delete, statusDialog))
+        var result = await jobSessionRunner.RunSingleDeleteSingleAsync(fileFilter, folderFilter, presenter, statusDialog);
+
+        if (!result.Started)
         {
+            switch (result.Failure)
+            {
+                case JobSessionStartFailure.TaskRunning:
+                    _logger.Error("Another task is running, so the delete task will not be started.");
+                    break;
+                case JobSessionStartFailure.DeviceNotReady:
+                    _logger.Error("Device is not ready, so the delete task will not be started.");
+                    break;
+                case JobSessionStartFailure.PasswordRequired:
+                    _logger.Error("Password request was cancelled, so the delete task will not be started.");
+                    break;
+            }
+
+            await presenter.CompleteAsync(honorCompletionActions: false);
             return;
         }
 
-        // run delete job
-        try
+        await presenter.CompleteAsync();
+    }
+
+    /// <summary>
+    /// Runs a modify backup task to edit the backup.
+    /// </summary>
+    /// <param name="statusDialog">Specifies if the user should be shown a status user interface.</param>
+    /// <returns></returns>
+    public async Task ModifyBackupAsync(bool statusDialog = true)
+    {
+        _logger.Debug("Modify task started.");
+
+        var result = await jobSessionRunner.RunSingleModifyAsync(presenter, statusDialog);
+
+        if (!result.Started)
         {
-            await backupService.StartDeleteSingle(fileFilter, folderFilter, ref jobReportCallback, cancellationToken, !statusDialog);
-        }
-        catch
-        {
-            // exception already handled
+            switch (result.Failure)
+            {
+                case JobSessionStartFailure.TaskRunning:
+                    _logger.Error("Another task is running, so the modify task will not be started.");
+                    break;
+                case JobSessionStartFailure.DeviceNotReady:
+                    _logger.Error("Device is not ready, so the modify task will not be started.");
+                    break;
+                case JobSessionStartFailure.PasswordRequired:
+                    _logger.Error("Password request was cancelled, so the modify task will not be started.");
+                    break;
+            }
+
+            await presenter.CompleteAsync(honorCompletionActions: false);
+            return;
         }
 
-        // finish
-        HandleFinishedStatusDialog(statusDialog);
+        await presenter.CompleteAsync();
     }
 
     /// <summary>

--- a/src/BSH.Test/Runtime/JobSessionRunnerTests.cs
+++ b/src/BSH.Test/Runtime/JobSessionRunnerTests.cs
@@ -177,17 +177,94 @@ public class JobSessionRunnerTests
         Assert.That(presenter.RequestPasswordCalls, Is.EqualTo(1));
     }
 
+    [Test]
+    public async Task RunSingleRestoreAsync_StartsRestore_WhenSessionCanBePrepared()
+    {
+        var backupService = new BackupServiceStub { CheckMediaResult = true };
+        using var jobRuntime = new JobRuntime(backupService, () => false, () => false, (_, _, _) => Task.FromResult(false), () => Task.FromResult(true));
+        var presenter = new JobReportStub();
+        var runner = new JobSessionRunner(backupService, jobRuntime);
+
+        var result = await runner.RunSingleRestoreAsync("5", "\\file.txt", "C:\\Restore", presenter, statusDialog: true, overwrite: FileOverwrite.Overwrite);
+
+        Assert.That(result.Started, Is.True);
+        Assert.That(backupService.StartRestoreCalls, Is.EqualTo(1));
+        Assert.That(backupService.LastVersion, Is.EqualTo("5"));
+        Assert.That(backupService.LastFile, Is.EqualTo("\\file.txt"));
+        Assert.That(backupService.LastDestination, Is.EqualTo("C:\\Restore"));
+        Assert.That(backupService.LastOverwrite, Is.EqualTo(FileOverwrite.Overwrite));
+        Assert.That(backupService.LastSilent, Is.False);
+    }
+
+    [Test]
+    public async Task RunSingleDeleteAsync_StartsDelete_WhenSessionCanBePrepared()
+    {
+        var backupService = new BackupServiceStub { CheckMediaResult = true };
+        using var jobRuntime = new JobRuntime(backupService, () => false, () => false, (_, _, _) => Task.FromResult(false), () => Task.FromResult(true));
+        var presenter = new JobReportStub();
+        var runner = new JobSessionRunner(backupService, jobRuntime);
+
+        var result = await runner.RunSingleDeleteAsync("7", presenter, statusDialog: false);
+
+        Assert.That(result.Started, Is.True);
+        Assert.That(backupService.StartDeleteCalls, Is.EqualTo(1));
+        Assert.That(backupService.LastVersion, Is.EqualTo("7"));
+        Assert.That(backupService.LastSilent, Is.True);
+    }
+
+    [Test]
+    public async Task RunSingleDeleteSingleAsync_StartsDeleteSingle_WhenSessionCanBePrepared()
+    {
+        var backupService = new BackupServiceStub { CheckMediaResult = true };
+        using var jobRuntime = new JobRuntime(backupService, () => false, () => false, (_, _, _) => Task.FromResult(false), () => Task.FromResult(true));
+        var presenter = new JobReportStub();
+        var runner = new JobSessionRunner(backupService, jobRuntime);
+
+        var result = await runner.RunSingleDeleteSingleAsync("*.tmp", "\\cache\\", presenter, statusDialog: true);
+
+        Assert.That(result.Started, Is.True);
+        Assert.That(backupService.StartDeleteSingleCalls, Is.EqualTo(1));
+        Assert.That(backupService.LastFileFilter, Is.EqualTo("*.tmp"));
+        Assert.That(backupService.LastPathFilter, Is.EqualTo("\\cache\\"));
+        Assert.That(backupService.LastSilent, Is.False);
+    }
+
+    [Test]
+    public async Task RunSingleModifyAsync_StartsEdit_WhenSessionCanBePrepared()
+    {
+        var backupService = new BackupServiceStub { CheckMediaResult = true };
+        using var jobRuntime = new JobRuntime(backupService, () => false, () => false, (_, _, _) => Task.FromResult(false), () => Task.FromResult(true));
+        var presenter = new JobReportStub();
+        var runner = new JobSessionRunner(backupService, jobRuntime);
+
+        var result = await runner.RunSingleModifyAsync(presenter, statusDialog: true);
+
+        Assert.That(result.Started, Is.True);
+        Assert.That(backupService.StartEditCalls, Is.EqualTo(1));
+        Assert.That(backupService.LastSilent, Is.False);
+    }
+
     private sealed class BackupServiceStub : IBackupService
     {
         public bool CheckMediaResult { get; set; } = true;
         public bool HasPasswordResult { get; set; } = true;
         public int StartBackupCalls { get; private set; }
+        public int StartRestoreCalls { get; private set; }
+        public int StartDeleteCalls { get; private set; }
+        public int StartDeleteSingleCalls { get; private set; }
+        public int StartEditCalls { get; private set; }
         public string LastTitle { get; private set; }
         public string LastDescription { get; private set; }
+        public string LastVersion { get; private set; }
+        public string LastFile { get; private set; }
+        public string LastDestination { get; private set; }
+        public string LastFileFilter { get; private set; }
+        public string LastPathFilter { get; private set; }
         public bool LastFullBackup { get; private set; }
         public string LastSources { get; private set; }
         public bool LastSilent { get; private set; }
         public string LastPasswordSet { get; private set; }
+        public FileOverwrite LastOverwrite { get; private set; }
 
         public Task<bool> CheckMedia(bool quickCheck = false) => Task.FromResult(CheckMediaResult);
         public string GetPassword() => string.Empty;
@@ -207,10 +284,40 @@ public class JobSessionRunnerTests
             return Task.CompletedTask;
         }
 
-        public Task StartDelete(string version, ref IJobReport jobReport, CancellationToken cancellationToken, bool silent = false) => throw new NotImplementedException();
-        public Task StartDeleteSingle(string fileFilter, string pathFilter, ref IJobReport jobReport, CancellationToken cancellationToken, bool silent = false) => throw new NotImplementedException();
-        public Task StartEdit(ref IJobReport jobReport, CancellationToken cancellationToken, bool silent = false) => throw new NotImplementedException();
-        public Task StartRestore(string version, string file, string destination, ref IJobReport jobReport, CancellationToken cancellationToken, FileOverwrite overwrite = FileOverwrite.Ask, bool silent = false) => throw new NotImplementedException();
+        public Task StartDelete(string version, ref IJobReport jobReport, CancellationToken cancellationToken, bool silent = false)
+        {
+            StartDeleteCalls++;
+            LastVersion = version;
+            LastSilent = silent;
+            return Task.CompletedTask;
+        }
+
+        public Task StartDeleteSingle(string fileFilter, string pathFilter, ref IJobReport jobReport, CancellationToken cancellationToken, bool silent = false)
+        {
+            StartDeleteSingleCalls++;
+            LastFileFilter = fileFilter;
+            LastPathFilter = pathFilter;
+            LastSilent = silent;
+            return Task.CompletedTask;
+        }
+
+        public Task StartEdit(ref IJobReport jobReport, CancellationToken cancellationToken, bool silent = false)
+        {
+            StartEditCalls++;
+            LastSilent = silent;
+            return Task.CompletedTask;
+        }
+
+        public Task StartRestore(string version, string file, string destination, ref IJobReport jobReport, CancellationToken cancellationToken, FileOverwrite overwrite = FileOverwrite.Ask, bool silent = false)
+        {
+            StartRestoreCalls++;
+            LastVersion = version;
+            LastFile = file;
+            LastDestination = destination;
+            LastOverwrite = overwrite;
+            LastSilent = silent;
+            return Task.CompletedTask;
+        }
         public void UpdateDatabaseFile(string databaseFile) { }
     }
 


### PR DESCRIPTION
## What to build

Extend the shared job-session architecture across the remaining single-operation WinForms flows: restore, delete, and modify. This slice should make those operations use the same shared session lifecycle that single backup uses, while preserving current terminal-state behavior and shell-specific completion side effects.

The goal is that WinForms single-operation job entry points become thin delegates to the shared runner rather than keeping their own orchestration logic.

## Acceptance criteria

- [ ] WinForms single restore, single delete, delete-single-file, and modify flows run through `JobSessionRunner`.
- [ ] Shared preparation, session lifecycle, and completion handling are reused across those WinForms single-operation flows.
- [ ] User-visible terminal-state behavior remains consistent with the current `FINISHED` / `ERROR` / `CANCELED` model.