### PR TITLE
feat: Route WinForms batch restore and batch delete through shared job sessions

### DIFF
--- a/.github/workflows/dotnet-desktop-build.yml
+++ b/.github/workflows/dotnet-desktop-build.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Setup dotnet
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
       with:
-        dotnet-version: 10.0.103
+        dotnet-version: 10.0.203
 
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/dotnet-desktop-release.yml
+++ b/.github/workflows/dotnet-desktop-release.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Setup dotnet
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
       with:
-        dotnet-version: 10.0.103
+        dotnet-version: 10.0.203
 
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/src/BSH.Engine/Runtime/JobSessionRunner.cs
+++ b/src/BSH.Engine/Runtime/JobSessionRunner.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Brightbits.BSH.Engine.Contracts.Services;
@@ -115,6 +116,35 @@ public sealed class JobSessionRunner
     }
 
     /// <summary>
+    /// Runs a batch restore session with shared lifecycle orchestration, overwrite carry-forward,
+    /// exception aggregation, and final-state reporting.
+    /// </summary>
+    public async Task<SingleBackupSessionResult> RunBatchRestoreAsync(
+        string version,
+        IReadOnlyList<string> files,
+        string destination,
+        IJobSessionPresenter presenter,
+        bool statusDialog = true)
+    {
+        ArgumentNullException.ThrowIfNull(files);
+
+        var overwrite = FileOverwrite.Ask;
+
+        return await RunBatchOperationAsync(
+            ActionType.Restore,
+            presenter,
+            statusDialog,
+            requirePassword: true,
+            files.Count,
+            async (jobReport, cancellationToken, index) =>
+            {
+                var file = files[index];
+                await backupService.StartRestore(version, file, destination, ref jobReport, cancellationToken, overwrite, !statusDialog);
+                overwrite = presenter.ResolveBatchOverwriteChoice(overwrite);
+            });
+    }
+
+    /// <summary>
     /// Runs a single delete session with shared session preparation and error handling.
     /// </summary>
     public async Task<SingleBackupSessionResult> RunSingleDeleteAsync(
@@ -129,6 +159,30 @@ public sealed class JobSessionRunner
             requirePassword: false,
             async (jobReport, cancellationToken) =>
             {
+                await backupService.StartDelete(version, ref jobReport, cancellationToken, !statusDialog);
+            });
+    }
+
+    /// <summary>
+    /// Runs a batch delete session with shared lifecycle orchestration, exception aggregation,
+    /// and final-state reporting.
+    /// </summary>
+    public async Task<SingleBackupSessionResult> RunBatchDeleteAsync(
+        IReadOnlyList<string> versions,
+        IJobSessionPresenter presenter,
+        bool statusDialog = true)
+    {
+        ArgumentNullException.ThrowIfNull(versions);
+
+        return await RunBatchOperationAsync(
+            ActionType.Delete,
+            presenter,
+            statusDialog,
+            requirePassword: false,
+            versions.Count,
+            async (jobReport, cancellationToken, index) =>
+            {
+                var version = versions[index];
                 await backupService.StartDelete(version, ref jobReport, cancellationToken, !statusDialog);
             });
     }
@@ -205,6 +259,98 @@ public sealed class JobSessionRunner
             catch
             {
             }
+
+            return new SingleBackupSessionResult()
+            {
+                Started = true,
+                Canceled = cancellationToken.IsCancellationRequested,
+                Failure = JobSessionStartFailure.None
+            };
+        }
+        catch (TaskRunningException)
+        {
+            if (statusDialog)
+            {
+                await presenter.ShowErrorTaskRunningAsync();
+            }
+
+            return new SingleBackupSessionResult() { Failure = JobSessionStartFailure.TaskRunning };
+        }
+        catch (Exception ex) when (ex is DeviceNotReadyException || ex is DeviceContainsWrongStateException)
+        {
+            if (statusDialog)
+            {
+                await presenter.ShowErrorDeviceNotReadyAsync();
+            }
+
+            return new SingleBackupSessionResult() { Failure = JobSessionStartFailure.DeviceNotReady };
+        }
+        catch (PasswordRequiredException)
+        {
+            if (statusDialog)
+            {
+                await presenter.ShowErrorPasswordRequiredAsync();
+            }
+
+            return new SingleBackupSessionResult() { Failure = JobSessionStartFailure.PasswordRequired };
+        }
+    }
+
+    private async Task<SingleBackupSessionResult> RunBatchOperationAsync(
+        ActionType action,
+        IJobSessionPresenter presenter,
+        bool statusDialog,
+        bool requirePassword,
+        int itemCount,
+        Func<IJobReport, CancellationToken, int, Task> runItemAsync)
+    {
+        ArgumentNullException.ThrowIfNull(presenter);
+        ArgumentNullException.ThrowIfNull(runItemAsync);
+
+        try
+        {
+            if (statusDialog)
+            {
+                await presenter.ShowStatusWindowAsync();
+            }
+
+            if (requirePassword)
+            {
+                await ResolvePasswordAsync(presenter);
+            }
+
+            var cancellationToken = await jobRuntime.PrepareAsync(action, statusDialog, requirePassword: false);
+            presenter.SetCancellationToken(cancellationToken);
+
+            presenter.ReportAction(action, !statusDialog);
+            presenter.ReportState(JobState.RUNNING);
+
+            var forwardJobReport = new ForwardJobReport(presenter);
+
+            for (var i = 0; i < itemCount; i++)
+            {
+                try
+                {
+                    presenter.ReportProgress(itemCount, i + 1);
+                    IJobReport activeReport = forwardJobReport;
+                    await runItemAsync(activeReport, cancellationToken, i);
+                }
+                catch
+                {
+                }
+
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+            }
+
+            forwardJobReport.ForwardExceptions(!statusDialog);
+
+            var finalState = cancellationToken.IsCancellationRequested
+                ? JobState.CANCELED
+                : (forwardJobReport.HasExceptions ? JobState.ERROR : JobState.FINISHED);
+            presenter.ReportState(finalState);
 
             return new SingleBackupSessionResult()
             {

--- a/src/BSH.Engine/Runtime/Ports/IJobSessionPresenter.cs
+++ b/src/BSH.Engine/Runtime/Ports/IJobSessionPresenter.cs
@@ -63,4 +63,9 @@ public interface IJobSessionPresenter : IJobReport
     /// Sets the cancellation token for the current session.
     /// </summary>
     void SetCancellationToken(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Resolves the overwrite mode that should be carried into the next batch restore item.
+    /// </summary>
+    FileOverwrite ResolveBatchOverwriteChoice(FileOverwrite currentOverwrite);
 }

--- a/src/BSH.Main/Modules/BackupController.cs
+++ b/src/BSH.Main/Modules/BackupController.cs
@@ -10,7 +10,6 @@ using System.Windows.Forms;
 using Brightbits.BSH.Engine;
 using Brightbits.BSH.Engine.Contracts;
 using Brightbits.BSH.Engine.Contracts.Services;
-using Brightbits.BSH.Engine.Exceptions;
 using Brightbits.BSH.Engine.Jobs;
 using Brightbits.BSH.Engine.Runtime;
 using Brightbits.BSH.Engine.Runtime.Ports;
@@ -33,8 +32,6 @@ public class BackupController : IDisposable
     private readonly IBackupService backupService;
 
     private readonly IConfigurationManager configurationManager;
-
-    private IJobReport jobReportCallback;
 
     private readonly JobRuntime jobRuntime;
     private readonly JobSessionRunner jobSessionRunner;
@@ -82,8 +79,6 @@ public class BackupController : IDisposable
             () => this.configurationManager.EncryptPassMD5,
             this.storedPasswordAdapter);
 
-        jobReportCallback = StatusController.Current;
-
         GetNewCancellationToken();
     }
 
@@ -115,104 +110,6 @@ public class BackupController : IDisposable
     public async Task<bool> CheckMediaAsync(ActionType action, bool silent = false)
     {
         return await jobRuntime.CheckMediaAsync(action, silent);
-    }
-
-    /// <summary>
-    /// Prepares a backup job by setting internal states, informs all observers, and
-    /// shows (if applicable) the corresponding user interfaces to the user.
-    /// </summary>
-    /// <param name="action">Specifies the action that is executed.</param>
-    /// <param name="statusDialog">Specifies if the status window should be shown.</param>
-    /// <returns></returns>
-    /// <exception cref="TaskRunningException"></exception>
-    /// <exception cref="DeviceNotReadyException"></exception>
-    /// <exception cref="PasswordRequiredException"></exception>
-    private async Task PrepareJob(ActionType action, bool statusDialog)
-    {
-        // show dialog?
-        if (statusDialog)
-        {
-            PresentationController.Current.ShowStatusWindow();
-        }
-
-        cancellationToken = await jobRuntime.PrepareAsync(action, statusDialog);
-    }
-
-    /// <summary>
-    /// Prepares a backup job by setting internal states, informs all observers, and
-    /// shows (if applicable) the corresponding user interfaces to the user. This method
-    /// also handles potential exceptions and returns false.
-    /// </summary>
-    /// <param name="action">Specifies the action that is executed.</param>
-    /// <param name="statusDialog">Specifies if the status window should be shown.</param>
-    /// <returns></returns>
-    private async Task<bool> PrepareJobAndHandleExceptions(ActionType action, bool statusDialog)
-    {
-        try
-        {
-            await PrepareJob(action, statusDialog);
-        }
-        catch (TaskRunningException ex)
-        {
-            _logger.Error(ex, "Another task is running, so the backup task will not be started.");
-
-            if (statusDialog)
-            {
-                MessageBox.Show(Resources.MSG_TASK_RUNNING_TEXT, Resources.MSG_TASK_RUNNING_TITLE, MessageBoxButtons.OK, MessageBoxIcon.Warning);
-            }
-
-            HandleFinishedStatusDialog(statusDialog);
-            return false;
-        }
-        catch (Exception ex) when (ex is DeviceNotReadyException || ex is DeviceContainsWrongStateException)
-        {
-            _logger.Error(ex, "Device is not ready, so the backup task will not be started.");
-
-            if (statusDialog)
-            {
-                MessageBox.Show(Resources.MSG_BACKUP_DEVICE_NOT_READY_TEXT, Resources.MSG_BACKUP_DEVICE_NOT_READY_TITLE, MessageBoxButtons.OK, MessageBoxIcon.Warning);
-            }
-
-            HandleFinishedStatusDialog(statusDialog);
-            return false;
-        }
-        catch (PasswordRequiredException ex)
-        {
-            _logger.Error(ex, "Password request was cancelled, so the backup task will not be started.");
-            HandleFinishedStatusDialog(statusDialog);
-            return false;
-        }
-
-        return true;
-    }
-
-    /// <summary>
-    /// Ensures that the corresponding finishing tasks of the status windows are handled according
-    /// to the user settings. If the user specifies to shutdown the computer, the computer will be
-    /// shut down. If the user specifies to hibernate the computer, the computer will be put into
-    /// this mode as well.
-    /// </summary>
-    /// <param name="statusDialog"></param>
-    /// <param name="triggerAction"></param>
-    private void HandleFinishedStatusDialog(bool statusDialog, bool triggerAction = false)
-    {
-        // finish job
-        if (statusDialog)
-        {
-            var action = PresentationController.Current.CloseStatusWindow();
-            if (triggerAction && action == TaskCompleteAction.ShutdownPC)
-            {
-                _logger.Debug("Computer will be shutdown after task has finished.");
-
-                Process.Start("shutdown.exe", "-s -t 60 -c \"" + Resources.TASK_BSH_SHUTDOWN_PC + "\"");
-            }
-            else if (triggerAction && action == TaskCompleteAction.HibernatePC)
-            {
-                _logger.Debug("Computer will be hibernated after task has finished.");
-
-                Process.Start("rundll32.exe", "powrprof.dll,SetSuspendState");
-            }
-        }
     }
 
     /// <summary>
@@ -322,54 +219,28 @@ public class BackupController : IDisposable
         _logger.Debug("Restore task for version {version} and {files} files to \"{destination}\" started.",
             version, files.Count, destination);
 
-        // check job requirements
-        if (!await PrepareJobAndHandleExceptions(ActionType.Restore, statusDialog))
+        var result = await jobSessionRunner.RunBatchRestoreAsync(version, files, destination, presenter, statusDialog);
+
+        if (!result.Started)
         {
+            switch (result.Failure)
+            {
+                case JobSessionStartFailure.TaskRunning:
+                    _logger.Error("Another task is running, so the restore task will not be started.");
+                    break;
+                case JobSessionStartFailure.DeviceNotReady:
+                    _logger.Error("Device is not ready, so the restore task will not be started.");
+                    break;
+                case JobSessionStartFailure.PasswordRequired:
+                    _logger.Error("Password request was cancelled, so the restore task will not be started.");
+                    break;
+            }
+
+            await presenter.CompleteAsync(honorCompletionActions: false);
             return;
         }
 
-        // run restore job
-        var fileOverwrite = FileOverwrite.Ask;
-
-        jobReportCallback.ReportAction(ActionType.Restore, !statusDialog);
-        jobReportCallback.ReportState(JobState.RUNNING);
-
-        IJobReport forwardJobReport = new ForwardJobReport(jobReportCallback);
-
-        for (var i = 0; i < files.Count; i++)
-        {
-            var file = files[i];
-            try
-            {
-                jobReportCallback.ReportProgress(files.Count, i + 1);
-
-                // restore file
-                await backupService.StartRestore(version, file, destination, ref forwardJobReport, cancellationToken, fileOverwrite, !statusDialog);
-            }
-            catch
-            {
-                // exception already handled
-            }
-            finally
-            {
-                // persist overwrite
-                if (StatusController.Current.LastFileOverwriteChoice == RequestOverwriteResult.OverwriteAll || StatusController.Current.LastFileOverwriteChoice == RequestOverwriteResult.NoOverwriteAll)
-                {
-                    fileOverwrite = StatusController.Current.LastFileOverwriteChoice == RequestOverwriteResult.OverwriteAll ? FileOverwrite.Overwrite : FileOverwrite.DontCopy;
-                }
-            }
-
-            if (cancellationToken.IsCancellationRequested)
-            {
-                break;
-            }
-        }
-
-        ((ForwardJobReport)forwardJobReport).ForwardExceptions(!statusDialog);
-        jobReportCallback.ReportState(cancellationToken.IsCancellationRequested ? JobState.CANCELED : JobState.FINISHED);
-
-        // finish
-        HandleFinishedStatusDialog(statusDialog);
+        await presenter.CompleteAsync();
     }
 
     /// <summary>
@@ -416,40 +287,28 @@ public class BackupController : IDisposable
     {
         _logger.Debug("Delete task started for {versions} versions.", versions.Count);
 
-        // check job requirements
-        if (!await PrepareJobAndHandleExceptions(ActionType.Delete, statusDialog))
+        var result = await jobSessionRunner.RunBatchDeleteAsync(versions, presenter, statusDialog);
+
+        if (!result.Started)
         {
+            switch (result.Failure)
+            {
+                case JobSessionStartFailure.TaskRunning:
+                    _logger.Error("Another task is running, so the delete task will not be started.");
+                    break;
+                case JobSessionStartFailure.DeviceNotReady:
+                    _logger.Error("Device is not ready, so the delete task will not be started.");
+                    break;
+                case JobSessionStartFailure.PasswordRequired:
+                    _logger.Error("Password request was cancelled, so the delete task will not be started.");
+                    break;
+            }
+
+            await presenter.CompleteAsync(honorCompletionActions: false);
             return;
         }
 
-        // run delete job
-        jobReportCallback.ReportAction(ActionType.Delete, !statusDialog);
-        jobReportCallback.ReportState(JobState.RUNNING);
-
-        IJobReport forwardJobReport = new ForwardJobReport(jobReportCallback);
-
-        foreach (var version in versions)
-        {
-            try
-            {
-                await backupService.StartDelete(version, ref forwardJobReport, cancellationToken, !statusDialog);
-            }
-            catch
-            {
-                // exception already handled
-            }
-
-            if (cancellationToken.IsCancellationRequested)
-            {
-                break;
-            }
-        }
-
-        ((ForwardJobReport)forwardJobReport).ForwardExceptions(!statusDialog);
-        jobReportCallback.ReportState(cancellationToken.IsCancellationRequested ? JobState.CANCELED : JobState.FINISHED);
-
-        // finish
-        HandleFinishedStatusDialog(statusDialog);
+        await presenter.CompleteAsync();
     }
 
     /// <summary>

--- a/src/BSH.Main/WinFormsJobSessionPresenter.cs
+++ b/src/BSH.Main/WinFormsJobSessionPresenter.cs
@@ -114,6 +114,16 @@ public class WinFormsJobSessionPresenter : IJobSessionPresenter
         this.cancellationToken = cancellationToken;
     }
 
+    public FileOverwrite ResolveBatchOverwriteChoice(FileOverwrite currentOverwrite)
+    {
+        return lastFileOverwriteChoice switch
+        {
+            RequestOverwriteResult.OverwriteAll => FileOverwrite.Overwrite,
+            RequestOverwriteResult.NoOverwriteAll => FileOverwrite.DontCopy,
+            _ => currentOverwrite
+        };
+    }
+
     private bool IsTaskRunning() => StatusController.Current.IsTaskRunning();
 
     public void ReportAction(ActionType action, bool silent)

--- a/src/BSH.Main/WinFormsJobSessionPresenter.cs
+++ b/src/BSH.Main/WinFormsJobSessionPresenter.cs
@@ -189,7 +189,7 @@ public class WinFormsJobSessionPresenter : IJobSessionPresenter
 
         dlgFilesOverwrite.picIco2.Image = dlgFilesOverwrite.picIco1.Image;
 
-        if (await dlgFilesOverwrite.ShowDialogAsync() == DialogResult.Cancel)
+        if (dlgFilesOverwrite.ShowDialog() == DialogResult.Cancel)
         {
             await CancelAsync();
             return RequestOverwriteResult.NoOverwrite;

--- a/src/BSH.Test/Runtime/JobSessionRunnerTests.cs
+++ b/src/BSH.Test/Runtime/JobSessionRunnerTests.cs
@@ -244,6 +244,42 @@ public class JobSessionRunnerTests
         Assert.That(backupService.LastSilent, Is.False);
     }
 
+    [Test]
+    public async Task RunBatchRestoreAsync_CarriesForwardOverwriteChoice_AndReportsFinishedState()
+    {
+        var backupService = new BackupServiceStub { CheckMediaResult = true };
+        using var jobRuntime = new JobRuntime(backupService, () => false, () => false, (_, _, _) => Task.FromResult(false), () => Task.FromResult(true));
+        var presenter = new JobReportStub();
+        presenter.BatchOverwriteChoices.Enqueue(FileOverwrite.Overwrite);
+        var runner = new JobSessionRunner(backupService, jobRuntime);
+
+        var result = await runner.RunBatchRestoreAsync("11", new[] { "\\a.txt", "\\b.txt" }, "C:\\Restore", presenter, statusDialog: true);
+
+        Assert.That(result.Started, Is.True);
+        Assert.That(backupService.StartRestoreCalls, Is.EqualTo(2));
+        Assert.That(backupService.RestoreOverwrites, Is.EqualTo(new[] { FileOverwrite.Ask, FileOverwrite.Overwrite }));
+        Assert.That(presenter.ReportedStates, Is.EqualTo(new[] { JobState.RUNNING, JobState.FINISHED }));
+        Assert.That(presenter.ProgressUpdates, Is.EqualTo(new[] { "2/1", "2/2" }));
+    }
+
+    [Test]
+    public async Task RunBatchDeleteAsync_ReportsError_WhenAnyItemFails()
+    {
+        var backupService = new BackupServiceStub { CheckMediaResult = true };
+        backupService.DeleteFailures.Enqueue(new FileExceptionEntry() { Exception = new InvalidOperationException("boom") });
+        using var jobRuntime = new JobRuntime(backupService, () => false, () => false, (_, _, _) => Task.FromResult(false), () => Task.FromResult(true));
+        var presenter = new JobReportStub();
+        var runner = new JobSessionRunner(backupService, jobRuntime);
+
+        var result = await runner.RunBatchDeleteAsync(new[] { "5", "6" }, presenter, statusDialog: false);
+
+        Assert.That(result.Started, Is.True);
+        Assert.That(backupService.StartDeleteCalls, Is.EqualTo(2));
+        Assert.That(presenter.ReportedStates, Is.EqualTo(new[] { JobState.RUNNING, JobState.ERROR }));
+        Assert.That(presenter.ReportedExceptions.Count, Is.EqualTo(1));
+        Assert.That(presenter.ReportedExceptions[0].Exception.Message, Is.EqualTo("boom"));
+    }
+
     private sealed class BackupServiceStub : IBackupService
     {
         public bool CheckMediaResult { get; set; } = true;
@@ -265,6 +301,8 @@ public class JobSessionRunnerTests
         public bool LastSilent { get; private set; }
         public string LastPasswordSet { get; private set; }
         public FileOverwrite LastOverwrite { get; private set; }
+        public System.Collections.Generic.List<FileOverwrite> RestoreOverwrites { get; } = new();
+        public System.Collections.Generic.Queue<FileExceptionEntry> DeleteFailures { get; } = new();
 
         public Task<bool> CheckMedia(bool quickCheck = false) => Task.FromResult(CheckMediaResult);
         public string GetPassword() => string.Empty;
@@ -289,6 +327,11 @@ public class JobSessionRunnerTests
             StartDeleteCalls++;
             LastVersion = version;
             LastSilent = silent;
+            if (DeleteFailures.Count > 0)
+            {
+                jobReport.ReportExceptions(new Collection<FileExceptionEntry> { DeleteFailures.Dequeue() }, silent);
+            }
+
             return Task.CompletedTask;
         }
 
@@ -316,6 +359,7 @@ public class JobSessionRunnerTests
             LastDestination = destination;
             LastOverwrite = overwrite;
             LastSilent = silent;
+            RestoreOverwrites.Add(overwrite);
             return Task.CompletedTask;
         }
         public void UpdateDatabaseFile(string databaseFile) { }
@@ -324,11 +368,17 @@ public class JobSessionRunnerTests
     private sealed class JobReportStub : IJobSessionPresenter
     {
         public void ReportAction(ActionType action, bool silent) { }
-        public void ReportState(JobState jobState) { }
+        public void ReportState(JobState jobState) => ReportedStates.Add(jobState);
         public void ReportStatus(string title, string text) { }
-        public void ReportProgress(int total, int current) { }
+        public void ReportProgress(int total, int current) => ProgressUpdates.Add($"{total}/{current}");
         public void ReportFileProgress(string file) { }
-        public void ReportExceptions(Collection<FileExceptionEntry> files, bool silent) { }
+        public void ReportExceptions(Collection<FileExceptionEntry> files, bool silent)
+        {
+            foreach (var file in files)
+            {
+                ReportedExceptions.Add(file);
+            }
+        }
         public Task<RequestOverwriteResult> RequestOverwrite(FileTableRow localFile, FileTableRow remoteFile) => Task.FromResult(RequestOverwriteResult.None);
         public Task RequestShowErrorInsufficientDiskSpaceAsync() => Task.CompletedTask;
 
@@ -340,6 +390,10 @@ public class JobSessionRunnerTests
         public int RequestPasswordCalls { get; private set; }
         public JobSessionPasswordRequest NextPasswordRequest { get; set; }
         public System.Collections.Generic.Queue<JobSessionPasswordRequest> PasswordRequests { get; } = new();
+        public System.Collections.Generic.Queue<FileOverwrite> BatchOverwriteChoices { get; } = new();
+        public System.Collections.Generic.List<JobState> ReportedStates { get; } = new();
+        public System.Collections.Generic.List<string> ProgressUpdates { get; } = new();
+        public System.Collections.Generic.List<FileExceptionEntry> ReportedExceptions { get; } = new();
 
         public Task ShowStatusWindowAsync()
         {
@@ -387,6 +441,16 @@ public class JobSessionRunnerTests
         public Task CancelAsync() => Task.CompletedTask;
         public CancellationToken GetCancellationToken() => CancellationToken.None;
         public void SetCancellationToken(CancellationToken cancellationToken) { }
+
+        public FileOverwrite ResolveBatchOverwriteChoice(FileOverwrite currentOverwrite)
+        {
+            if (BatchOverwriteChoices.Count > 0)
+            {
+                return BatchOverwriteChoices.Dequeue();
+            }
+
+            return currentOverwrite;
+        }
     }
 
     private sealed class StoredPasswordAdapterStub : IStoredPasswordAdapter


### PR DESCRIPTION
Fixes #497 

## What to build

Move the WinForms batch restore and batch delete flows onto the shared `JobSessionRunner`. This slice should make the runner own the full batch session lifecycle, including loop orchestration, cancellation behavior, overwrite-choice carry-forward, exception aggregation, and final-state calculation.

This should complete the main-product adoption of the shared job-session architecture for both single-operation and batch-operation job paths.

## Acceptance criteria

- [ ] WinForms batch restore and batch delete flows run through `JobSessionRunner` rather than custom caller-side orchestration.
- [ ] Batch-session concerns such as loop supervision, cancellation handling, overwrite-choice carry-forward, and exception aggregation are owned by the shared runner.
- [ ] Final batch terminal-state behavior remains consistent with the current model: `CANCELED` when canceled, `ERROR` when any item fails, and `FINISHED` otherwise.