### PR TITLE
feat: Port WinUI single-operation job sessions to the shared runner

### DIFF
--- a/src/BSH.MainApp/Services/JobService.cs
+++ b/src/BSH.MainApp/Services/JobService.cs
@@ -27,6 +27,9 @@ public class JobService : IJobService, IDisposable
     private readonly ILocalSettingsService localSettingsService;
     private readonly Func<IWaitForMediaService> waitForMediaServiceFactory;
     private readonly JobRuntime jobRuntime;
+    private readonly JobSessionRunner jobSessionRunner;
+    private readonly WinUIJobSessionPresenter presenter;
+    private readonly WinUIStoredPasswordAdapter storedPasswordAdapter;
 
     private IJobReport jobReportCallback;
 
@@ -67,6 +70,14 @@ public class JobService : IJobService, IDisposable
                 return await waitForMediaService.ExecuteAsync(silent, cancellationTokenSource);
             },
             this.RequestPassword);
+        this.presenter = new WinUIJobSessionPresenter(this.presentationService, this.statusService, this.Cancel);
+        this.storedPasswordAdapter = new WinUIStoredPasswordAdapter(this.localSettingsService);
+        this.jobSessionRunner = new JobSessionRunner(
+            backupService,
+            this.jobRuntime,
+            () => this.configurationManager.Encrypt == 1,
+            () => this.configurationManager.EncryptPassMD5,
+            this.storedPasswordAdapter);
 
         jobReportCallback = (IJobReport)statusService;
 
@@ -217,24 +228,16 @@ public class JobService : IJobService, IDisposable
         _logger.Debug("Backup task is started with title: {title}, description: {description}, statusDialog: {statusDialog}, fullBackup: {fullBackup}",
             title, description, statusDialog, fullBackup);
 
-        // check job requirements
-        if (!await PrepareJobAndHandleExceptions(ActionType.Backup, statusDialog))
+        var result = await jobSessionRunner.RunSingleBackupAsync(title, description, presenter, statusDialog, fullBackup, sourceFolders);
+        if (!result.Started)
         {
+            LogSingleOperationStartFailure(result.Failure, "backup");
+            await presenter.CompleteAsync(honorCompletionActions: false);
             return false;
         }
 
-        // run backup job
-        try
-        {
-            await backupService.StartBackup(title, description, ref jobReportCallback, cancellationToken, fullBackup, sourceFolders, !statusDialog);
-        }
-        catch
-        {
-            // exception already handled
-        }
-
-        await HandleFinishedStatusDialog(statusDialog);
-        return !cancellationToken.IsCancellationRequested;
+        await presenter.CompleteAsync(triggerShutdown: shutdownPC);
+        return !result.Canceled;
     }
 
     /// <summary>
@@ -250,24 +253,15 @@ public class JobService : IJobService, IDisposable
         _logger.Debug("Restore task for version {version} and file \"{file}\" to \"{destination}\" started.",
             version, file, destination);
 
-        // check job requirements
-        if (!await PrepareJobAndHandleExceptions(ActionType.Restore, statusDialog))
+        var result = await jobSessionRunner.RunSingleRestoreAsync(version, file, destination, presenter, statusDialog);
+        if (!result.Started)
         {
+            LogSingleOperationStartFailure(result.Failure, "restore");
+            await presenter.CompleteAsync(honorCompletionActions: false);
             return;
         }
 
-        // run restore job
-        try
-        {
-            await backupService.StartRestore(version, file, destination, ref jobReportCallback, cancellationToken, FileOverwrite.Ask, !statusDialog);
-        }
-        catch
-        {
-            // exception already handled
-        }
-
-        // finish
-        await HandleFinishedStatusDialog(statusDialog);
+        await presenter.CompleteAsync();
     }
 
     /// <summary>
@@ -347,24 +341,15 @@ public class JobService : IJobService, IDisposable
     {
         _logger.Debug("Delete task started for version {version}.", version);
 
-        // check job requirements
-        if (!await PrepareJobAndHandleExceptions(ActionType.Delete, statusDialog))
+        var result = await jobSessionRunner.RunSingleDeleteAsync(version, presenter, statusDialog);
+        if (!result.Started)
         {
+            LogSingleOperationStartFailure(result.Failure, "delete");
+            await presenter.CompleteAsync(honorCompletionActions: false);
             return;
         }
 
-        // run delete job
-        try
-        {
-            await backupService.StartDelete(version, ref jobReportCallback, cancellationToken, !statusDialog);
-        }
-        catch
-        {
-            // exception already handled
-        }
-
-        // finish
-        await HandleFinishedStatusDialog(statusDialog);
+        await presenter.CompleteAsync();
     }
 
     /// <summary>
@@ -433,24 +418,15 @@ public class JobService : IJobService, IDisposable
     {
         _logger.Debug("Delete task started for file and folder filter.");
 
-        // check job requirements
-        if (!await PrepareJobAndHandleExceptions(ActionType.Delete, statusDialog))
+        var result = await jobSessionRunner.RunSingleDeleteSingleAsync(fileFilter, folderFilter, presenter, statusDialog);
+        if (!result.Started)
         {
+            LogSingleOperationStartFailure(result.Failure, "delete");
+            await presenter.CompleteAsync(honorCompletionActions: false);
             return;
         }
 
-        // run delete job
-        try
-        {
-            await backupService.StartDeleteSingle(fileFilter, folderFilter, ref jobReportCallback, cancellationToken, !statusDialog);
-        }
-        catch
-        {
-            // exception already handled
-        }
-
-        // finish
-        await HandleFinishedStatusDialog(statusDialog);
+        await presenter.CompleteAsync();
     }
 
     /// <summary>
@@ -462,24 +438,15 @@ public class JobService : IJobService, IDisposable
     {
         _logger.Debug("Modify task started.");
 
-        // check job requirements
-        if (!await PrepareJobAndHandleExceptions(ActionType.Modify, statusDialog))
+        var result = await jobSessionRunner.RunSingleModifyAsync(presenter, statusDialog);
+        if (!result.Started)
         {
+            LogSingleOperationStartFailure(result.Failure, "modify");
+            await presenter.CompleteAsync(honorCompletionActions: false);
             return;
         }
 
-        // run modify job
-        try
-        {
-            await backupService.StartEdit(ref jobReportCallback, cancellationToken, statusDialog);
-        }
-        catch
-        {
-            // exception already handled
-        }
-
-        // finish
-        await HandleFinishedStatusDialog(statusDialog);
+        await presenter.CompleteAsync();
     }
 
     /// <summary>
@@ -547,5 +514,21 @@ public class JobService : IJobService, IDisposable
     {
         jobRuntime.Dispose();
         GC.SuppressFinalize(this);
+    }
+
+    private void LogSingleOperationStartFailure(JobSessionStartFailure failure, string operationName)
+    {
+        switch (failure)
+        {
+            case JobSessionStartFailure.TaskRunning:
+                _logger.Error("Another task is running, so the {operationName} task will not be started.", operationName);
+                break;
+            case JobSessionStartFailure.DeviceNotReady:
+                _logger.Error("Device is not ready, so the {operationName} task will not be started.", operationName);
+                break;
+            case JobSessionStartFailure.PasswordRequired:
+                _logger.Error("Password request was cancelled, so the {operationName} task will not be started.", operationName);
+                break;
+        }
     }
 }

--- a/src/BSH.MainApp/Services/WinUIJobSessionPresenter.cs
+++ b/src/BSH.MainApp/Services/WinUIJobSessionPresenter.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Collections.ObjectModel;
+using Brightbits.BSH.Engine;
+using Brightbits.BSH.Engine.Jobs;
+using Brightbits.BSH.Engine.Models;
+using Brightbits.BSH.Engine.Runtime.Ports;
+using BSH.MainApp.Contracts.Services;
+using BSH.MainApp.Helpers;
+using BSH.MainApp.Models;
+
+namespace BSH.MainApp.Services;
+
+/// <summary>
+/// WinUI implementation of <see cref="IJobSessionPresenter"/> using existing presentation
+/// and status services.
+/// </summary>
+public sealed class WinUIJobSessionPresenter : IJobSessionPresenter
+{
+    private readonly Action cancelAction;
+    private readonly IPresentationService presentationService;
+    private readonly IStatusService statusService;
+    private CancellationToken cancellationToken;
+
+    public WinUIJobSessionPresenter(IPresentationService presentationService, IStatusService statusService, Action cancelAction)
+    {
+        ArgumentNullException.ThrowIfNull(presentationService);
+        ArgumentNullException.ThrowIfNull(statusService);
+        ArgumentNullException.ThrowIfNull(cancelAction);
+
+        this.cancelAction = cancelAction;
+        this.presentationService = presentationService;
+        this.statusService = statusService;
+    }
+
+    public Task ShowStatusWindowAsync() => presentationService.ShowStatusWindowAsync();
+
+    public async Task CompleteAsync(bool triggerShutdown = false, bool triggerHibernate = false, bool honorCompletionActions = true)
+    {
+        _ = triggerShutdown;
+        _ = triggerHibernate;
+        _ = honorCompletionActions;
+
+        await presentationService.CloseStatusWindowAsync();
+    }
+
+    public Task ShowErrorTaskRunningAsync()
+    {
+        return presentationService.ShowMessageBoxAsync(
+            "MSG_TASK_RUNNING_TITLE".GetLocalized(),
+            "MSG_TASK_RUNNING_TEXT".GetLocalized(),
+            null);
+    }
+
+    public Task ShowErrorDeviceNotReadyAsync()
+    {
+        return presentationService.ShowMessageBoxAsync(
+            "MSG_BACKUP_DEVICE_NOT_READY_TITLE".GetLocalized(),
+            "MSG_BACKUP_DEVICE_NOT_READY_TEXT".GetLocalized(),
+            null);
+    }
+
+    public Task ShowErrorPasswordRequiredAsync() => Task.CompletedTask;
+
+    public async Task<JobSessionPasswordRequest> RequestPasswordAsync()
+    {
+        var (password, persist) = await presentationService.RequestPasswordAsync();
+        return new JobSessionPasswordRequest(password, persist);
+    }
+
+    public Task ShowErrorPasswordWrongAsync()
+    {
+        return presentationService.ShowMessageBoxAsync(
+            "MSG_PASSWORD_WRONG_TITLE".GetLocalized(),
+            "MSG_PASSWORD_WRONG_TEXT".GetLocalized(),
+            null);
+    }
+
+    public Task CancelAsync()
+    {
+        cancelAction();
+        return Task.CompletedTask;
+    }
+
+    public CancellationToken GetCancellationToken() => cancellationToken;
+
+    public void SetCancellationToken(CancellationToken cancellationToken)
+    {
+        this.cancellationToken = cancellationToken;
+    }
+
+    public FileOverwrite ResolveBatchOverwriteChoice(FileOverwrite currentOverwrite)
+    {
+        return statusService.LastFileOverwriteChoice switch
+        {
+            RequestOverwriteResult.OverwriteAll => FileOverwrite.Overwrite,
+            RequestOverwriteResult.NoOverwriteAll => FileOverwrite.DontCopy,
+            _ => currentOverwrite
+        };
+    }
+
+    public void ReportAction(ActionType action, bool silent) => statusService.ReportAction(action, silent);
+
+    public void ReportState(JobState jobState) => statusService.ReportState(jobState);
+
+    public void ReportStatus(string title, string text) => statusService.ReportStatus(title, text);
+
+    public void ReportProgress(int total, int current) => statusService.ReportProgress(total, current);
+
+    public void ReportFileProgress(string file) => statusService.ReportFileProgress(file);
+
+    public void ReportExceptions(Collection<FileExceptionEntry> files, bool silent) => statusService.ReportExceptions(files, silent);
+
+    public Task<RequestOverwriteResult> RequestOverwrite(FileTableRow localFile, FileTableRow remoteFile) => statusService.RequestOverwrite(localFile, remoteFile);
+
+    public Task RequestShowErrorInsufficientDiskSpaceAsync() => statusService.RequestShowErrorInsufficientDiskSpaceAsync();
+}

--- a/src/BSH.MainApp/Services/WinUIStoredPasswordAdapter.cs
+++ b/src/BSH.MainApp/Services/WinUIStoredPasswordAdapter.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Brightbits.BSH.Engine.Runtime.Ports;
+using Brightbits.BSH.Engine.Security;
+using BSH.MainApp.Contracts.Services;
+
+namespace BSH.MainApp.Services;
+
+/// <summary>
+/// WinUI adapter for durable backup password storage.
+/// </summary>
+public sealed class WinUIStoredPasswordAdapter : IStoredPasswordAdapter
+{
+    private const string BackupPasswordSettingKey = "BackupPassword";
+    private readonly ILocalSettingsService localSettingsService;
+
+    public WinUIStoredPasswordAdapter(ILocalSettingsService localSettingsService)
+    {
+        ArgumentNullException.ThrowIfNull(localSettingsService);
+
+        this.localSettingsService = localSettingsService;
+    }
+
+    public string GetPassword()
+    {
+        var encryptedPassword = localSettingsService.ReadSettingAsync<string>(BackupPasswordSettingKey).GetAwaiter().GetResult();
+        if (string.IsNullOrEmpty(encryptedPassword))
+        {
+            return string.Empty;
+        }
+
+        return Crypto.DecryptString(encryptedPassword);
+    }
+
+    public void StorePassword(string password)
+    {
+        localSettingsService.SaveSettingAsync(BackupPasswordSettingKey, Crypto.EncryptString(password)).GetAwaiter().GetResult();
+    }
+}


### PR DESCRIPTION
Fixes #500 

## What to build

Port the WinUI single-operation job paths to the shared `JobSessionRunner` after the main-product WinForms single-operation adoption is in place. This slice should make WinUI reuse the shared session lifecycle for its single-operation flows while preserving current user-visible behavior.

The goal is to prove that the deepened job-session seam serves both shells once it has been established in the main product.

## Acceptance criteria

- [x] WinUI single backup, single restore, single delete, delete-single-file, and modify flows run through `JobSessionRunner`.
- [x] WinUI single-operation job entry points become thin delegates to the shared session runner.
- [x] User-visible single-operation behavior remains functionally consistent from the WinUI shell’s perspective.