### PR TITLE
fix: Single-file delete looks in the wrong long-file directory, so long-path backups are never removed from storage

### DIFF
--- a/src/BSH.Engine/Jobs/DeleteSingleJob.cs
+++ b/src/BSH.Engine/Jobs/DeleteSingleJob.cs
@@ -180,7 +180,7 @@ public class DeleteSingleJob : Job
         string remoteFile;
         if ((fileType == "1" || fileType == "2" || fileType == "6") && !string.IsNullOrEmpty(longFileName))
         {
-            remoteFile = Path.Combine(versionDate, "_LONG_FILES", longFileName);
+            remoteFile = Path.Combine(versionDate, "_LONGFILES_", longFileName);
         }
         else
         {

--- a/src/BSH.Test/DeleteTests.cs
+++ b/src/BSH.Test/DeleteTests.cs
@@ -114,6 +114,26 @@ public class DeleteTests
         Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT versionStatus FROM versiontable WHERE versionID = 1")), Is.EqualTo(1));
     }
 
+    [Test]
+    public async Task TestDeleteSingleUsesLongFileDirectoryForEncryptedLongFiles()
+    {
+        const string versionDate = "01-01-2021 00-00-00";
+        await SeedVersionAsync(1, versionDate);
+        await SeedFileForVersionAsync(1, 1, 1, "encrypted-long.txt", @"\docs\", 6, "very-long-file-name");
+
+        var storage = new RecordingDeleteStorage();
+        var deleteJob = CreateDeleteSingleJob(storage);
+
+        await deleteJob.DeleteSingleAsync("encrypted-long.txt", @"\docs\");
+
+        Assert.That(storage.DeletedEncrypted, Has.Count.EqualTo(1));
+        Assert.That(storage.DeletedEncrypted[0], Is.EqualTo(Path.Combine(versionDate, "_LONGFILES_", "very-long-file-name")));
+
+        using var dbClient = dbClientFactory.CreateDbClient();
+        Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT COUNT(*) FROM fileversiontable")), Is.EqualTo(0));
+        Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT COUNT(*) FROM filetable")), Is.EqualTo(0));
+    }
+
     private DeleteJob CreateDeleteJob(IStorage storage, string version)
     {
         return new DeleteJob(
@@ -126,6 +146,17 @@ public class DeleteTests
         {
             Version = version
         };
+    }
+
+    private DeleteSingleJob CreateDeleteSingleJob(IStorage storage)
+    {
+        return new DeleteSingleJob(
+            storage,
+            dbClientFactory,
+            queryManager,
+            configurationManager,
+            versionQueryRepository,
+            backupMutationRepository);
     }
 
     private async Task SeedVersionAsync(int versionId, string versionDate)


### PR DESCRIPTION
Backups and normal delete/restore code consistently use the `_LONGFILES_` directory for path-too-long fallbacks. `DeleteSingleJob` instead targets `_LONG_FILES` (extra underscore, missing trailing underscore). Any single-file delete against a long-path file will fail to remove the blob from storage, but the job still proceeds to delete metadata afterward, leaving orphaned backup data and an inconsistent database view.

recommendation:
Change `DeleteSingleJob.DeleteFileFromDevice` to use the same `_LONGFILES_` directory name as backup, restore, and bulk delete paths. Then add a regression test that seeds a longfilename row and verifies single-file delete calls the storage backend with `_LONGFILES_`.

test analysis:
The existing delete tests cover `DeleteJob` only. There is no `DeleteSingleJob` test exercising longfilename handling, so this path mismatch is currently untested.

suggested regression test:
Seed a fileversion row with `fileType = 6` and `longfilename` set, run `DeleteSingleJob.DeleteSingleAsync`, and assert the storage mock receives `Path.Combine(versionDate, "_LONGFILES_", longfilename)`.

minimum fix scope:
src/BSH.Engine/Jobs/DeleteSingleJob.cs plus a new or expanded delete test covering `DeleteSingleJob` long-file deletion.