### PR TITLE
fix: Single-file restore can return the wrong file when the name or path contains SQL LIKE metacharacters

### DIFF
--- a/src/BSH.Engine/Repo/VersionQueryRepository.cs
+++ b/src/BSH.Engine/Repo/VersionQueryRepository.cs
@@ -55,8 +55,8 @@ public class VersionQueryRepository : IVersionQueryRepository
             "WHERE filelink.fileversionID = fileversiontable.fileversionID " +
             "AND filelink.versionID = @version " +
             "AND fileversiontable.filePackage = versiontable.versionID " +
-            "AND filetable.fileName LIKE @fileName " +
-            "AND filetable.filePath LIKE @filePath " +
+            "AND filetable.fileName = @fileName " +
+            "AND filetable.filePath = @filePath " +
             "AND fileversiontable.fileID = filetable.fileID LIMIT 1",
             parameters);
     }

--- a/src/BSH.Test/QueryManagerTests.cs
+++ b/src/BSH.Test/QueryManagerTests.cs
@@ -9,6 +9,7 @@ using Brightbits.BSH.Engine.Contracts;
 using Brightbits.BSH.Engine.Contracts.Database;
 using Brightbits.BSH.Engine.Database;
 using Brightbits.BSH.Engine.Models;
+using Brightbits.BSH.Engine.Repo;
 using BSH.Test.Mocks;
 using NUnit.Framework;
 
@@ -18,6 +19,7 @@ public class QueryManagerTests
     private IDbClientFactory dbClientFactory;
     private IConfigurationManager configurationManager;
     private IQueryManager queryManager;
+    private VersionQueryRepository versionQueryRepository;
 
     [SetUp]
     public async Task Setup()
@@ -45,6 +47,7 @@ public class QueryManagerTests
 
         var storageFactory = new StorageFactoryMock();
         queryManager = new QueryManager(dbClientFactory, configurationManager, storageFactory);
+        versionQueryRepository = new VersionQueryRepository();
 
         // insert some data
         await PopulateExampleData();
@@ -255,6 +258,28 @@ public class QueryManagerTests
     {
         var result = await queryManager.GetFileNameFromDriveAsync(1, "file1.txt", "\\source_1\\", null);
         Assert.That(result, Is.EqualTo(("X:\\Backups\\01-01-2021 00-00-00\\source_1\\file1.txt", false)));
+    }
+
+    [Test]
+    public async Task GetRestoreSingleFileAsyncTreatsLikeMetacharactersAsLiteral()
+    {
+        await dbClientFactory.ExecuteNonQueryAsync("INSERT INTO filetable (fileID, fileName, filePath) VALUES (4, 'report_1%.txt', '\\source_%\\')");
+        await dbClientFactory.ExecuteNonQueryAsync("INSERT INTO filetable (fileID, fileName, filePath) VALUES (5, 'reportA12.txt', '\\source_X\\')");
+
+        await dbClientFactory.ExecuteNonQueryAsync("INSERT INTO filelink (fileversionID, versionID) VALUES (4, 1)");
+        await dbClientFactory.ExecuteNonQueryAsync("INSERT INTO filelink (fileversionID, versionID) VALUES (5, 1)");
+
+        await dbClientFactory.ExecuteNonQueryAsync("INSERT INTO fileversiontable (fileversionID, fileStatus, fileType, fileHash, fileDateModified, fileDateCreated, fileSize, filePackage, fileID) VALUES (4, 0, 1, 'hash4', '2021-01-01 00:00:00', '2021-01-01 00:00:00', 100, 1, '4')");
+        await dbClientFactory.ExecuteNonQueryAsync("INSERT INTO fileversiontable (fileversionID, fileStatus, fileType, fileHash, fileDateModified, fileDateCreated, fileSize, filePackage, fileID) VALUES (5, 0, 1, 'hash5', '2021-01-01 00:00:00', '2021-01-01 00:00:00', 100, 1, '5')");
+
+        using var dbClient = dbClientFactory.CreateDbClient();
+        using var reader = await versionQueryRepository.GetRestoreSingleFileAsync(dbClient, 1, "report_1%.txt", "\\source_%\\");
+
+        Assert.That(await reader.ReadAsync(), Is.True);
+        Assert.That(reader.GetInt32(reader.GetOrdinal("fileID")), Is.EqualTo(4));
+        Assert.That(reader.GetString(reader.GetOrdinal("fileName")), Is.EqualTo("report_1%.txt"));
+        Assert.That(reader.GetString(reader.GetOrdinal("filePath")), Is.EqualTo("\\source_%\\"));
+        Assert.That(await reader.ReadAsync(), Is.False);
     }
 
     [Test]


### PR DESCRIPTION
## Summary

- patch attempt: `pat_fnd-sig-feat-library-0ab4bb0252-_80ea248593`
- status: `applied`
- files changed: 2

## Findings

- `fnd_sig-feat-library-0ab4bb0252-97a2_4ade78dd9a`: Single-file restore can return the wrong file when the name or path contains SQL LIKE metacharacters (medium)

## Changed Files

- `src/BSH.Engine/Repo/VersionQueryRepository.cs`
- `src/BSH.Test/QueryManagerTests.cs`

## Validation

- `dotnet test src/BSH.Test/BSH.Test.csproj` => 1
- `dotnet build "src/Backup Service Home 3.sln"` => 1
- `dotnet test "src/Backup Service Home 3.sln"` => 1

## Plan

Replaced `LIKE` with exact `=` predicates in `GetRestoreSingleFileAsync` so restore lookups treat `%` and `_` in file names and paths as literal characters, and added a regression test covering both metacharacters.

