### PR TITLE
fix: Startup continues after database/config initialization failure and dereferences null services

### DIFF
--- a/src/BSH.Main/Modules/BackupLogic.cs
+++ b/src/BSH.Main/Modules/BackupLogic.cs
@@ -81,8 +81,25 @@ static class BackupLogic
 
     private static Timer tmrUserReminder;
 
-    private static async Task LoadDatabaseAsync()
+    private static void ResetStartupServices()
     {
+        DbClientFactory = null;
+        ConfigurationManager = null;
+        QueryManager = null;
+        ScheduleRepository = null;
+        VersionQueryRepository = null;
+        BackupMutationRepository = null;
+        BackupService = null;
+        BackupController = null;
+        fileCollectorServiceFactory = null;
+        mediaWatcherFactory = null;
+        schedulerAdapterFactory = null;
+    }
+
+    private static async Task<bool> LoadDatabaseAsync()
+    {
+        ResetStartupServices();
+
         try
         {
             // init database and configuration manager
@@ -95,11 +112,15 @@ static class BackupLogic
             // database migration?
             var dbMigration = new DbMigrationService(DbClientFactory, ConfigurationManager);
             await dbMigration.InitializeAsync();
+            return true;
         }
         catch (Exception ex)
         {
+            ResetStartupServices();
+
             // global error
             ExceptionController.HandleGlobalException(null, new System.Threading.ThreadExceptionEventArgs(ex));
+            return false;
         }
     }
 
@@ -109,7 +130,10 @@ static class BackupLogic
     public static async Task StartupAsync()
     {
         // init database
-        await LoadDatabaseAsync();
+        if (!await LoadDatabaseAsync())
+        {
+            return;
+        }
 
         // start main system
         var storageFactory = new StorageFactory(ConfigurationManager);

--- a/src/BSH.Main/Program.cs
+++ b/src/BSH.Main/Program.cs
@@ -64,7 +64,7 @@ static class Program
             BackupLogic.StartupAsync().Wait();
 
             // parse command line if system is configured
-            if (BackupLogic.ConfigurationManager.IsConfigured == "1")
+            if (BackupLogic.ConfigurationManager?.IsConfigured == "1")
             {
                 CheckCommands(args);
             }


### PR DESCRIPTION
## Summary

- patch attempt: `pat_fnd-sig-feat-library-02f4da30aa-_2646a2a7a1`
- status: `applied`
- files changed: 2

## Findings

- `fnd_sig-feat-library-02f4da30aa-b15b_a24b70e6e2`: Startup continues after database/config initialization failure and dereferences null services (high)

## Changed Files

- `src/BSH.Main/Modules/BackupLogic.cs`
- `src/BSH.Main/Program.cs`

## Validation

- `dotnet build "src/Backup Service Home 3.sln"` => 0
- `dotnet test "src/Backup Service Home 3.sln"` => 0

## Plan

Made startup fail fast when database/config initialization fails by resetting partially initialized services, returning early from `StartupAsync`, and guarding `Program.Main` against a missing `ConfigurationManager` after failed startup.

