### PR TITLE
fix: Incremental version matching collapses distinct file changes made within the same second

### DIFF
--- a/src/BSH.Engine/Repo/BackupMutationRepository.cs
+++ b/src/BSH.Engine/Repo/BackupMutationRepository.cs
@@ -86,7 +86,7 @@ public class BackupMutationRepository : IBackupMutationRepository
         var result = await dbClient.ExecuteScalarAsync(
             CommandType.Text,
             "SELECT fileversionID FROM fileversiontable WHERE" +
-            " fileID = @fileID AND fileStatus = 1 AND fileSize = @fileSize AND datetime(fileDateModified) = datetime(@fileDateModified) ORDER BY fileversionID DESC LIMIT 1",
+            " fileID = @fileID AND fileStatus = 1 AND fileSize = @fileSize AND fileDateModified = @fileDateModified ORDER BY fileversionID DESC LIMIT 1",
             parameters);
 
         if (result == null)

--- a/src/BSH.Test/BackupTests.cs
+++ b/src/BSH.Test/BackupTests.cs
@@ -136,6 +136,67 @@ public class BackupTests
     }
 
     [Test]
+    public async Task TestIncrementalCreatesNewFileVersionForSameSizeEditWithinSameSecond()
+    {
+        var firstModified = new DateTime(2024, 1, 2, 3, 4, 5, 100, DateTimeKind.Local);
+        var secondModified = new DateTime(2024, 1, 2, 3, 4, 5, 900, DateTimeKind.Local);
+        var created = new DateTime(2024, 1, 2, 3, 0, 0, DateTimeKind.Local);
+
+        fileCollectorServiceFactory = new FileCollectorServiceFactoryMock(
+            new List<FolderTableRow>(),
+            new List<FileTableRow>
+            {
+                new FileTableRow
+                {
+                    FileName = "test.txt",
+                    FilePath = "",
+                    FileRoot = "D:\\Meine Dokumente",
+                    FileSize = 1024,
+                    FileDateCreated = created,
+                    FileDateModified = firstModified,
+                }
+            });
+
+        var firstBackupJob = new BackupJob(new StorageMock(), dbClientFactory, queryManager, configurationManager, fileCollectorServiceFactory, vssClient, versionQueryRepository, backupMutationRepository)
+        {
+            SourceFolder = "D:\\Meine Dokumente",
+            Title = "Blub",
+            Description = "",
+        };
+
+        var token = new CancellationTokenSource().Token;
+        await firstBackupJob.BackupAsync(token);
+
+        fileCollectorServiceFactory = new FileCollectorServiceFactoryMock(
+            new List<FolderTableRow>(),
+            new List<FileTableRow>
+            {
+                new FileTableRow
+                {
+                    FileName = "test.txt",
+                    FilePath = "",
+                    FileRoot = "D:\\Meine Dokumente",
+                    FileSize = 1024,
+                    FileDateCreated = created,
+                    FileDateModified = secondModified,
+                }
+            });
+
+        var secondBackupJob = new BackupJob(new StorageMock(), dbClientFactory, queryManager, configurationManager, fileCollectorServiceFactory, vssClient, versionQueryRepository, backupMutationRepository)
+        {
+            SourceFolder = "D:\\Meine Dokumente",
+            Title = "Blub",
+            Description = "",
+        };
+
+        await secondBackupJob.BackupAsync(token);
+
+        using var dbClient = dbClientFactory.CreateDbClient();
+        Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT COUNT(*) FROM fileversiontable")), Is.EqualTo(2));
+        Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT fileversionID FROM filelink WHERE versionID = 2")), Is.EqualTo(2));
+    }
+
+    [Test]
     public async Task TestCompressedFull()
     {
         // set compressed state


### PR DESCRIPTION
## Summary

- patch attempt: `pat_fnd-sig-feat-library-0ab4bb0252-_1fd1bd6d76`
- status: `applied`
- files changed: 2

## Findings

- `fnd_sig-feat-library-0ab4bb0252-34b6_203be6dac0`: Incremental version matching collapses distinct file changes made within the same second (high)

## Changed Files

- `src/BSH.Engine/Repo/BackupMutationRepository.cs`
- `src/BSH.Test/BackupTests.cs`

## Validation

- `dotnet test src/BSH.Test/BSH.Test.csproj` => 0
- `dotnet build "src/Backup Service Home 3.sln"` => 0
- `dotnet test "src/Backup Service Home 3.sln"` => 0

## Plan

Updated incremental file-version matching to use the full stored modification timestamp instead of SQLite's second-truncating `datetime(...)` conversion, and added a regression test covering same-size edits within the same second across incremental backups.

