### PR TITLE
WinUI: Add schedule editor parity

### DIFF
--- a/src/BSH.Engine/Models/ScheduleEntryKind.cs
+++ b/src/BSH.Engine/Models/ScheduleEntryKind.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Brightbits.BSH.Engine.Models;
+
+public enum ScheduleEntryKind
+{
+    Once = 1,
+    Hourly = 2,
+    Daily = 3,
+    Weekly = 4,
+    Monthly = 5,
+}

--- a/src/BSH.Engine/Models/ScheduleRetentionIntervalUnit.cs
+++ b/src/BSH.Engine/Models/ScheduleRetentionIntervalUnit.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Brightbits.BSH.Engine.Models;
+
+public enum ScheduleRetentionIntervalUnit
+{
+    Hour,
+    Day,
+    Week,
+}

--- a/src/BSH.Engine/Models/ScheduleRetentionMode.cs
+++ b/src/BSH.Engine/Models/ScheduleRetentionMode.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Brightbits.BSH.Engine.Models;
+
+public enum ScheduleRetentionMode
+{
+    None,
+    Automatic,
+    Interval,
+}

--- a/src/BSH.Engine/Models/ScheduleSettings.cs
+++ b/src/BSH.Engine/Models/ScheduleSettings.cs
@@ -61,6 +61,35 @@ public sealed class ScheduleSettings
         return entry;
     }
 
+    public ScheduleEntry AddSchedule(
+        ScheduleEntryKind kind,
+        DateTimeOffset startDate,
+        TimeSpan startTime,
+        DayOfWeek weeklyDay,
+        int monthlyDay)
+    {
+        return AddSchedule(kind, BuildScheduleDate(kind, startDate, startTime, weeklyDay, monthlyDay));
+    }
+
+    public static DateTime BuildScheduleDate(
+        ScheduleEntryKind kind,
+        DateTimeOffset startDate,
+        TimeSpan startTime,
+        DayOfWeek weeklyDay,
+        int monthlyDay)
+    {
+        var date = startDate.Date;
+        return kind switch
+        {
+            ScheduleEntryKind.Once => date.Add(startTime),
+            ScheduleEntryKind.Hourly => date.Add(startTime),
+            ScheduleEntryKind.Daily => date.Add(startTime),
+            ScheduleEntryKind.Weekly => GetWeeklyDate(date, startTime, weeklyDay),
+            ScheduleEntryKind.Monthly => GetMonthlyDate(date, startTime, monthlyDay),
+            _ => date.Add(startTime),
+        };
+    }
+
     public bool DeleteSchedule(ScheduleEntry entry)
     {
         return Entries.Remove(entry);
@@ -70,5 +99,17 @@ public sealed class ScheduleSettings
     {
         var entry = Entries.FirstOrDefault(x => x.Type == (int)kind && x.Date == date);
         return entry != null && Entries.Remove(entry);
+    }
+
+    private static DateTime GetWeeklyDate(DateTime baseDate, TimeSpan startTime, DayOfWeek weeklyDay)
+    {
+        var daysUntilSelectedDay = ((int)weeklyDay - (int)baseDate.DayOfWeek + 7) % 7;
+        return baseDate.AddDays(daysUntilSelectedDay).Add(startTime);
+    }
+
+    private static DateTime GetMonthlyDate(DateTime baseDate, TimeSpan startTime, int monthlyDay)
+    {
+        var day = Math.Clamp(monthlyDay, 1, DateTime.DaysInMonth(baseDate.Year, baseDate.Month));
+        return new DateTime(baseDate.Year, baseDate.Month, day).Add(startTime);
     }
 }

--- a/src/BSH.Engine/Models/ScheduleSettings.cs
+++ b/src/BSH.Engine/Models/ScheduleSettings.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Brightbits.BSH.Engine.Models;
+
+public sealed class ScheduleSettings
+{
+    public List<ScheduleEntry> Entries
+    {
+        get;
+    } = new();
+
+    public ScheduleRetentionMode RetentionMode
+    {
+        get; set;
+    }
+
+    public ScheduleRetentionIntervalUnit RetentionIntervalUnit
+    {
+        get; set;
+    } = ScheduleRetentionIntervalUnit.Day;
+
+    public int RetentionInterval
+    {
+        get; set;
+    } = 1;
+
+    public int AutomaticHourlyBackupThreshold
+    {
+        get; set;
+    } = 24;
+
+    public bool EnableScheduledFullBackups
+    {
+        get; set;
+    }
+
+    public int ScheduledFullBackupDays
+    {
+        get; set;
+    } = 1;
+
+    public bool PerformMissedBackupsLater
+    {
+        get; set;
+    }
+
+    public ScheduleEntry AddSchedule(ScheduleEntryKind kind, DateTime date)
+    {
+        var entry = new ScheduleEntry
+        {
+            Type = (int)kind,
+            Date = date
+        };
+
+        Entries.Add(entry);
+        return entry;
+    }
+
+    public bool DeleteSchedule(ScheduleEntry entry)
+    {
+        return Entries.Remove(entry);
+    }
+
+    public bool DeleteSchedule(DateTime date, ScheduleEntryKind kind)
+    {
+        var entry = Entries.FirstOrDefault(x => x.Type == (int)kind && x.Date == date);
+        return entry != null && Entries.Remove(entry);
+    }
+}

--- a/src/BSH.Engine/Services/ScheduleSettingsService.cs
+++ b/src/BSH.Engine/Services/ScheduleSettingsService.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading.Tasks;
+using Brightbits.BSH.Engine.Contracts;
+using Brightbits.BSH.Engine.Contracts.Repo;
+using Brightbits.BSH.Engine.Models;
+
+namespace Brightbits.BSH.Engine.Services;
+
+public sealed class ScheduleSettingsService
+{
+    private readonly IConfigurationManager configurationManager;
+    private readonly IScheduleRepository scheduleRepository;
+
+    public ScheduleSettingsService(
+        IConfigurationManager configurationManager,
+        IScheduleRepository scheduleRepository)
+    {
+        this.configurationManager = configurationManager;
+        this.scheduleRepository = scheduleRepository;
+    }
+
+    public async Task<ScheduleSettings> LoadAsync()
+    {
+        var settings = new ScheduleSettings();
+        settings.Entries.AddRange(await scheduleRepository.GetSchedulesAsync());
+
+        LoadRetention(settings);
+        settings.AutomaticHourlyBackupThreshold = ParsePositiveInt(configurationManager.IntervallAutoHourBackups, 24);
+        LoadScheduledFullBackup(settings);
+        settings.PerformMissedBackupsLater = configurationManager.DoPastBackups == "1";
+
+        return settings;
+    }
+
+    public async Task SaveAsync(ScheduleSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        await scheduleRepository.ReplaceSchedulesAsync(settings.Entries);
+        configurationManager.IntervallDelete = BuildRetentionConfig(settings);
+        configurationManager.IntervallAutoHourBackups = Math.Max(1, settings.AutomaticHourlyBackupThreshold).ToString(CultureInfo.InvariantCulture);
+        configurationManager.ScheduleFullBackup = settings.EnableScheduledFullBackups
+            ? "day|" + Math.Max(1, settings.ScheduledFullBackupDays).ToString(CultureInfo.InvariantCulture)
+            : string.Empty;
+        configurationManager.DoPastBackups = settings.PerformMissedBackupsLater ? "1" : "0";
+    }
+
+    private void LoadRetention(ScheduleSettings settings)
+    {
+        var interval = configurationManager.IntervallDelete ?? string.Empty;
+        if (string.IsNullOrEmpty(interval))
+        {
+            settings.RetentionMode = ScheduleRetentionMode.None;
+            return;
+        }
+
+        if (interval == "auto")
+        {
+            settings.RetentionMode = ScheduleRetentionMode.Automatic;
+            return;
+        }
+
+        var parts = interval.Split('|');
+        settings.RetentionMode = ScheduleRetentionMode.Interval;
+        settings.RetentionInterval = parts.Length > 1 ? ParsePositiveInt(parts[1], 1) : 1;
+        settings.RetentionIntervalUnit = parts.Length > 0
+            ? ParseRetentionUnit(parts[0])
+            : ScheduleRetentionIntervalUnit.Day;
+    }
+
+    private void LoadScheduledFullBackup(ScheduleSettings settings)
+    {
+        var fullBackup = configurationManager.ScheduleFullBackup ?? string.Empty;
+        if (string.IsNullOrEmpty(fullBackup))
+        {
+            settings.EnableScheduledFullBackups = false;
+            return;
+        }
+
+        var parts = fullBackup.Split('|');
+        settings.EnableScheduledFullBackups = parts.Length > 0 && parts[0] == "day";
+        settings.ScheduledFullBackupDays = parts.Length > 1 ? ParsePositiveInt(parts[1], 1) : 1;
+    }
+
+    private static string BuildRetentionConfig(ScheduleSettings settings)
+    {
+        return settings.RetentionMode switch
+        {
+            ScheduleRetentionMode.Automatic => "auto",
+            ScheduleRetentionMode.Interval => $"{FormatRetentionUnit(settings.RetentionIntervalUnit)}|{Math.Max(1, settings.RetentionInterval).ToString(CultureInfo.InvariantCulture)}",
+            _ => string.Empty,
+        };
+    }
+
+    private static ScheduleRetentionIntervalUnit ParseRetentionUnit(string unit)
+    {
+        return unit switch
+        {
+            "hour" => ScheduleRetentionIntervalUnit.Hour,
+            "week" => ScheduleRetentionIntervalUnit.Week,
+            _ => ScheduleRetentionIntervalUnit.Day,
+        };
+    }
+
+    private static string FormatRetentionUnit(ScheduleRetentionIntervalUnit unit)
+    {
+        return unit switch
+        {
+            ScheduleRetentionIntervalUnit.Hour => "hour",
+            ScheduleRetentionIntervalUnit.Week => "week",
+            _ => "day",
+        };
+    }
+
+    private static int ParsePositiveInt(string value, int fallback)
+    {
+        return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) && parsed > 0
+            ? parsed
+            : fallback;
+    }
+}

--- a/src/BSH.Main/Modules/BackupLogic.cs
+++ b/src/BSH.Main/Modules/BackupLogic.cs
@@ -412,6 +412,9 @@ static class BackupLogic
     {
         var listDelete = new List<VersionDetails>();
         var listVersions = QueryManager.GetVersions();
+        var hourlyBackupThreshold = int.TryParse(ConfigurationManager.IntervallAutoHourBackups, out var threshold) && threshold > 0
+            ? threshold
+            : 24;
 
         foreach (var version in listVersions)
         {
@@ -421,8 +424,8 @@ static class BackupLogic
                 continue;
             }
 
-            // version not older than 24h
-            if (DateTime.Now.Subtract(version.CreationDate) <= new TimeSpan(24, 0, 0))
+            // keep hourly backups for the configured automatic-retention threshold
+            if (DateTime.Now.Subtract(version.CreationDate) <= new TimeSpan(hourlyBackupThreshold, 0, 0))
             {
                 continue;
             }

--- a/src/BSH.MainApp/App.xaml.cs
+++ b/src/BSH.MainApp/App.xaml.cs
@@ -106,6 +106,7 @@ public partial class App : Application
             services.AddSingleton<IVersionQueryRepository, VersionQueryRepository>();
             services.AddSingleton<IBackupMutationRepository, BackupMutationRepository>();
             services.AddSingleton<IScheduleRepository, ScheduleRepository>();
+            services.AddSingleton<ScheduleSettingsService>();
 
             services.AddSingleton<IVssClient, VolumeShadowCopyClient>();
             services.AddSingleton<ISchedulerAdapterFactory, SchedulerAdapterFactory>();
@@ -126,6 +127,7 @@ public partial class App : Application
             services.AddTransient<SettingsPage>();
 
             services.AddTransient<FilterViewModel>();
+            services.AddTransient<ScheduleEditorViewModel>();
 
             // Configuration
             services.Configure<LocalSettingsOptions>(context.Configuration.GetSection(nameof(LocalSettingsOptions)));

--- a/src/BSH.MainApp/Contracts/Services/IPresentationService.cs
+++ b/src/BSH.MainApp/Contracts/Services/IPresentationService.cs
@@ -27,4 +27,5 @@ public interface IPresentationService
     Task ShowStatusWindowAsync();
     Task<ContentDialogResult> ShowMessageBoxAsync(string title, string content, IList<IUICommand>? commands, uint defaultCommandIndex = 0, uint cancelCommandIndex = 1);
     Task ShowExcludeFileFolderWindowAsync();
+    Task ShowScheduleEditorWindowAsync();
 }

--- a/src/BSH.MainApp/Services/PresentationService.cs
+++ b/src/BSH.MainApp/Services/PresentationService.cs
@@ -202,4 +202,13 @@ public class PresentationService : IPresentationService
             await dialog.ShowDialogAsync();
         });
     }
+
+    public async Task ShowScheduleEditorWindowAsync()
+    {
+        await App.MainWindow.DispatcherQueue.EnqueueAsync(async () =>
+        {
+            var dialog = new ScheduleEditorWindow();
+            await dialog.ShowDialogAsync();
+        });
+    }
 }

--- a/src/BSH.MainApp/Services/ScheduledBackupService.cs
+++ b/src/BSH.MainApp/Services/ScheduledBackupService.cs
@@ -127,6 +127,9 @@ public class ScheduledBackupService : IScheduledBackupService
     {
         var listDelete = new List<VersionDetails>();
         var listVersions = queryManager.GetVersions();
+        var hourlyBackupThreshold = int.TryParse(configurationManager.IntervallAutoHourBackups, out var threshold) && threshold > 0
+            ? threshold
+            : 24;
 
         foreach (var version in listVersions)
         {
@@ -136,8 +139,8 @@ public class ScheduledBackupService : IScheduledBackupService
                 continue;
             }
 
-            // version not older than 24h
-            if (DateTime.Now.Subtract(version.CreationDate) <= new TimeSpan(24, 0, 0))
+            // keep hourly backups for the configured automatic-retention threshold
+            if (DateTime.Now.Subtract(version.CreationDate) <= new TimeSpan(hourlyBackupThreshold, 0, 0))
             {
                 continue;
             }
@@ -377,8 +380,11 @@ public class ScheduledBackupService : IScheduledBackupService
             if (Item[0] == "day")
             {
                 var lastFullBackup = await queryManager.GetLastFullBackupAsync();
-                var Diff = DateTime.Now.Subtract(lastFullBackup.CreationDate);
-                fullBackupOption = Diff.Days >= Convert.ToInt32(Item[1]);
+                if (lastFullBackup != null)
+                {
+                    var Diff = DateTime.Now.Subtract(lastFullBackup.CreationDate);
+                    fullBackupOption = Diff.Days >= Convert.ToInt32(Item[1]);
+                }
             }
         }
 

--- a/src/BSH.MainApp/ViewModels/SettingsViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/SettingsViewModel.cs
@@ -435,6 +435,12 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
         this.configurationManager.TaskType = newValue;
     }
 
+    [RelayCommand]
+    private async Task ShowScheduleEditorWindow()
+    {
+        await this.presentationController.ShowScheduleEditorWindowAsync();
+    }
+
     #endregion
 
     #region Enhanced Settings

--- a/src/BSH.MainApp/ViewModels/Windows/ScheduleEditorEntryViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/Windows/ScheduleEditorEntryViewModel.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Globalization;
+using Brightbits.BSH.Engine.Models;
+
+namespace BSH.MainApp.ViewModels.Windows;
+
+public sealed class ScheduleEditorEntryViewModel
+{
+    public ScheduleEditorEntryViewModel(ScheduleEntry entry)
+    {
+        Entry = entry;
+    }
+
+    public ScheduleEntry Entry
+    {
+        get;
+    }
+
+    public ScheduleEntryKind Kind => (ScheduleEntryKind)Entry.Type;
+
+    public string RepeatText => Kind switch
+    {
+        ScheduleEntryKind.Once => "Once",
+        ScheduleEntryKind.Hourly => "Hourly",
+        ScheduleEntryKind.Daily => "Daily",
+        ScheduleEntryKind.Weekly => "Weekly",
+        ScheduleEntryKind.Monthly => "Monthly",
+        _ => "Unknown",
+    };
+
+    public string ScheduleText => Kind switch
+    {
+        ScheduleEntryKind.Once => Entry.Date.ToString("g", CultureInfo.CurrentCulture),
+        ScheduleEntryKind.Hourly => $"At minute {Entry.Date.Minute:00}",
+        ScheduleEntryKind.Daily => Entry.Date.ToString("t", CultureInfo.CurrentCulture),
+        ScheduleEntryKind.Weekly => $"{Entry.Date:dddd}, {Entry.Date:t}",
+        ScheduleEntryKind.Monthly => $"Day {Entry.Date.Day}, {Entry.Date:t}",
+        _ => Entry.Date.ToString("g", CultureInfo.CurrentCulture),
+    };
+}

--- a/src/BSH.MainApp/ViewModels/Windows/ScheduleEditorViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/Windows/ScheduleEditorViewModel.cs
@@ -1,0 +1,182 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Collections.ObjectModel;
+using Brightbits.BSH.Engine;
+using Brightbits.BSH.Engine.Contracts;
+using Brightbits.BSH.Engine.Models;
+using Brightbits.BSH.Engine.Services;
+using BSH.MainApp.Contracts.Services;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace BSH.MainApp.ViewModels.Windows;
+
+public partial class ScheduleEditorViewModel : ObservableObject
+{
+    private readonly ScheduleSettingsService scheduleSettingsService;
+    private readonly IConfigurationManager configurationManager;
+    private readonly IScheduledBackupService scheduledBackupService;
+
+    private ScheduleSettings settings = new();
+
+    public TaskCompletionSource<bool> TaskCompletionSource
+    {
+        get;
+    } = new();
+
+    public IReadOnlyList<ScheduleEntryKind> ScheduleKinds
+    {
+        get;
+    } =
+    [
+        ScheduleEntryKind.Once,
+        ScheduleEntryKind.Hourly,
+        ScheduleEntryKind.Daily,
+        ScheduleEntryKind.Weekly,
+        ScheduleEntryKind.Monthly
+    ];
+
+    public IReadOnlyList<ScheduleRetentionMode> RetentionModes
+    {
+        get;
+    } =
+    [
+        ScheduleRetentionMode.None,
+        ScheduleRetentionMode.Automatic,
+        ScheduleRetentionMode.Interval
+    ];
+
+    public IReadOnlyList<ScheduleRetentionIntervalUnit> RetentionIntervalUnits
+    {
+        get;
+    } =
+    [
+        ScheduleRetentionIntervalUnit.Hour,
+        ScheduleRetentionIntervalUnit.Day,
+        ScheduleRetentionIntervalUnit.Week
+    ];
+
+    public ObservableCollection<ScheduleEditorEntryViewModel> Entries
+    {
+        get;
+    } = new();
+
+    [ObservableProperty]
+    private ScheduleEntryKind selectedScheduleKind = ScheduleEntryKind.Daily;
+
+    [ObservableProperty]
+    private DateTimeOffset startDate = DateTimeOffset.Now;
+
+    [ObservableProperty]
+    private TimeSpan startTime = DateTime.Now.TimeOfDay;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(DeleteScheduleCommand))]
+    private ScheduleEditorEntryViewModel? selectedEntry;
+
+    [ObservableProperty]
+    private ScheduleRetentionMode retentionMode = ScheduleRetentionMode.None;
+
+    [ObservableProperty]
+    private ScheduleRetentionIntervalUnit retentionIntervalUnit = ScheduleRetentionIntervalUnit.Day;
+
+    [ObservableProperty]
+    private int retentionInterval = 1;
+
+    [ObservableProperty]
+    private int automaticHourlyBackupThreshold = 24;
+
+    [ObservableProperty]
+    private bool enableScheduledFullBackups;
+
+    [ObservableProperty]
+    private int scheduledFullBackupDays = 1;
+
+    [ObservableProperty]
+    private bool performMissedBackupsLater;
+
+    public ScheduleEditorViewModel(
+        ScheduleSettingsService scheduleSettingsService,
+        IConfigurationManager configurationManager,
+        IScheduledBackupService scheduledBackupService)
+    {
+        this.scheduleSettingsService = scheduleSettingsService;
+        this.configurationManager = configurationManager;
+        this.scheduledBackupService = scheduledBackupService;
+    }
+
+    public async Task InitializeAsync()
+    {
+        settings = await scheduleSettingsService.LoadAsync();
+        LoadEntries();
+
+        RetentionMode = settings.RetentionMode;
+        RetentionIntervalUnit = settings.RetentionIntervalUnit;
+        RetentionInterval = settings.RetentionInterval;
+        AutomaticHourlyBackupThreshold = settings.AutomaticHourlyBackupThreshold;
+        EnableScheduledFullBackups = settings.EnableScheduledFullBackups;
+        ScheduledFullBackupDays = settings.ScheduledFullBackupDays;
+        PerformMissedBackupsLater = settings.PerformMissedBackupsLater;
+    }
+
+    [RelayCommand]
+    private void AddSchedule()
+    {
+        var date = StartDate.Date.Add(StartTime);
+        settings.AddSchedule(SelectedScheduleKind, date);
+        LoadEntries();
+    }
+
+    [RelayCommand(CanExecute = nameof(CanDeleteSchedule))]
+    private void DeleteSchedule()
+    {
+        if (SelectedEntry == null)
+        {
+            return;
+        }
+
+        settings.DeleteSchedule(SelectedEntry.Entry);
+        SelectedEntry = null;
+        LoadEntries();
+    }
+
+    [RelayCommand]
+    private async Task Save()
+    {
+        settings.RetentionMode = RetentionMode;
+        settings.RetentionIntervalUnit = RetentionIntervalUnit;
+        settings.RetentionInterval = RetentionInterval;
+        settings.AutomaticHourlyBackupThreshold = AutomaticHourlyBackupThreshold;
+        settings.EnableScheduledFullBackups = EnableScheduledFullBackups;
+        settings.ScheduledFullBackupDays = ScheduledFullBackupDays;
+        settings.PerformMissedBackupsLater = PerformMissedBackupsLater;
+
+        await scheduleSettingsService.SaveAsync(settings);
+
+        if (configurationManager.TaskType == TaskType.Schedule)
+        {
+            scheduledBackupService.Stop();
+            await scheduledBackupService.StartAsync();
+        }
+
+        TaskCompletionSource.TrySetResult(true);
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        TaskCompletionSource.TrySetResult(false);
+    }
+
+    private bool CanDeleteSchedule() => SelectedEntry != null;
+
+    private void LoadEntries()
+    {
+        Entries.Clear();
+        foreach (var entry in settings.Entries.OrderBy(x => x.Type).ThenBy(x => x.Date))
+        {
+            Entries.Add(new ScheduleEditorEntryViewModel(entry));
+        }
+    }
+}

--- a/src/BSH.MainApp/ViewModels/Windows/ScheduleEditorViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/Windows/ScheduleEditorViewModel.cs
@@ -37,6 +37,20 @@ public partial class ScheduleEditorViewModel : ObservableObject
         ScheduleEntryKind.Monthly
     ];
 
+    public IReadOnlyList<DayOfWeek> WeeklyDays
+    {
+        get;
+    } =
+    [
+        DayOfWeek.Monday,
+        DayOfWeek.Tuesday,
+        DayOfWeek.Wednesday,
+        DayOfWeek.Thursday,
+        DayOfWeek.Friday,
+        DayOfWeek.Saturday,
+        DayOfWeek.Sunday
+    ];
+
     public IReadOnlyList<ScheduleRetentionMode> RetentionModes
     {
         get;
@@ -63,6 +77,11 @@ public partial class ScheduleEditorViewModel : ObservableObject
     } = new();
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ShowDatePicker))]
+    [NotifyPropertyChangedFor(nameof(ShowWeeklyDayPicker))]
+    [NotifyPropertyChangedFor(nameof(ShowMonthlyDayPicker))]
+    [NotifyPropertyChangedFor(nameof(TimeHeader))]
+    [NotifyPropertyChangedFor(nameof(AddScheduleHelpText))]
     private ScheduleEntryKind selectedScheduleKind = ScheduleEntryKind.Daily;
 
     [ObservableProperty]
@@ -70,6 +89,12 @@ public partial class ScheduleEditorViewModel : ObservableObject
 
     [ObservableProperty]
     private TimeSpan startTime = DateTime.Now.TimeOfDay;
+
+    [ObservableProperty]
+    private DayOfWeek selectedWeeklyDay = DayOfWeek.Monday;
+
+    [ObservableProperty]
+    private int selectedMonthlyDay = 1;
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(DeleteScheduleCommand))]
@@ -95,6 +120,26 @@ public partial class ScheduleEditorViewModel : ObservableObject
 
     [ObservableProperty]
     private bool performMissedBackupsLater;
+
+    public bool ShowDatePicker => SelectedScheduleKind == ScheduleEntryKind.Once;
+
+    public bool ShowWeeklyDayPicker => SelectedScheduleKind == ScheduleEntryKind.Weekly;
+
+    public bool ShowMonthlyDayPicker => SelectedScheduleKind == ScheduleEntryKind.Monthly;
+
+    public string TimeHeader => SelectedScheduleKind == ScheduleEntryKind.Hourly
+        ? "Minute"
+        : "Time";
+
+    public string AddScheduleHelpText => SelectedScheduleKind switch
+    {
+        ScheduleEntryKind.Once => "Run once on the selected date and time.",
+        ScheduleEntryKind.Hourly => "Run every hour at the selected minute.",
+        ScheduleEntryKind.Daily => "Run every day at the selected time.",
+        ScheduleEntryKind.Weekly => "Run every week on the selected day and time.",
+        ScheduleEntryKind.Monthly => "Run every month on the selected day and time.",
+        _ => string.Empty,
+    };
 
     public ScheduleEditorViewModel(
         ScheduleSettingsService scheduleSettingsService,
@@ -123,8 +168,12 @@ public partial class ScheduleEditorViewModel : ObservableObject
     [RelayCommand]
     private void AddSchedule()
     {
-        var date = StartDate.Date.Add(StartTime);
-        settings.AddSchedule(SelectedScheduleKind, date);
+        settings.AddSchedule(
+            SelectedScheduleKind,
+            StartDate,
+            StartTime,
+            SelectedWeeklyDay,
+            SelectedMonthlyDay);
         LoadEntries();
     }
 

--- a/src/BSH.MainApp/Views/SettingsPages/ModeSettingsPage.xaml
+++ b/src/BSH.MainApp/Views/SettingsPages/ModeSettingsPage.xaml
@@ -67,7 +67,7 @@
                                     </TextBlock>
                                 </StackPanel>
                             </toolkit:SettingsCard.Header>
-                            <Button Content="Set schedule" />
+                            <Button Command="{x:Bind ViewModel.ShowScheduleEditorWindowCommand}" Content="Set schedule" />
                         </toolkit:SettingsCard>
 
                         <toolkit:SettingsCard>

--- a/src/BSH.MainApp/Windows/ScheduleEditorWindow.xaml
+++ b/src/BSH.MainApp/Windows/ScheduleEditorWindow.xaml
@@ -1,0 +1,253 @@
+<?xml version="1.0" encoding="utf-8"?>
+<winex:WindowEx
+    x:Class="BSH.MainApp.Windows.ScheduleEditorWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:viewmodels="using:BSH.MainApp.ViewModels.Windows"
+    xmlns:winex="using:WinUIEx"
+    Title="Schedule"
+    Width="920"
+    Height="720"
+    IsAlwaysOnTop="True"
+    IsMaximizable="False"
+    IsMinimizable="False"
+    IsResizable="True"
+    mc:Ignorable="d">
+
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" d:DataContext="{d:DesignInstance Type=viewmodels:ScheduleEditorViewModel}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <ScrollViewer Grid.Row="0" Padding="28,24,28,20" VerticalScrollBarVisibility="Auto">
+            <Grid MaxWidth="980" HorizontalAlignment="Center" RowSpacing="20">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <StackPanel Grid.Row="0" Spacing="4">
+                    <TextBlock FontSize="26" FontWeight="SemiBold" Text="Schedule" />
+                    <TextBlock
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Text="Create schedule entries and choose how scheduled backups are retained."
+                        TextWrapping="WrapWholeWords" />
+                </StackPanel>
+
+                <Border
+                    Grid.Row="1"
+                    Padding="18"
+                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    CornerRadius="8">
+                    <Grid RowSpacing="16">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="220" />
+                        </Grid.RowDefinitions>
+
+                        <Grid Grid.Row="0" ColumnSpacing="12">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <StackPanel Spacing="2">
+                                <TextBlock FontWeight="SemiBold" Text="Backup times" />
+                                <TextBlock
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    Text="Add one-time or recurring backup entries."
+                                    TextWrapping="WrapWholeWords" />
+                            </StackPanel>
+                            <CommandBar
+                                Grid.Column="1"
+                                Background="Transparent"
+                                DefaultLabelPosition="Right"
+                                IsOpen="False">
+                                <AppBarButton
+                                    Command="{Binding DeleteScheduleCommand}"
+                                    Icon="Delete"
+                                    Label="Delete" />
+                            </CommandBar>
+                        </Grid>
+
+                        <Grid Grid.Row="1" ColumnSpacing="12">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="170" />
+                                <ColumnDefinition Width="240" />
+                                <ColumnDefinition Width="200" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+
+                            <ComboBox
+                                Grid.Column="0"
+                                Header="Repeat"
+                                HorizontalAlignment="Stretch"
+                                ItemsSource="{Binding ScheduleKinds}"
+                                SelectedItem="{Binding SelectedScheduleKind, Mode=TwoWay}" />
+                            <DatePicker
+                                Grid.Column="1"
+                                Header="Date"
+                                Date="{Binding StartDate, Mode=TwoWay}" />
+                            <TimePicker
+                                Grid.Column="2"
+                                Header="Time"
+                                Time="{Binding StartTime, Mode=TwoWay}" />
+                            <Button
+                                Grid.Column="3"
+                                MinWidth="78"
+                                Margin="0,28,0,0"
+                                Command="{Binding AddScheduleCommand}"
+                                Style="{StaticResource AccentButtonStyle}">
+                                Add
+                            </Button>
+                        </Grid>
+
+                        <Grid Grid.Row="2" Padding="12,0" ColumnSpacing="16">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="180" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock
+                                FontWeight="SemiBold"
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                Text="Repeat" />
+                            <TextBlock
+                                Grid.Column="1"
+                                FontWeight="SemiBold"
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                Text="Date / time" />
+                        </Grid>
+
+                        <ListView
+                            Grid.Row="3"
+                            ItemsSource="{Binding Entries}"
+                            SelectedItem="{Binding SelectedEntry, Mode=TwoWay}"
+                            SelectionMode="Single">
+                            <ListView.ItemTemplate>
+                                <DataTemplate x:DataType="viewmodels:ScheduleEditorEntryViewModel">
+                                    <Grid MinHeight="42" Padding="12,6" ColumnSpacing="16">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="180" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock VerticalAlignment="Center" Text="{x:Bind RepeatText}" />
+                                        <TextBlock
+                                            Grid.Column="1"
+                                            VerticalAlignment="Center"
+                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                            Text="{x:Bind ScheduleText}" />
+                                    </Grid>
+                                </DataTemplate>
+                            </ListView.ItemTemplate>
+                        </ListView>
+                    </Grid>
+                </Border>
+
+                <Grid Grid.Row="2" ColumnSpacing="16">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <Border
+                        Padding="18"
+                        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                        BorderThickness="1"
+                        CornerRadius="8">
+                        <StackPanel Spacing="12">
+                            <StackPanel Spacing="2">
+                                <TextBlock FontWeight="SemiBold" Text="Retention" />
+                                <TextBlock
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    Text="Choose how long scheduled backup versions stay available."
+                                    TextWrapping="WrapWholeWords" />
+                            </StackPanel>
+
+                            <ComboBox
+                                Header="Mode"
+                                Width="240"
+                                HorizontalAlignment="Left"
+                                ItemsSource="{Binding RetentionModes}"
+                                SelectedItem="{Binding RetentionMode, Mode=TwoWay}" />
+
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <NumberBox
+                                    Header="Delete interval"
+                                    Minimum="1"
+                                    SpinButtonPlacementMode="Inline"
+                                    Value="{Binding RetentionInterval, Mode=TwoWay}"
+                                    Width="150" />
+                                <ComboBox
+                                    Header="Unit"
+                                    Width="150"
+                                    ItemsSource="{Binding RetentionIntervalUnits}"
+                                    SelectedItem="{Binding RetentionIntervalUnit, Mode=TwoWay}" />
+                            </StackPanel>
+
+                            <NumberBox
+                                Header="Hourly backup threshold"
+                                Minimum="1"
+                                SpinButtonPlacementMode="Inline"
+                                Value="{Binding AutomaticHourlyBackupThreshold, Mode=TwoWay}"
+                                Width="190" />
+                        </StackPanel>
+                    </Border>
+
+                    <Border
+                        Grid.Column="1"
+                        Padding="18"
+                        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                        BorderThickness="1"
+                        CornerRadius="8">
+                        <StackPanel Spacing="12">
+                            <StackPanel Spacing="2">
+                                <TextBlock FontWeight="SemiBold" Text="Full backups" />
+                                <TextBlock
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    Text="Control scheduled full backups and missed backup handling."
+                                    TextWrapping="WrapWholeWords" />
+                            </StackPanel>
+
+                            <ToggleSwitch Header="Create full backup after an interval" IsOn="{Binding EnableScheduledFullBackups, Mode=TwoWay}" />
+
+                            <NumberBox
+                                Header="Days between full backups"
+                                Minimum="1"
+                                SpinButtonPlacementMode="Inline"
+                                Value="{Binding ScheduledFullBackupDays, Mode=TwoWay}"
+                                Width="190" />
+
+                            <ToggleSwitch Header="Perform missed scheduled backups later" IsOn="{Binding PerformMissedBackupsLater, Mode=TwoWay}" />
+                        </StackPanel>
+                    </Border>
+                </Grid>
+            </Grid>
+        </ScrollViewer>
+
+        <Grid
+            Grid.Row="1"
+            Padding="28,12"
+            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+            BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+            BorderThickness="0,1,0,0">
+            <Grid MaxWidth="980" HorizontalAlignment="Stretch">
+                <StackPanel
+                    HorizontalAlignment="Right"
+                    Orientation="Horizontal"
+                    Spacing="10">
+                    <Button Command="{Binding CancelCommand}">Cancel</Button>
+                    <Button Command="{Binding SaveCommand}" Style="{StaticResource AccentButtonStyle}">Save</Button>
+                </StackPanel>
+            </Grid>
+        </Grid>
+    </Grid>
+</winex:WindowEx>

--- a/src/BSH.MainApp/Windows/ScheduleEditorWindow.xaml
+++ b/src/BSH.MainApp/Windows/ScheduleEditorWindow.xaml
@@ -77,37 +77,49 @@
                             </CommandBar>
                         </Grid>
 
-                        <Grid Grid.Row="1" ColumnSpacing="12">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="170" />
-                                <ColumnDefinition Width="240" />
-                                <ColumnDefinition Width="200" />
-                                <ColumnDefinition Width="Auto" />
-                            </Grid.ColumnDefinitions>
-
-                            <ComboBox
-                                Grid.Column="0"
-                                Header="Repeat"
-                                HorizontalAlignment="Stretch"
-                                ItemsSource="{Binding ScheduleKinds}"
-                                SelectedItem="{Binding SelectedScheduleKind, Mode=TwoWay}" />
-                            <DatePicker
-                                Grid.Column="1"
-                                Header="Date"
-                                Date="{Binding StartDate, Mode=TwoWay}" />
-                            <TimePicker
-                                Grid.Column="2"
-                                Header="Time"
-                                Time="{Binding StartTime, Mode=TwoWay}" />
-                            <Button
-                                Grid.Column="3"
-                                MinWidth="78"
-                                Margin="0,28,0,0"
-                                Command="{Binding AddScheduleCommand}"
-                                Style="{StaticResource AccentButtonStyle}">
-                                Add
-                            </Button>
-                        </Grid>
+                        <StackPanel Grid.Row="1" Spacing="8">
+                            <StackPanel Orientation="Horizontal" Spacing="12">
+                                <ComboBox
+                                    Header="Repeat"
+                                    ItemsSource="{Binding ScheduleKinds}"
+                                    SelectedItem="{Binding SelectedScheduleKind, Mode=TwoWay}"
+                                    Width="170" />
+                                <DatePicker
+                                    Header="Date"
+                                    Date="{Binding StartDate, Mode=TwoWay}"
+                                    Visibility="{x:Bind ViewModel.ShowDatePicker, Mode=OneWay}"
+                                    Width="240" />
+                                <ComboBox
+                                    Header="Day"
+                                    ItemsSource="{Binding WeeklyDays}"
+                                    SelectedItem="{Binding SelectedWeeklyDay, Mode=TwoWay}"
+                                    Visibility="{x:Bind ViewModel.ShowWeeklyDayPicker, Mode=OneWay}"
+                                    Width="160" />
+                                <NumberBox
+                                    Header="Day of month"
+                                    Minimum="1"
+                                    Maximum="31"
+                                    SpinButtonPlacementMode="Inline"
+                                    Value="{Binding SelectedMonthlyDay, Mode=TwoWay}"
+                                    Visibility="{x:Bind ViewModel.ShowMonthlyDayPicker, Mode=OneWay}"
+                                    Width="160" />
+                                <TimePicker
+                                    Header="{x:Bind ViewModel.TimeHeader, Mode=OneWay}"
+                                    Time="{Binding StartTime, Mode=TwoWay}"
+                                    Width="200" />
+                                <Button
+                                    MinWidth="78"
+                                    Margin="0,28,0,0"
+                                    Command="{Binding AddScheduleCommand}"
+                                    Style="{StaticResource AccentButtonStyle}">
+                                    Add
+                                </Button>
+                            </StackPanel>
+                            <TextBlock
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                Text="{x:Bind ViewModel.AddScheduleHelpText, Mode=OneWay}"
+                                TextWrapping="WrapWholeWords" />
+                        </StackPanel>
 
                         <Grid Grid.Row="2" Padding="12,0" ColumnSpacing="16">
                             <Grid.ColumnDefinitions>

--- a/src/BSH.MainApp/Windows/ScheduleEditorWindow.xaml.cs
+++ b/src/BSH.MainApp/Windows/ScheduleEditorWindow.xaml.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using BSH.MainApp.ViewModels.Windows;
+using WinUIEx;
+
+namespace BSH.MainApp.Windows;
+
+public sealed partial class ScheduleEditorWindow : WindowEx
+{
+    public ScheduleEditorViewModel ViewModel
+    {
+        get;
+    } = App.GetService<ScheduleEditorViewModel>();
+
+    public ScheduleEditorWindow()
+    {
+        InitializeComponent();
+        ((Microsoft.UI.Xaml.FrameworkElement)Content).DataContext = ViewModel;
+    }
+
+    public async Task<bool> ShowDialogAsync()
+    {
+        await ViewModel.InitializeAsync();
+
+        Activate();
+        this.CenterOnScreen();
+        var result = await ViewModel.TaskCompletionSource.Task;
+
+        Close();
+        return result;
+    }
+}

--- a/src/BSH.Test/ScheduleSettingsServiceTests.cs
+++ b/src/BSH.Test/ScheduleSettingsServiceTests.cs
@@ -110,4 +110,21 @@ public class ScheduleSettingsServiceTests
         Assert.That(reloaded.ScheduledFullBackupDays, Is.EqualTo(7));
         Assert.That(reloaded.PerformMissedBackupsLater, Is.True);
     }
+
+    [Test]
+    public void BuildScheduleDateUsesKindSpecificDateParts()
+    {
+        var baseDate = new DateTimeOffset(new DateTime(2026, 6, 1, 8, 0, 0));
+        var startTime = new TimeSpan(14, 30, 0);
+
+        Assert.That(
+            ScheduleSettings.BuildScheduleDate(ScheduleEntryKind.Once, baseDate, startTime, DayOfWeek.Friday, 31),
+            Is.EqualTo(new DateTime(2026, 6, 1, 14, 30, 0)));
+        Assert.That(
+            ScheduleSettings.BuildScheduleDate(ScheduleEntryKind.Weekly, baseDate, startTime, DayOfWeek.Friday, 31),
+            Is.EqualTo(new DateTime(2026, 6, 5, 14, 30, 0)));
+        Assert.That(
+            ScheduleSettings.BuildScheduleDate(ScheduleEntryKind.Monthly, baseDate, startTime, DayOfWeek.Friday, 31),
+            Is.EqualTo(new DateTime(2026, 6, 30, 14, 30, 0)));
+    }
 }

--- a/src/BSH.Test/ScheduleSettingsServiceTests.cs
+++ b/src/BSH.Test/ScheduleSettingsServiceTests.cs
@@ -1,0 +1,113 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Brightbits.BSH.Engine;
+using Brightbits.BSH.Engine.Contracts;
+using Brightbits.BSH.Engine.Contracts.Database;
+using Brightbits.BSH.Engine.Contracts.Repo;
+using Brightbits.BSH.Engine.Database;
+using Brightbits.BSH.Engine.Models;
+using Brightbits.BSH.Engine.Repo;
+using Brightbits.BSH.Engine.Services;
+using NUnit.Framework;
+
+namespace BSH.Test;
+
+public class ScheduleSettingsServiceTests
+{
+    private const string DatabaseFileName = "testdb_schedule_settings.db";
+
+    private IDbClientFactory dbClientFactory;
+    private IConfigurationManager configurationManager;
+    private IScheduleRepository scheduleRepository;
+    private ScheduleSettingsService scheduleSettingsService;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        DbClientFactory.ClosePool();
+        if (File.Exists(DatabaseFileName))
+        {
+            File.Delete(DatabaseFileName);
+        }
+
+        dbClientFactory = new DbClientFactory();
+        await dbClientFactory.InitializeAsync(Path.Combine(Environment.CurrentDirectory, DatabaseFileName));
+
+        configurationManager = new ConfigurationManager(dbClientFactory);
+        await configurationManager.InitializeAsync();
+
+        scheduleRepository = new ScheduleRepository(dbClientFactory);
+        scheduleSettingsService = new ScheduleSettingsService(configurationManager, scheduleRepository);
+    }
+
+    [TearDown]
+    public void Cleanup()
+    {
+        DbClientFactory.ClosePool();
+        if (File.Exists(DatabaseFileName))
+        {
+            File.Delete(DatabaseFileName);
+        }
+    }
+
+    [Test]
+    public async Task SaveAsyncPersistsCreatedAndDeletedScheduleEntries()
+    {
+        var settings = await scheduleSettingsService.LoadAsync();
+        var once = settings.AddSchedule(ScheduleEntryKind.Once, new DateTime(2026, 6, 1, 8, 30, 0));
+        settings.AddSchedule(ScheduleEntryKind.Hourly, new DateTime(2026, 6, 1, 0, 15, 0));
+        settings.AddSchedule(ScheduleEntryKind.Daily, new DateTime(2026, 6, 1, 10, 0, 0));
+        settings.AddSchedule(ScheduleEntryKind.Weekly, new DateTime(2026, 6, 3, 11, 0, 0));
+        settings.AddSchedule(ScheduleEntryKind.Monthly, new DateTime(2026, 6, 12, 12, 0, 0));
+
+        settings.DeleteSchedule(once);
+        await scheduleSettingsService.SaveAsync(settings);
+
+        var reloaded = await scheduleSettingsService.LoadAsync();
+
+        Assert.That(reloaded.Entries, Has.Count.EqualTo(4));
+        Assert.That(reloaded.Entries.Select(x => x.Type), Is.EquivalentTo(new[]
+        {
+            (int)ScheduleEntryKind.Hourly,
+            (int)ScheduleEntryKind.Daily,
+            (int)ScheduleEntryKind.Weekly,
+            (int)ScheduleEntryKind.Monthly
+        }));
+        Assert.That(reloaded.Entries.Any(x => x.Type == (int)ScheduleEntryKind.Once), Is.False);
+    }
+
+    [Test]
+    public async Task SaveAsyncPersistsRetentionFullBackupAndMissedBackupSettings()
+    {
+        var settings = await scheduleSettingsService.LoadAsync();
+        settings.RetentionMode = ScheduleRetentionMode.Interval;
+        settings.RetentionIntervalUnit = ScheduleRetentionIntervalUnit.Week;
+        settings.RetentionInterval = 3;
+        settings.AutomaticHourlyBackupThreshold = 36;
+        settings.EnableScheduledFullBackups = true;
+        settings.ScheduledFullBackupDays = 7;
+        settings.PerformMissedBackupsLater = true;
+
+        await scheduleSettingsService.SaveAsync(settings);
+
+        Assert.That(configurationManager.IntervallDelete, Is.EqualTo("week|3"));
+        Assert.That(configurationManager.IntervallAutoHourBackups, Is.EqualTo("36"));
+        Assert.That(configurationManager.ScheduleFullBackup, Is.EqualTo("day|7"));
+        Assert.That(configurationManager.DoPastBackups, Is.EqualTo("1"));
+
+        var reloaded = await scheduleSettingsService.LoadAsync();
+
+        Assert.That(reloaded.RetentionMode, Is.EqualTo(ScheduleRetentionMode.Interval));
+        Assert.That(reloaded.RetentionIntervalUnit, Is.EqualTo(ScheduleRetentionIntervalUnit.Week));
+        Assert.That(reloaded.RetentionInterval, Is.EqualTo(3));
+        Assert.That(reloaded.AutomaticHourlyBackupThreshold, Is.EqualTo(36));
+        Assert.That(reloaded.EnableScheduledFullBackups, Is.True);
+        Assert.That(reloaded.ScheduledFullBackupDays, Is.EqualTo(7));
+        Assert.That(reloaded.PerformMissedBackupsLater, Is.True);
+    }
+}


### PR DESCRIPTION
Add a WinUI schedule editor that is reachable from the scheduled backup settings flow and replicates the legacy schedule-management behavior end to end. Users should be able to open the schedule editor, add and delete schedule entries, configure retention behavior, configure automatic retention thresholds, configure scheduled full-backup cadence, save changes, and see those changes affect scheduled backup behavior.