### PR TITLE
Implement WinUI backup browser search and file details (#523, PRD #521)

### DIFF
--- a/src/BSH.Engine/Contracts/IQueryManager.cs
+++ b/src/BSH.Engine/Contracts/IQueryManager.cs
@@ -30,6 +30,6 @@ public interface IQueryManager
     Task<VersionDetails> GetVersionByIdAsync(string id);
     List<VersionDetails> GetVersions(bool desc = true);
     Task<List<FileTableRow>> GetVersionsByFileAsync(string fileName, string filePath);
-    Task<List<FileTableRow>> SearchFilesByVersionAsync(string version, string searchTerm, int? limit = 500);
+    Task<List<FileTableRow>> SearchFilesByVersionAsync(string version, string searchTerm, int limit = 500);
     Task<bool> HasChangesOrNewAsync(string path, string versionId);
 }

--- a/src/BSH.Engine/Contracts/IQueryManager.cs
+++ b/src/BSH.Engine/Contracts/IQueryManager.cs
@@ -30,6 +30,6 @@ public interface IQueryManager
     Task<VersionDetails> GetVersionByIdAsync(string id);
     List<VersionDetails> GetVersions(bool desc = true);
     Task<List<FileTableRow>> GetVersionsByFileAsync(string fileName, string filePath);
-    Task<List<FileTableRow>> SearchFilesByVersionAsync(string version, string searchTerm);
+    Task<List<FileTableRow>> SearchFilesByVersionAsync(string version, string searchTerm, int? limit = 500);
     Task<bool> HasChangesOrNewAsync(string path, string versionId);
 }

--- a/src/BSH.Engine/Contracts/IQueryManager.cs
+++ b/src/BSH.Engine/Contracts/IQueryManager.cs
@@ -14,6 +14,7 @@ public interface IQueryManager
     Task<string> GetBackVersionWhereFilesInFolderAsync(string startVersion, string path);
     string GetFileNameFromDrive(FileTableRow file);
     Task<ValueTuple<string, bool>> GetFileNameFromDriveAsync(int versionId, string fileName, string filePath, string password);
+    Task<FileDetails> GetFileDetailsAsync(string version, string fileName, string filePath);
     Task<List<FileTableRow>> GetFilesByVersionAsync(string version, string path);
     Task<List<string>> GetFolderListAsync(string version, string path);
     Task<string> GetFullRestoreFolderAsync(string folder, string version);
@@ -29,5 +30,6 @@ public interface IQueryManager
     Task<VersionDetails> GetVersionByIdAsync(string id);
     List<VersionDetails> GetVersions(bool desc = true);
     Task<List<FileTableRow>> GetVersionsByFileAsync(string fileName, string filePath);
+    Task<List<FileTableRow>> SearchFilesByVersionAsync(string version, string searchTerm);
     Task<bool> HasChangesOrNewAsync(string path, string versionId);
 }

--- a/src/BSH.Engine/Models/FileDetails.cs
+++ b/src/BSH.Engine/Models/FileDetails.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Collections.Generic;
+
+namespace Brightbits.BSH.Engine.Models;
+
+public class FileDetails
+{
+    public string Name
+    {
+        get; set;
+    }
+
+    public string RestorePath
+    {
+        get; set;
+    }
+
+    public string Type
+    {
+        get; set;
+    }
+
+    public double Size
+    {
+        get; set;
+    }
+
+    public DateTime Created
+    {
+        get; set;
+    }
+
+    public DateTime Modified
+    {
+        get; set;
+    }
+
+    public IReadOnlyList<VersionDetails> AvailableVersions
+    {
+        get; set;
+    } = [];
+}

--- a/src/BSH.Engine/QueryManager.cs
+++ b/src/BSH.Engine/QueryManager.cs
@@ -480,6 +480,133 @@ public class QueryManager : IQueryManager
         return result;
     }
 
+    public async Task<List<FileTableRow>> SearchFilesByVersionAsync(string version, string searchTerm)
+    {
+        var result = new List<FileTableRow>();
+
+        if (string.IsNullOrWhiteSpace(searchTerm))
+        {
+            return result;
+        }
+
+        using (var dbClient = dbClientFactory.CreateDbClient())
+        {
+            var parameters = new (string, object)[] {
+                ("versionID", version),
+                ("searchTerm", "%" + searchTerm + "%")
+            };
+
+            using var reader = await dbClient.ExecuteDataReaderAsync(
+                CommandType.Text,
+                "SELECT " +
+                "fileversiontable.fileStatus, " +
+                "fileversiontable.fileType, " +
+                "fileversiontable.fileDateModified, " +
+                "fileversiontable.fileDateCreated, " +
+                "fileversiontable.fileSize, " +
+                "fileversiontable.filePackage, " +
+                "fileversiontable.longfilename, " +
+                "filetable.fileName, " +
+                "filetable.filePath, " +
+                "versiontable.versionDate, " +
+                "filelink.versionID, " +
+                "filetable.fileID " +
+                "FROM " +
+                "filelink " +
+                "INNER JOIN fileversiontable On (filelink.fileversionID = fileversiontable.fileversionID) " +
+                "INNER JOIN filetable On (fileversiontable.fileID = filetable.fileID) " +
+                "INNER JOIN versiontable On (versiontable.versionID = fileversiontable.filePackage) " +
+                "WHERE filelink.versionID = @versionID " +
+                "AND (filetable.fileName LIKE @searchTerm OR filetable.filePath LIKE @searchTerm) " +
+                "ORDER BY filetable.filePath, filetable.fileName",
+                parameters);
+            while (await reader.ReadAsync())
+            {
+                result.Add(FileTableRow.FromReaderFile(reader));
+            }
+
+            await reader.CloseAsync();
+        }
+
+        return result;
+    }
+
+    public async Task<FileDetails> GetFileDetailsAsync(string version, string fileName, string filePath)
+    {
+        var files = await GetFilesByVersionAsync(version, filePath);
+        var file = files.Find(x => string.Equals(x.FileName, fileName, StringComparison.OrdinalIgnoreCase));
+        if (file == null)
+        {
+            return null;
+        }
+
+        return new FileDetails
+        {
+            Name = file.FileName,
+            RestorePath = await GetFullRestoreFilePathAsync(file.FileName, file.FilePath, version),
+            Type = GetFileTypeDisplayName(file.FileType),
+            Size = file.FileSize,
+            Created = file.FileDateCreated,
+            Modified = file.FileDateModified,
+            AvailableVersions = await GetAvailableVersionsForFileAsync(file.FileName, file.FilePath)
+        };
+    }
+
+    private async Task<string> GetFullRestoreFilePathAsync(string fileName, string filePath, string version)
+    {
+        var restoreFolder = await GetFullRestoreFolderAsync(filePath, version);
+        return string.IsNullOrEmpty(restoreFolder)
+            ? Path.Combine(GetPathWithoutSlashes(filePath), fileName)
+            : Path.Combine(restoreFolder, fileName);
+    }
+
+    private async Task<List<VersionDetails>> GetAvailableVersionsForFileAsync(string fileName, string filePath)
+    {
+        var result = new List<VersionDetails>();
+
+        using (var dbClient = dbClientFactory.CreateDbClient())
+        {
+            var parameters = new (string, object)[] {
+                ("fileName", fileName),
+                ("filePath", GetPathWithSlashes(filePath))
+            };
+
+            using var reader = await dbClient.ExecuteDataReaderAsync(
+                CommandType.Text,
+                "SELECT DISTINCT versiontable.* " +
+                "FROM versiontable " +
+                "INNER JOIN filelink ON filelink.versionID = versiontable.versionID " +
+                "INNER JOIN fileversiontable ON filelink.fileversionID = fileversiontable.fileversionID " +
+                "INNER JOIN filetable ON fileversiontable.fileID = filetable.fileID " +
+                "WHERE versiontable.versionStatus = 0 " +
+                "AND filetable.fileName = @fileName " +
+                "AND filetable.filePath = @filePath " +
+                "ORDER BY versiontable.versionID DESC",
+                parameters);
+
+            while (await reader.ReadAsync())
+            {
+                result.Add(VersionDetails.FromReader(reader));
+            }
+
+            await reader.CloseAsync();
+        }
+
+        return result;
+    }
+
+    private static string GetFileTypeDisplayName(string fileType)
+    {
+        return fileType switch
+        {
+            "1" => "Regular copy",
+            "2" or "4" => "Compressed",
+            "3" => "Stored copy",
+            "5" or "6" => "Encrypted",
+            _ => "Unknown"
+        };
+    }
+
     /// <summary>
     /// Returns a local file path if the file is directly accessable, otherwise null.
     /// </summary>

--- a/src/BSH.Engine/QueryManager.cs
+++ b/src/BSH.Engine/QueryManager.cs
@@ -518,7 +518,8 @@ public class QueryManager : IQueryManager
                 "INNER JOIN versiontable On (versiontable.versionID = fileversiontable.filePackage) " +
                 "WHERE filelink.versionID = @versionID " +
                 "AND (filetable.fileName LIKE @searchTerm OR filetable.filePath LIKE @searchTerm) " +
-                "ORDER BY filetable.filePath, filetable.fileName",
+                "ORDER BY filetable.filePath, filetable.fileName " +
+                "LIMIT 500",
                 parameters);
             while (await reader.ReadAsync())
             {

--- a/src/BSH.Engine/QueryManager.cs
+++ b/src/BSH.Engine/QueryManager.cs
@@ -480,7 +480,7 @@ public class QueryManager : IQueryManager
         return result;
     }
 
-    public async Task<List<FileTableRow>> SearchFilesByVersionAsync(string version, string searchTerm)
+    public async Task<List<FileTableRow>> SearchFilesByVersionAsync(string version, string searchTerm, int limit = 500)
     {
         var result = new List<FileTableRow>();
 
@@ -493,7 +493,8 @@ public class QueryManager : IQueryManager
         {
             var parameters = new (string, object)[] {
                 ("versionID", version),
-                ("searchTerm", "%" + searchTerm + "%")
+                ("searchTerm", "%" + searchTerm + "%"),
+                ("limit", limit)
             };
 
             using var reader = await dbClient.ExecuteDataReaderAsync(
@@ -519,7 +520,7 @@ public class QueryManager : IQueryManager
                 "WHERE filelink.versionID = @versionID " +
                 "AND (filetable.fileName LIKE @searchTerm OR filetable.filePath LIKE @searchTerm) " +
                 "ORDER BY filetable.filePath, filetable.fileName " +
-                "LIMIT 500",
+                "LIMIT @limit",
                 parameters);
             while (await reader.ReadAsync())
             {

--- a/src/BSH.MainApp/Contracts/Services/IPresentationService.cs
+++ b/src/BSH.MainApp/Contracts/Services/IPresentationService.cs
@@ -22,6 +22,7 @@ public interface IPresentationService
     Task<(bool, NewBackupViewModel)> ShowCreateBackupWindowAsync();
     Task<(bool, EditBackupViewModel)> ShowEditBackupWindowAsync(EditBackupViewModel backupViewModel);
     Task<bool> ShowDeleteBackupWindowAsync();
+    Task ShowFileDetailsAsync(FileDetails fileDetails);
     Task ShowErrorInsufficientDiskSpaceAsync();
     Task ShowMainWindowAsync();
     Task ShowStatusWindowAsync();

--- a/src/BSH.MainApp/Models/FileOrFolderItem.cs
+++ b/src/BSH.MainApp/Models/FileOrFolderItem.cs
@@ -19,6 +19,11 @@ public class FileOrFolderItem : INotifyPropertyChanged
         get; set;
     }
 
+    public string DisplayName
+    {
+        get; set;
+    } = string.Empty;
+
     public string FullPath
     {
         get; set;

--- a/src/BSH.MainApp/Services/PresentationService.cs
+++ b/src/BSH.MainApp/Services/PresentationService.cs
@@ -8,6 +8,7 @@ using BSH.MainApp.Models;
 using BSH.MainApp.ViewModels.Windows;
 using BSH.MainApp.Windows;
 using CommunityToolkit.WinUI;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Windows.UI.Popups;
 using WinUIEx;
@@ -122,6 +123,22 @@ public class PresentationService : IPresentationService
         return messageBoxResult == ContentDialogResult.Primary;
     }
 
+    public async Task ShowFileDetailsAsync(FileDetails fileDetails)
+    {
+        await App.MainWindow.DispatcherQueue.EnqueueAsync(async () =>
+        {
+            var dialog = new ContentDialog
+            {
+                XamlRoot = App.MainWindow.Content.XamlRoot,
+                Title = fileDetails.Name,
+                CloseButtonText = "Close",
+                Content = BuildFileDetailsContent(fileDetails)
+            };
+
+            await dialog.ShowAsync();
+        });
+    }
+
     public async Task<ContentDialogResult> ShowMessageBoxAsync(string title, string content, IList<IUICommand>? commands, uint defaultCommandIndex = 0, uint cancelCommandIndex = 1)
     {
         return await App.MainWindow.DispatcherQueue.EnqueueAsync(async () =>
@@ -192,6 +209,52 @@ public class PresentationService : IPresentationService
         }
 
         return dialog;
+    }
+
+    private static Grid BuildFileDetailsContent(FileDetails fileDetails)
+    {
+        var grid = new Grid
+        {
+            RowSpacing = 8,
+            ColumnSpacing = 16,
+            MaxWidth = 560
+        };
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+
+        AddDetailsRow(grid, "Restore path", fileDetails.RestorePath);
+        AddDetailsRow(grid, "Type", fileDetails.Type);
+        AddDetailsRow(grid, "Size", fileDetails.Size.ToString("N0") + " bytes");
+        AddDetailsRow(grid, "Created", fileDetails.Created.ToString("g"));
+        AddDetailsRow(grid, "Modified", fileDetails.Modified.ToString("g"));
+        AddDetailsRow(grid, "Available versions", string.Join(Environment.NewLine, fileDetails.AvailableVersions.Select(x => $"{x.Id} - {x.CreationDate:g}")));
+
+        return grid;
+    }
+
+    private static void AddDetailsRow(Grid grid, string label, string value)
+    {
+        var row = grid.RowDefinitions.Count;
+        grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+
+        var labelBlock = new TextBlock
+        {
+            Text = label,
+            FontWeight = Microsoft.UI.Text.FontWeights.SemiBold
+        };
+        Grid.SetRow(labelBlock, row);
+        Grid.SetColumn(labelBlock, 0);
+
+        var valueBlock = new TextBlock
+        {
+            Text = value,
+            TextWrapping = Microsoft.UI.Xaml.TextWrapping.Wrap
+        };
+        Grid.SetRow(valueBlock, row);
+        Grid.SetColumn(valueBlock, 1);
+
+        grid.Children.Add(labelBlock);
+        grid.Children.Add(valueBlock);
     }
 
     public async Task ShowExcludeFileFolderWindowAsync()

--- a/src/BSH.MainApp/ViewModels/BrowserViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/BrowserViewModel.cs
@@ -38,7 +38,7 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
     private string? currentFavorite;
 
     [ObservableProperty]
-    private string searchTerms;
+    private string searchTerms = string.Empty;
 
     [ObservableProperty]
     private bool toggleInfoPane = false;
@@ -68,6 +68,31 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
     private bool HasVersionSelected() => CurrentVersion != null;
     private bool HasFileSelected() => CurrentItem != null && CurrentItem.IsFile;
 
+    partial void OnSearchTermsChanged(string value)
+    {
+        _ = ApplySearchTermsAsync(value);
+    }
+
+    private async Task ApplySearchTermsAsync(string value)
+    {
+        if (CurrentVersion == null)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            if (CurrentFolderPath.Count > 0)
+            {
+                await LoadFolderAsync(CurrentVersion.Id, CurrentFolderPath[^1].FullPath);
+            }
+
+            return;
+        }
+
+        await LoadSearchResultsAsync(CurrentVersion.Id, value);
+    }
+
     [RelayCommand(CanExecute = nameof(HasVersionSelected))]
     private async Task LoadVersion()
     {
@@ -84,6 +109,7 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
         sources.ForEach(Favorites.Add);
         CurrentFavorite = sources[0];
 
+        SearchTerms = string.Empty;
         await LoadFolderAsync(CurrentVersion.Id, CurrentFavorite);
     }
 
@@ -187,7 +213,16 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
     [RelayCommand(CanExecute = nameof(HasFileSelected))]
     private async Task ShowFileProperties()
     {
-        throw new NotImplementedException();
+        if (CurrentItem == null || CurrentVersion == null)
+        {
+            return;
+        }
+
+        var fileDetails = await queryManager.GetFileDetailsAsync(CurrentVersion.Id, CurrentItem.Name, CurrentItem.FullPath);
+        if (fileDetails != null)
+        {
+            await presentationService.ShowFileDetailsAsync(fileDetails);
+        }
     }
 
     [RelayCommand(CanExecute = nameof(HasFileSelected))]
@@ -276,6 +311,7 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
 
     private async Task LoadFolderAsync(string version, string path)
     {
+        CurrentItem = null;
         var rootSplit = path.Split("\\", StringSplitOptions.RemoveEmptyEntries);
 
         CurrentFolderPath.Clear();
@@ -284,6 +320,7 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
             CurrentFolderPath.Add(new FileOrFolderItem()
             {
                 Name = rootSplit[i],
+                DisplayName = rootSplit[i],
                 FullPath = string.Join("\\", rootSplit[0..(i + 1)])
             });
         }
@@ -298,6 +335,7 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
             .Select(x => new FileOrFolderItem()
             {
                 Name = x[(x.LastIndexOf("\\") + 1)..],
+                DisplayName = x[(x.LastIndexOf("\\") + 1)..],
                 FullPath = x
             })
             .ToList();
@@ -307,6 +345,7 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
             .Select(x => new FileOrFolderItem()
             {
                 Name = x.FileName,
+                DisplayName = x.FileName,
                 FullPath = x.FilePath,
                 IsFile = true,
                 FileNameOnDrive = x.FileName,
@@ -332,6 +371,36 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
         LoadVersionCommand.NotifyCanExecuteChanged();
         LoadFolderCommand.NotifyCanExecuteChanged();
         UpFolderCommand.NotifyCanExecuteChanged();
+    }
+
+    private async Task LoadSearchResultsAsync(string version, string searchTerms)
+    {
+        CurrentItem = null;
+        var fileList = (await queryManager.SearchFilesByVersionAsync(version, searchTerms))
+            .Select(x => new FileOrFolderItem()
+            {
+                Name = x.FileName,
+                DisplayName = $"{x.FileName} - {x.FilePath.Trim('\\')}",
+                FullPath = x.FilePath,
+                IsFile = true,
+                FileNameOnDrive = x.FileName,
+
+                FileDateModified = x.FileDateModified,
+                FileDateCreated = x.FileDateCreated,
+                FileSize = x.FileSize
+            })
+            .ToList();
+
+        foreach (var file in fileList)
+        {
+            file.Icon16 = await FileSystemIconHelpers.GetFileIconAsync(file.FileNameOnDrive);
+            file.Icon64 = await FileSystemIconHelpers.GetFileIconAsync(file.FileNameOnDrive, 64);
+        }
+
+        Items.Clear();
+        fileList.ForEach(Items.Add);
+
+        LoadFolderCommand.NotifyCanExecuteChanged();
     }
 
     public async void OnNavigatedTo(object parameter)

--- a/src/BSH.MainApp/ViewModels/BrowserViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/BrowserViewModel.cs
@@ -21,6 +21,9 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
     private readonly IJobService jobService;
     private readonly IBackupService backupService;
     private readonly IPresentationService presentationService;
+    private BrowserContentMode contentMode = BrowserContentMode.Folder;
+    private long contentRequestId;
+    private bool suppressSearchTermsChanged;
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(RestoreFileCommand))]
@@ -62,14 +65,19 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
         this.presentationService = presentationService;
     }
 
-    private bool CanUpFolder() => CurrentFolderPath.Count > 1;
+    private bool CanUpFolder() => contentMode == BrowserContentMode.Folder && CurrentFolderPath.Count > 1;
     private bool HasFileOrFolderSelected() => CurrentItem != null && CurrentVersion != null;
-    private bool CanRestoreAll() => CurrentVersion != null && CurrentFolderPath.Count > 0;
+    private bool CanRestoreAll() => contentMode == BrowserContentMode.Folder && CurrentVersion != null && CurrentFolderPath.Count > 0;
     private bool HasVersionSelected() => CurrentVersion != null;
     private bool HasFileSelected() => CurrentItem != null && CurrentItem.IsFile;
 
     partial void OnSearchTermsChanged(string value)
     {
+        if (suppressSearchTermsChanged)
+        {
+            return;
+        }
+
         _ = ApplySearchTermsAsync(value);
     }
 
@@ -80,17 +88,18 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
             return;
         }
 
+        var requestId = BeginContentRequest();
         if (string.IsNullOrWhiteSpace(value))
         {
             if (CurrentFolderPath.Count > 0)
             {
-                await LoadFolderAsync(CurrentVersion.Id, CurrentFolderPath[^1].FullPath);
+                await LoadFolderAsync(CurrentVersion.Id, CurrentFolderPath[^1].FullPath, requestId);
             }
 
             return;
         }
 
-        await LoadSearchResultsAsync(CurrentVersion.Id, value);
+        await LoadSearchResultsAsync(CurrentVersion.Id, value, requestId);
     }
 
     [RelayCommand(CanExecute = nameof(HasVersionSelected))]
@@ -109,8 +118,8 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
         sources.ForEach(Favorites.Add);
         CurrentFavorite = sources[0];
 
-        SearchTerms = string.Empty;
-        await LoadFolderAsync(CurrentVersion.Id, CurrentFavorite);
+        ClearSearchTerms();
+        await LoadFolderAsync(CurrentVersion.Id, CurrentFavorite, BeginContentRequest());
     }
 
     [RelayCommand]
@@ -121,7 +130,8 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
             return;
         }
 
-        await LoadFolderAsync(CurrentVersion.Id, CurrentFavorite);
+        ClearSearchTerms();
+        await LoadFolderAsync(CurrentVersion.Id, CurrentFavorite, BeginContentRequest());
     }
 
     [RelayCommand(CanExecute = nameof(HasVersionSelected))]
@@ -133,7 +143,8 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
         }
 
         // load folder
-        await LoadFolderAsync(CurrentVersion.Id, CurrentItem.FullPath);
+        ClearSearchTerms();
+        await LoadFolderAsync(CurrentVersion.Id, CurrentItem.FullPath, BeginContentRequest());
     }
 
     [RelayCommand(CanExecute = nameof(CanUpFolder))]
@@ -145,7 +156,8 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
         }
 
         // load parent folder
-        await LoadFolderAsync(CurrentVersion.Id, CurrentFolderPath[^2].FullPath);
+        ClearSearchTerms();
+        await LoadFolderAsync(CurrentVersion.Id, CurrentFolderPath[^2].FullPath, BeginContentRequest());
     }
 
     [RelayCommand]
@@ -159,13 +171,23 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
         var favorite = CurrentFavorite;
         var versionId = CurrentVersion.Id;
         var currentFolder = CurrentFolderPath[^1].FullPath;
+        var searchTerms = SearchTerms;
+        var wasSearching = contentMode == BrowserContentMode.Search && !string.IsNullOrWhiteSpace(searchTerms);
 
         LoadVersions();
 
         CurrentVersion = Versions.First(x => x.Id == versionId);
         CurrentFavorite = favorite;
 
-        await LoadFolderAsync(CurrentVersion.Id, currentFolder);
+        var requestId = BeginContentRequest();
+        if (wasSearching)
+        {
+            await LoadSearchResultsAsync(CurrentVersion.Id, searchTerms, requestId);
+        }
+        else
+        {
+            await LoadFolderAsync(CurrentVersion.Id, currentFolder, requestId);
+        }
     }
 
     [RelayCommand]
@@ -176,7 +198,8 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
             return;
         }
 
-        await LoadFolderAsync(CurrentVersion.Id, selectedItem.FullPath);
+        ClearSearchTerms();
+        await LoadFolderAsync(CurrentVersion.Id, selectedItem.FullPath, BeginContentRequest());
     }
 
     [RelayCommand(CanExecute = nameof(HasFileOrFolderSelected))]
@@ -309,15 +332,14 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
         backupVersions.ForEach(Versions.Add);
     }
 
-    private async Task LoadFolderAsync(string version, string path)
+    private async Task LoadFolderAsync(string version, string path, long requestId)
     {
-        CurrentItem = null;
         var rootSplit = path.Split("\\", StringSplitOptions.RemoveEmptyEntries);
 
-        CurrentFolderPath.Clear();
+        var folderPath = new List<FileOrFolderItem>();
         for (var i = 0; i < rootSplit.Length; i++)
         {
-            CurrentFolderPath.Add(new FileOrFolderItem()
+            folderPath.Add(new FileOrFolderItem()
             {
                 Name = rootSplit[i],
                 DisplayName = rootSplit[i],
@@ -362,20 +384,21 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
             file.Icon64 = await FileSystemIconHelpers.GetFileIconAsync(file.FileNameOnDrive, 64);
         }
 
-        // merge lists
-        Items.Clear();
-        folderList.ForEach(Items.Add);
-        fileList.ForEach(Items.Add);
+        if (!IsCurrentContentRequest(requestId))
+        {
+            return;
+        }
 
-        // notify UI about potential changes
-        LoadVersionCommand.NotifyCanExecuteChanged();
-        LoadFolderCommand.NotifyCanExecuteChanged();
-        UpFolderCommand.NotifyCanExecuteChanged();
+        contentMode = BrowserContentMode.Folder;
+        CurrentItem = null;
+        CurrentFolderPath.Clear();
+        folderPath.ForEach(CurrentFolderPath.Add);
+        ReplaceItems(folderList.Concat(fileList));
+        NotifyContentCommandsChanged();
     }
 
-    private async Task LoadSearchResultsAsync(string version, string searchTerms)
+    private async Task LoadSearchResultsAsync(string version, string searchTerms, long requestId)
     {
-        CurrentItem = null;
         var fileList = (await queryManager.SearchFilesByVersionAsync(version, searchTerms))
             .Select(x => new FileOrFolderItem()
             {
@@ -397,10 +420,48 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
             file.Icon64 = await FileSystemIconHelpers.GetFileIconAsync(file.FileNameOnDrive, 64);
         }
 
-        Items.Clear();
-        fileList.ForEach(Items.Add);
+        if (!IsCurrentContentRequest(requestId))
+        {
+            return;
+        }
 
+        contentMode = BrowserContentMode.Search;
+        CurrentItem = null;
+        ReplaceItems(fileList);
+        NotifyContentCommandsChanged();
+    }
+
+    private long BeginContentRequest() => Interlocked.Increment(ref contentRequestId);
+
+    private bool IsCurrentContentRequest(long requestId) => Interlocked.Read(ref contentRequestId) == requestId;
+
+    private void ClearSearchTerms()
+    {
+        if (SearchTerms.Length == 0)
+        {
+            return;
+        }
+
+        suppressSearchTermsChanged = true;
+        SearchTerms = string.Empty;
+        suppressSearchTermsChanged = false;
+    }
+
+    private void ReplaceItems(IEnumerable<FileOrFolderItem> items)
+    {
+        Items.Clear();
+        foreach (var item in items)
+        {
+            Items.Add(item);
+        }
+    }
+
+    private void NotifyContentCommandsChanged()
+    {
+        LoadVersionCommand.NotifyCanExecuteChanged();
         LoadFolderCommand.NotifyCanExecuteChanged();
+        UpFolderCommand.NotifyCanExecuteChanged();
+        RestoreAllCommand.NotifyCanExecuteChanged();
     }
 
     public async void OnNavigatedTo(object parameter)
@@ -417,5 +478,11 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
     public void OnNavigatedFrom()
     {
         FileSystemIconHelpers.ClearIconCache();
+    }
+
+    private enum BrowserContentMode
+    {
+        Folder,
+        Search
     }
 }

--- a/src/BSH.MainApp/Views/BrowserPage.xaml
+++ b/src/BSH.MainApp/Views/BrowserPage.xaml
@@ -135,7 +135,7 @@
                 </Grid>
 
                 <!-- search box -->
-                <TextBox x:Name="tbSearchBox" Grid.Column="2" PlaceholderText="Search" Text="{x:Bind ViewModel.SearchTerms, Mode=TwoWay}" />
+                <TextBox x:Name="tbSearchBox" Grid.Column="2" PlaceholderText="Search" Text="{x:Bind ViewModel.SearchTerms, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
             </Grid>
 
 
@@ -221,7 +221,6 @@
                             LabelPosition="Collapsed"
                             Width="Auto"
                             MinWidth="40"
-                            Visibility="Collapsed"
                         >
                                 <AppBarButton.Icon>
                                     <FontIcon FontSize="16" Glyph="&#xe946;" />
@@ -294,7 +293,7 @@
                                         <StackPanel Orientation="Horizontal">
                                             <FontIcon Visibility="{x:Bind IsFile, Mode=OneWay, Converter={StaticResource VisibilityInvertConverter}}" VerticalAlignment="Center" FontSize="16" FontFamily="Segoe MDL2 Assets" Glyph="&#xE8B7;" Margin="0,0,10,0" />
                                             <Image Visibility="{x:Bind IsFile, Mode=OneWay}" Source="{x:Bind Icon16, Mode=OneWay}" Height="16" Width="16" Margin="0,0,10,0" />
-                                            <TextBlock Grid.Column="0" VerticalAlignment="Center" Text="{x:Bind Name, Mode=OneWay}" />
+                                            <TextBlock Grid.Column="0" VerticalAlignment="Center" Text="{x:Bind DisplayName, Mode=OneWay}" />
                                         </StackPanel>
                                         <TextBlock Visibility="{x:Bind IsFile, Mode=OneWay}" Grid.Column="1" VerticalAlignment="Center" Text="{x:Bind FileDateModified, Mode=OneWay}"/>
                                         <TextBlock Visibility="{x:Bind IsFile, Mode=OneWay}" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Right" Text="{x:Bind FileSize, Mode=OneWay, Converter={StaticResource FileSizeConverter}}"/>

--- a/src/BSH.Test/QueryManagerTests.cs
+++ b/src/BSH.Test/QueryManagerTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Brightbits.BSH.Engine;
 using Brightbits.BSH.Engine.Contracts;
@@ -224,6 +225,41 @@ public class QueryManagerTests
         result = await queryManager.GetFilesByVersionAsync("2", "\\source_1\\");
         Assert.That(result.Count, Is.EqualTo(1));
         Assert.That(result[0].FileName, Is.EqualTo("file1.txt"));
+    }
+
+    [Test]
+    public async Task SearchFilesByVersionAsyncReturnsMatchingFilesWithPathContext()
+    {
+        var result = await queryManager.SearchFilesByVersionAsync("1", "file2");
+
+        Assert.That(result.Count, Is.EqualTo(1));
+        Assert.That(result[0].FileName, Is.EqualTo("file2.txt"));
+        Assert.That(result[0].FilePath, Is.EqualTo("\\source_1\\subfolder\\"));
+    }
+
+    [Test]
+    public async Task SearchFilesByVersionAsyncMatchesFilePath()
+    {
+        var result = await queryManager.SearchFilesByVersionAsync("1", "source_2");
+
+        Assert.That(result.Count, Is.EqualTo(1));
+        Assert.That(result[0].FileName, Is.EqualTo("file3.txt"));
+        Assert.That(result[0].FilePath, Is.EqualTo("\\source_2\\subfolder\\"));
+    }
+
+    [Test]
+    public async Task GetFileDetailsAsyncComposesMetadataAndAvailableVersions()
+    {
+        var result = await queryManager.GetFileDetailsAsync("2", "file1.txt", "\\source_1\\");
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Name, Is.EqualTo("file1.txt"));
+        Assert.That(result.RestorePath, Is.EqualTo("Y:\\MyFiles\\source_1\\file1.txt"));
+        Assert.That(result.Type, Is.EqualTo("Regular copy"));
+        Assert.That(result.Size, Is.EqualTo(100d));
+        Assert.That(result.Created, Is.EqualTo(new DateTime(2021, 1, 1)));
+        Assert.That(result.Modified, Is.EqualTo(new DateTime(2021, 1, 1)));
+        Assert.That(result.AvailableVersions.Select(x => x.Id), Is.EqualTo(new[] { "2", "1" }));
     }
 
     [Test]


### PR DESCRIPTION
Task completed:
- Added selected-version backup browser search and file details for WinUI.
- Implements the browser parity slice from PRD #521 for issue #523.

Key decisions:
- Kept search and file-details data composition in QueryManager so the behavior is testable without WinUI automation.
- Reused FileOrFolderItem for search results while adding DisplayName so visible path context does not break restore/details paths.
- Used a simple WinUI ContentDialog for file details to close the no-op/throwing command without adding a larger dialog framework.

Files changed:
- BSH.Engine/Contracts/IQueryManager.cs
- BSH.Engine/Models/FileDetails.cs
- BSH.Engine/QueryManager.cs
- BSH.MainApp/Contracts/Services/IPresentationService.cs
- BSH.MainApp/Models/FileOrFolderItem.cs
- BSH.MainApp/Services/PresentationService.cs
- BSH.MainApp/ViewModels/BrowserViewModel.cs
- BSH.MainApp/Views/BrowserPage.xaml
- BSH.Test/QueryManagerTests.cs

Blockers for next iteration:
- npm run typecheck and npm run test cannot run in this C# solution because there is no package.json in src.
- Direct executable launch starts the tray-first app process but does not create a top-level window until UI activation.