### PR TITLE
WinUI: Close settings parity gaps for targets and filters

### DIFF
--- a/src/BSH.MainApp/App.xaml.cs
+++ b/src/BSH.MainApp/App.xaml.cs
@@ -93,6 +93,7 @@ public partial class App : Application
             services.AddSingleton<IBrowserFavoritesService, BrowserFavoritesService>();
             services.AddSingleton<IBrowserContentService, BrowserContentService>();
             services.AddSingleton<IBrowserDialogService, BrowserDialogService>();
+            services.AddSingleton<IBackupTargetService, BackupTargetService>();
             services.AddTransient<IWaitForMediaService, WaitForMediaService>();
             services.AddSingleton<Func<IWaitForMediaService>>(x => () => x.GetRequiredService<IWaitForMediaService>());
             services.AddSingleton<IScheduledBackupService, ScheduledBackupService>();

--- a/src/BSH.MainApp/Contracts/Services/IBackupTargetService.cs
+++ b/src/BSH.MainApp/Contracts/Services/IBackupTargetService.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace BSH.MainApp.Contracts.Services;
+
+public interface IBackupTargetService
+{
+    Task<BackupTargetMoveResult> MoveExistingBackupDataAsync(string currentFolderPath, string newFolderPath);
+}
+
+public sealed record BackupTargetMoveResult(bool Success, string? ErrorMessage = null)
+{
+    public static BackupTargetMoveResult Succeeded { get; } = new(true);
+
+    public static BackupTargetMoveResult Failed(string errorMessage) => new(false, errorMessage);
+}

--- a/src/BSH.MainApp/Converters/EnumComparisionConverter.cs
+++ b/src/BSH.MainApp/Converters/EnumComparisionConverter.cs
@@ -10,7 +10,7 @@ public class EnumComparisonConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, string language)
     {
-        return ((int)value).Equals(parameter);
+        return Equals(value, parameter);
     }
 
     public object ConvertBack(object value, Type targetType, object parameter, string language)

--- a/src/BSH.MainApp/Converters/EnumComparisionConverter.cs
+++ b/src/BSH.MainApp/Converters/EnumComparisionConverter.cs
@@ -10,7 +10,7 @@ public class EnumComparisonConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, string language)
     {
-        return Equals(value, parameter);
+        return ((int)value).Equals(parameter);
     }
 
     public object ConvertBack(object value, Type targetType, object parameter, string language)

--- a/src/BSH.MainApp/Helpers/CompressionExclusionFormatter.cs
+++ b/src/BSH.MainApp/Helpers/CompressionExclusionFormatter.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace BSH.MainApp.Helpers;
+
+public static class CompressionExclusionFormatter
+{
+    public static IEnumerable<string> Parse(string? value)
+    {
+        return (value ?? string.Empty)
+            .Split('|', StringSplitOptions.RemoveEmptyEntries)
+            .Select(NormalizeExtension)
+            .Where(x => !string.IsNullOrEmpty(x))
+            .Distinct(StringComparer.OrdinalIgnoreCase);
+    }
+
+    public static string Format(IEnumerable<string> extensions)
+    {
+        return string.Join("|", extensions.Select(NormalizeExtension).Where(x => !string.IsNullOrEmpty(x)));
+    }
+
+    public static string NormalizeExtension(string? extension)
+    {
+        var normalized = (extension ?? string.Empty).Trim().TrimStart('*').TrimStart('.').ToLowerInvariant();
+        return string.IsNullOrEmpty(normalized) ? string.Empty : "." + normalized;
+    }
+}

--- a/src/BSH.MainApp/Helpers/PathRules.cs
+++ b/src/BSH.MainApp/Helpers/PathRules.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace BSH.MainApp.Helpers;
+
+public static class PathRules
+{
+    public static bool IsDriveRoot(string folderPath)
+    {
+        var fullPath = Path.GetFullPath(folderPath).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var root = Path.GetPathRoot(fullPath)?.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return !string.IsNullOrEmpty(root) && string.Equals(fullPath, root, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static bool TryNormalizeFolderPath(string folderPath, out string normalizedPath)
+    {
+        normalizedPath = string.Empty;
+        if (string.IsNullOrWhiteSpace(folderPath))
+        {
+            return false;
+        }
+
+        try
+        {
+            normalizedPath = Path.GetFullPath(folderPath.Trim()).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/BSH.MainApp/Services/BackupTargetService.cs
+++ b/src/BSH.MainApp/Services/BackupTargetService.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using BSH.MainApp.Contracts.Services;
+using BSH.MainApp.Helpers;
+
+namespace BSH.MainApp.Services;
+
+public sealed class BackupTargetService : IBackupTargetService
+{
+    public Task<BackupTargetMoveResult> MoveExistingBackupDataAsync(string currentFolderPath, string newFolderPath)
+    {
+        return Task.Run(() => MoveExistingBackupData(currentFolderPath, newFolderPath));
+    }
+
+    private static BackupTargetMoveResult MoveExistingBackupData(string currentFolderPath, string newFolderPath)
+    {
+        try
+        {
+            if (PathRules.IsDriveRoot(newFolderPath))
+            {
+                return BackupTargetMoveResult.Failed("Selecting a drive root as backup target is not supported. Choose a specific folder instead.");
+            }
+
+            if (string.IsNullOrWhiteSpace(currentFolderPath) || string.Equals(currentFolderPath, newFolderPath, StringComparison.OrdinalIgnoreCase))
+            {
+                return BackupTargetMoveResult.Succeeded;
+            }
+
+            if (Directory.Exists(newFolderPath) && Directory.EnumerateFileSystemEntries(newFolderPath).Any())
+            {
+                return BackupTargetMoveResult.Failed("The selected target folder already contains files.");
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(newFolderPath) ?? newFolderPath);
+            if (Directory.Exists(newFolderPath))
+            {
+                Directory.Delete(newFolderPath, true);
+            }
+
+            Directory.Move(currentFolderPath, newFolderPath);
+            return BackupTargetMoveResult.Succeeded;
+        }
+        catch (Exception ex)
+        {
+            return BackupTargetMoveResult.Failed(ex.Message);
+        }
+    }
+}

--- a/src/BSH.MainApp/ViewModels/SettingsViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/SettingsViewModel.cs
@@ -42,9 +42,19 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
 
     public ObservableCollection<string> Sources { get; } = new();
 
+    private string? sourceValidationErrorMessage;
+    public string? SourceValidationErrorMessage
+    {
+        get => sourceValidationErrorMessage;
+        set => SetProperty(ref sourceValidationErrorMessage, value);
+    }
+
     private void InitSourcesSettings()
     {
-        Array.ForEach(this.configurationManager.SourceFolder.Split("|"), this.Sources.Add);
+        this.Sources.Clear();
+        Array.ForEach(
+            this.configurationManager.SourceFolder.Split("|", StringSplitOptions.RemoveEmptyEntries),
+            this.Sources.Add);
     }
 
     [RelayCommand]
@@ -62,14 +72,47 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
         var folder = await folderPicker.PickSingleFolderAsync();
         if (folder != null)
         {
-            if (this.Sources.Contains(folder.Path))
-            {
-                return;
-            }
-
-            this.Sources.Add(folder.Path);
-            this.configurationManager.SourceFolder = string.Join("|", this.Sources);
+            TryAddSourceFolderPath(folder.Path);
         }
+    }
+
+    public bool TryAddSourceFolderPath(string folderPath)
+    {
+        SourceValidationErrorMessage = null;
+
+        if (string.IsNullOrWhiteSpace(folderPath))
+        {
+            return false;
+        }
+
+        string fullPath;
+        try
+        {
+            fullPath = Path.GetFullPath(folderPath.Trim()).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        }
+        catch
+        {
+            SourceValidationErrorMessage = "Selected source folder path is invalid.";
+            return false;
+        }
+
+        if (IsDriveRoot(fullPath))
+        {
+            SourceValidationErrorMessage = "Selecting a drive root is risky. Choose a specific folder instead.";
+            return false;
+        }
+
+        var folderName = Path.GetFileName(fullPath);
+        if (this.Sources.Any(source =>
+            string.Equals(Path.GetFileName(source.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)), folderName, StringComparison.OrdinalIgnoreCase)))
+        {
+            SourceValidationErrorMessage = "A source folder with the same name is already configured.";
+            return false;
+        }
+
+        this.Sources.Add(fullPath);
+        this.configurationManager.SourceFolder = string.Join("|", this.Sources);
+        return true;
     }
 
     [RelayCommand(CanExecute = nameof(CanDeleteSourceFolder))]
@@ -140,6 +183,15 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
     [ObservableProperty]
     private bool ftpRemoteEnforceUnencrypted;
 
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(RemoveCompressionExclusionCommand))]
+    private string? selectedCompressionExclusion;
+
+    [ObservableProperty]
+    private string? compressionExclusionInputText;
+
+    public ObservableCollection<string> CompressionExclusions { get; } = new();
+
     private void InitTargetSettings()
     {
         // selected media type
@@ -158,6 +210,8 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
 
         // local device
         this.LocalDevicePath = this.configurationManager.BackupFolder;
+        this.LocalUNCUser = this.configurationManager.UNCUsername;
+        this.LocalUNCPassword = DecryptConfigurationPassword(this.configurationManager.UNCPassword);
 
         // ftp remote
         this.FtpRemoteHost = this.configurationManager.FtpHost;
@@ -231,29 +285,11 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
             [
                 new UICommand("MsgBox_LocalPath_Change_Use".GetLocalized(), (x) =>
                 {
-                    this.LocalDevicePath = folder.Path;
-                    this.configurationManager.BackupFolder = folder.Path;
-
-                    // update media serial (if local path)
-                    if (folder.Path.StartsWith(@"\\"))
-                    {
-                        return;
-                    }
-
-                    this.LocalUNCUser = "";
-                    this.LocalUNCPassword = "";
-
-                    this.configurationManager.MediaVolumeSerial = Win32Stuff.GetVolumeSerial(folder.Path.Substring(0, 3));
-                    if (this.configurationManager.MediaVolumeSerial == null || this.configurationManager.MediaVolumeSerial == "0")
-                    {
-                        this.configurationManager.MediaVolumeSerial = "";
-                    }
+                    UseLocalPath(folder.Path);
                 }),
                 new UICommand("MsgBox_LocalPath_Change_Move".GetLocalized(), (x) =>
                 {
-                    this.LocalDevicePath = folder.Path;
-
-                    // TODO: add move logic
+                    _ = MoveExistingLocalBackupDataAsync(folder.Path);
                 }),
                 new UICommand("MsgBox_Cancel".GetLocalized())
             ]
@@ -280,6 +316,7 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
             // add remove all backups logic
             var versions = this.queryManager.GetVersions().Select(x => x.Id).ToList();
             await this.jobService.DeleteBackupsAsync(versions);
+            this.configurationManager.MediumType = newValue;
 
             // update UI
             if (newValue == MediaType.LocalDevice)
@@ -313,7 +350,117 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
         if (oldValue == null) return;
         if (oldValue == newValue) return;
 
-        this.configurationManager.UNCPassword = newValue;
+        this.configurationManager.UNCPassword = string.IsNullOrEmpty(newValue)
+            ? string.Empty
+            : Crypto.EncryptString(newValue, System.Security.Cryptography.DataProtectionScope.LocalMachine);
+    }
+
+    partial void OnFtpRemoteHostChanged(string? oldValue, string newValue)
+    {
+        if (oldValue == null || oldValue == newValue) return;
+        this.configurationManager.FtpHost = newValue;
+        CheckFtpRemoteCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnFtpRemotePortChanged(int oldValue, int newValue)
+    {
+        if (oldValue == newValue) return;
+        this.configurationManager.FtpPort = newValue.ToString();
+    }
+
+    partial void OnFtpRemoteUserChanged(string? oldValue, string newValue)
+    {
+        if (oldValue == null || oldValue == newValue) return;
+        this.configurationManager.FtpUser = newValue;
+        CheckFtpRemoteCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnFtpRemotePasswordChanged(string? oldValue, string newValue)
+    {
+        if (oldValue == null || oldValue == newValue) return;
+        this.configurationManager.FtpPass = newValue;
+        CheckFtpRemoteCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnFtpRemotePathChanged(string? oldValue, string newValue)
+    {
+        if (oldValue == null || oldValue == newValue) return;
+        this.configurationManager.FtpFolder = newValue;
+    }
+
+    partial void OnFtpRemoteEncodingChanged(string? oldValue, string newValue)
+    {
+        if (oldValue == null || oldValue == newValue) return;
+        this.configurationManager.FtpCoding = newValue;
+    }
+
+    partial void OnFtpRemoteEnforceUnencryptedChanged(bool oldValue, bool newValue)
+    {
+        if (oldValue == newValue) return;
+        this.configurationManager.FtpEncryptionMode = newValue ? "3" : "0";
+    }
+
+    public void UseLocalPath(string folderPath)
+    {
+        this.LocalDevicePath = folderPath;
+        this.configurationManager.BackupFolder = folderPath;
+
+        if (folderPath.StartsWith(@"\\", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        this.LocalUNCUser = "";
+        this.LocalUNCPassword = "";
+
+        if (folderPath.Length >= 3)
+        {
+            this.configurationManager.MediaVolumeSerial = Win32Stuff.GetVolumeSerial(folderPath[..3]);
+            if (this.configurationManager.MediaVolumeSerial == null || this.configurationManager.MediaVolumeSerial == "0")
+            {
+                this.configurationManager.MediaVolumeSerial = "";
+            }
+        }
+    }
+
+    public async Task MoveExistingLocalBackupDataAsync(string newFolderPath)
+    {
+        var oldFolderPath = this.configurationManager.BackupFolder;
+
+        try
+        {
+            if (IsDriveRoot(newFolderPath))
+            {
+                throw new IOException("Selecting a drive root as backup target is not supported. Choose a specific folder instead.");
+            }
+
+            if (string.IsNullOrWhiteSpace(oldFolderPath) || string.Equals(oldFolderPath, newFolderPath, StringComparison.OrdinalIgnoreCase))
+            {
+                UseLocalPath(newFolderPath);
+                return;
+            }
+
+            if (Directory.Exists(newFolderPath) && Directory.EnumerateFileSystemEntries(newFolderPath).Any())
+            {
+                throw new IOException("The selected target folder already contains files.");
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(newFolderPath) ?? newFolderPath);
+            if (Directory.Exists(newFolderPath))
+            {
+                Directory.Delete(newFolderPath, true);
+            }
+
+            Directory.Move(oldFolderPath, newFolderPath);
+            UseLocalPath(newFolderPath);
+        }
+        catch (Exception ex)
+        {
+            await this.presentationController.ShowMessageBoxAsync(
+                "Could not move backup data",
+                ex.Message,
+                [new UICommand("OK")]);
+        }
     }
 
     #endregion
@@ -343,6 +490,55 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
         }
 
         this.WaitForDevice = this.configurationManager.ShowWaitOnMediaAutoBackups == "1";
+
+        this.CompressionExclusions.Clear();
+        foreach (var entry in (this.configurationManager.ExcludeCompression ?? string.Empty)
+            .Split('|', StringSplitOptions.RemoveEmptyEntries)
+            .Select(x => NormalizeExtension(x))
+            .Where(x => !string.IsNullOrEmpty(x))
+            .Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            this.CompressionExclusions.Add(entry);
+        }
+    }
+
+    [RelayCommand]
+    public void AddCompressionExclusion(string? extension)
+    {
+        var normalized = NormalizeExtension(extension);
+        if (string.IsNullOrEmpty(normalized) || this.CompressionExclusions.Contains(normalized, StringComparer.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        this.CompressionExclusions.Add(normalized);
+        CompressionExclusionInputText = null;
+        SaveCompressionExclusions();
+    }
+
+    [RelayCommand(CanExecute = nameof(CanRemoveCompressionExclusion))]
+    private void RemoveCompressionExclusion()
+    {
+        if (string.IsNullOrEmpty(SelectedCompressionExclusion))
+        {
+            return;
+        }
+
+        this.CompressionExclusions.Remove(SelectedCompressionExclusion);
+        SelectedCompressionExclusion = null;
+        SaveCompressionExclusions();
+    }
+
+    private bool CanRemoveCompressionExclusion() => !string.IsNullOrEmpty(SelectedCompressionExclusion);
+
+    private void SaveCompressionExclusions()
+    {
+        this.configurationManager.ExcludeCompression = string.Join("|", this.CompressionExclusions.Select(x => NormalizeExtension(x)).Where(x => !string.IsNullOrEmpty(x)));
+    }
+
+    private static string NormalizeExtension(string? extension)
+    {
+        return (extension ?? string.Empty).Trim().TrimStart('*').TrimStart('.').ToLowerInvariant();
     }
 
     partial void OnWaitForDeviceChanged(bool oldValue, bool newValue)
@@ -546,6 +742,30 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
         this.presentationController = presentationService;
         this.jobService = jobService;
         this.queryManager = queryManager;
+    }
+
+    private static string DecryptConfigurationPassword(string password)
+    {
+        if (string.IsNullOrEmpty(password))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            return Crypto.DecryptString(password, System.Security.Cryptography.DataProtectionScope.LocalMachine);
+        }
+        catch
+        {
+            return string.Empty;
+        }
+    }
+
+    private static bool IsDriveRoot(string folderPath)
+    {
+        var fullPath = Path.GetFullPath(folderPath).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var root = Path.GetPathRoot(fullPath)?.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return !string.IsNullOrEmpty(root) && string.Equals(fullPath, root, StringComparison.OrdinalIgnoreCase);
     }
 
     public void OnNavigatedFrom()

--- a/src/BSH.MainApp/ViewModels/SettingsViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/SettingsViewModel.cs
@@ -33,6 +33,7 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
     private readonly IPresentationService presentationController;
     private readonly IJobService jobService;
     private readonly IQueryManager queryManager;
+    private readonly IBackupTargetService backupTargetService;
 
     #region Sources Settings
 
@@ -85,18 +86,13 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
             return false;
         }
 
-        string fullPath;
-        try
-        {
-            fullPath = Path.GetFullPath(folderPath.Trim()).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        }
-        catch
+        if (!PathRules.TryNormalizeFolderPath(folderPath, out var fullPath))
         {
             SourceValidationErrorMessage = "Selected source folder path is invalid.";
             return false;
         }
 
-        if (IsDriveRoot(fullPath))
+        if (PathRules.IsDriveRoot(fullPath))
         {
             SourceValidationErrorMessage = "Selecting a drive root is risky. Choose a specific folder instead.";
             return false;
@@ -182,6 +178,15 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
 
     [ObservableProperty]
     private bool ftpRemoteEnforceUnencrypted;
+
+    [ObservableProperty]
+    private bool isMovingBackupTarget;
+
+    [ObservableProperty]
+    private bool isBackupTargetChangeEnabled = true;
+
+    [ObservableProperty]
+    private Visibility backupTargetMoveProgressVisibility = Visibility.Collapsed;
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(RemoveCompressionExclusionCommand))]
@@ -287,9 +292,9 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
                 {
                     UseLocalPath(folder.Path);
                 }),
-                new UICommand("MsgBox_LocalPath_Change_Move".GetLocalized(), (x) =>
+                new UICommand("MsgBox_LocalPath_Change_Move".GetLocalized(), async (x) =>
                 {
-                    _ = MoveExistingLocalBackupDataAsync(folder.Path);
+                    await MoveExistingLocalBackupDataAsync(folder.Path);
                 }),
                 new UICommand("MsgBox_Cancel".GetLocalized())
             ]
@@ -424,41 +429,31 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
 
     public async Task MoveExistingLocalBackupDataAsync(string newFolderPath)
     {
-        var oldFolderPath = this.configurationManager.BackupFolder;
-
         try
         {
-            if (IsDriveRoot(newFolderPath))
-            {
-                throw new IOException("Selecting a drive root as backup target is not supported. Choose a specific folder instead.");
-            }
+            IsMovingBackupTarget = true;
+            IsBackupTargetChangeEnabled = false;
+            BackupTargetMoveProgressVisibility = Visibility.Visible;
 
-            if (string.IsNullOrWhiteSpace(oldFolderPath) || string.Equals(oldFolderPath, newFolderPath, StringComparison.OrdinalIgnoreCase))
+            var oldFolderPath = this.configurationManager.BackupFolder;
+            var result = await this.backupTargetService.MoveExistingBackupDataAsync(oldFolderPath, newFolderPath);
+
+            if (result.Success)
             {
                 UseLocalPath(newFolderPath);
                 return;
             }
 
-            if (Directory.Exists(newFolderPath) && Directory.EnumerateFileSystemEntries(newFolderPath).Any())
-            {
-                throw new IOException("The selected target folder already contains files.");
-            }
-
-            Directory.CreateDirectory(Path.GetDirectoryName(newFolderPath) ?? newFolderPath);
-            if (Directory.Exists(newFolderPath))
-            {
-                Directory.Delete(newFolderPath, true);
-            }
-
-            Directory.Move(oldFolderPath, newFolderPath);
-            UseLocalPath(newFolderPath);
-        }
-        catch (Exception ex)
-        {
             await this.presentationController.ShowMessageBoxAsync(
                 "Could not move backup data",
-                ex.Message,
+                result.ErrorMessage ?? "The backup data could not be moved.",
                 [new UICommand("OK")]);
+        }
+        finally
+        {
+            IsMovingBackupTarget = false;
+            IsBackupTargetChangeEnabled = true;
+            BackupTargetMoveProgressVisibility = Visibility.Collapsed;
         }
     }
 
@@ -491,11 +486,7 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
         this.WaitForDevice = this.configurationManager.ShowWaitOnMediaAutoBackups == "1";
 
         this.CompressionExclusions.Clear();
-        foreach (var entry in (this.configurationManager.ExcludeCompression ?? string.Empty)
-            .Split('|', StringSplitOptions.RemoveEmptyEntries)
-            .Select(x => NormalizeExtension(x))
-            .Where(x => !string.IsNullOrEmpty(x))
-            .Distinct(StringComparer.OrdinalIgnoreCase))
+        foreach (var entry in CompressionExclusionFormatter.Parse(this.configurationManager.ExcludeCompression))
         {
             this.CompressionExclusions.Add(entry);
         }
@@ -504,7 +495,7 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
     [RelayCommand]
     public void AddCompressionExclusion(string? extension)
     {
-        var normalized = NormalizeExtension(extension);
+        var normalized = CompressionExclusionFormatter.NormalizeExtension(extension);
         if (string.IsNullOrEmpty(normalized) || this.CompressionExclusions.Contains(normalized, StringComparer.OrdinalIgnoreCase))
         {
             return;
@@ -532,13 +523,7 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
 
     private void SaveCompressionExclusions()
     {
-        this.configurationManager.ExcludeCompression = string.Join("|", this.CompressionExclusions.Select(x => NormalizeExtension(x)).Where(x => !string.IsNullOrEmpty(x)));
-    }
-
-    private static string NormalizeExtension(string? extension)
-    {
-        var normalized = (extension ?? string.Empty).Trim().TrimStart('*').TrimStart('.').ToLowerInvariant();
-        return string.IsNullOrEmpty(normalized) ? string.Empty : "." + normalized;
+        this.configurationManager.ExcludeCompression = CompressionExclusionFormatter.Format(this.CompressionExclusions);
     }
 
     partial void OnWaitForDeviceChanged(bool oldValue, bool newValue)
@@ -742,12 +727,18 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
 
     #endregion
 
-    public SettingsViewModel(IConfigurationManager configurationManager, IPresentationService presentationService, IJobService jobService, IQueryManager queryManager)
+    public SettingsViewModel(
+        IConfigurationManager configurationManager,
+        IPresentationService presentationService,
+        IJobService jobService,
+        IQueryManager queryManager,
+        IBackupTargetService backupTargetService)
     {
         this.configurationManager = configurationManager;
         this.presentationController = presentationService;
         this.jobService = jobService;
         this.queryManager = queryManager;
+        this.backupTargetService = backupTargetService;
     }
 
     private static string DecryptConfigurationPassword(string password)
@@ -765,13 +756,6 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
         {
             return string.Empty;
         }
-    }
-
-    private static bool IsDriveRoot(string folderPath)
-    {
-        var fullPath = Path.GetFullPath(folderPath).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        var root = Path.GetPathRoot(fullPath)?.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        return !string.IsNullOrEmpty(root) && string.Equals(fullPath, root, StringComparison.OrdinalIgnoreCase);
     }
 
     public void OnNavigatedFrom()

--- a/src/BSH.MainApp/ViewModels/SettingsViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/SettingsViewModel.cs
@@ -296,10 +296,13 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
         );
     }
 
-    async partial void OnSelectedMediaTypeChanging(MediaType oldValue, MediaType newValue)
+    public async Task ChangeSelectedMediaTypeAsync(MediaType newValue)
     {
-        if (oldValue == MediaType.Unset) return;
-        if (oldValue == newValue) return;
+        var oldValue = SelectedMediaType;
+        if (oldValue == MediaType.Unset || oldValue == newValue)
+        {
+            return;
+        }
 
         var result = await this.presentationController.ShowMessageBoxAsync(
             "MsgBox_MediaType_Change_Title".GetLocalized(),
@@ -310,31 +313,27 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
             ]
         );
 
-        // run the task
-        if (result == ContentDialogResult.Primary)
+        if (result != ContentDialogResult.Primary)
         {
-            // add remove all backups logic
-            var versions = this.queryManager.GetVersions().Select(x => x.Id).ToList();
-            await this.jobService.DeleteBackupsAsync(versions);
-            this.configurationManager.MediumType = newValue;
+            return;
+        }
 
-            // update UI
-            if (newValue == MediaType.LocalDevice)
-            {
-                this.FtpRemoteVisibility = Visibility.Collapsed;
-                this.LocalDeviceVisibility = Visibility.Visible;
-            }
-            else
-            {
-                this.FtpRemoteVisibility = Visibility.Visible;
-                this.LocalDeviceVisibility = Visibility.Collapsed;
-            }
+        var versions = this.queryManager.GetVersions().Select(x => x.Id).ToList();
+        await this.jobService.DeleteBackupsAsync(versions);
+
+        SelectedMediaType = newValue;
+        this.configurationManager.MediumType = newValue;
+
+        if (newValue == MediaType.LocalDevice)
+        {
+            this.FtpRemoteVisibility = Visibility.Collapsed;
+            this.LocalDeviceVisibility = Visibility.Visible;
         }
         else
         {
-            SelectedMediaType = oldValue;
+            this.FtpRemoteVisibility = Visibility.Visible;
+            this.LocalDeviceVisibility = Visibility.Collapsed;
         }
-
     }
 
     partial void OnLocalUNCUserChanged(string? oldValue, string newValue)
@@ -538,7 +537,8 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
 
     private static string NormalizeExtension(string? extension)
     {
-        return (extension ?? string.Empty).Trim().TrimStart('*').TrimStart('.').ToLowerInvariant();
+        var normalized = (extension ?? string.Empty).Trim().TrimStart('*').TrimStart('.').ToLowerInvariant();
+        return string.IsNullOrEmpty(normalized) ? string.Empty : "." + normalized;
     }
 
     partial void OnWaitForDeviceChanged(bool oldValue, bool newValue)
@@ -548,13 +548,18 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
         this.configurationManager.ShowWaitOnMediaAutoBackups = newValue ? "1" : "0";
     }
 
-    async partial void OnModeTypeChanging(ModeType oldValue, ModeType newValue)
+    [RelayCommand]
+    public async Task ChangeModeTypeAsync(ModeType newValue)
     {
-        if (oldValue == ModeType.Unset) return;
-        if (oldValue == newValue) return;
+        var oldValue = ModeType;
+        if (oldValue == ModeType.Unset || oldValue == newValue)
+        {
+            return;
+        }
 
         if (newValue == ModeType.Compression)
         {
+            ModeType = newValue;
             this.configurationManager.Compression = 1;
             this.configurationManager.Encrypt = 0;
         }
@@ -564,15 +569,16 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
             var (password, _) = await presentationController.RequestPasswordAsync();
             if (password == null)
             {
-                ModeType = oldValue;
                 return;
             }
 
+            ModeType = newValue;
             this.configurationManager.EncryptPassMD5 = Hash.GetMD5Hash(password);
             this.configurationManager.Encrypt = 1;
         }
         else
         {
+            ModeType = newValue;
             this.configurationManager.Compression = 0;
             this.configurationManager.Encrypt = 0;
         }

--- a/src/BSH.MainApp/ViewModels/Windows/FilterViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/Windows/FilterViewModel.cs
@@ -32,6 +32,20 @@ public partial class FilterViewModel : ObservableObject
 
     public ObservableCollection<string> RegexPatterns { get; } = [];
 
+    private bool excludeFilesBigger;
+    public bool ExcludeFilesBigger
+    {
+        get => excludeFilesBigger;
+        set => SetProperty(ref excludeFilesBigger, value);
+    }
+
+    private decimal excludeFileBigger;
+    public decimal ExcludeFileBigger
+    {
+        get => excludeFileBigger;
+        set => SetProperty(ref excludeFileBigger, value);
+    }
+
     private string? fileTypeInputText;
     public string? FileTypeInputText
     {
@@ -172,6 +186,9 @@ public partial class FilterViewModel : ObservableObject
         {
             RegexPatterns.Add(entry);
         }
+
+        ExcludeFilesBigger = decimal.TryParse(configurationManager.ExcludeFileBigger, out var maxFileSize);
+        ExcludeFileBigger = ExcludeFilesBigger ? maxFileSize : 0;
     }
 
     public void SaveToConfiguration()
@@ -180,6 +197,7 @@ public partial class FilterViewModel : ObservableObject
         configurationManager.ExcludeFile = string.Join("|", ExcludeFiles.Select(x => x.Trim()).Where(x => !string.IsNullOrEmpty(x)));
         configurationManager.ExcludeFileTypes = string.Join("|", ExcludeFileTypes.Select(x => x.Trim().TrimStart('*').TrimStart('.')).Where(x => !string.IsNullOrEmpty(x)));
         configurationManager.ExcludeMask = string.Join("|", RegexPatterns.Select(x => x.Trim()).Where(x => !string.IsNullOrEmpty(x)));
+        configurationManager.ExcludeFileBigger = ExcludeFilesBigger && ExcludeFileBigger > 0 ? ExcludeFileBigger.ToString() : string.Empty;
     }
 
     private string? selectedFolder;
@@ -400,6 +418,8 @@ public partial class FilterViewModel : ObservableObject
 
     private void AddRegex(string? regex)
     {
+        ValidationErrorMessage = null;
+
         if (string.IsNullOrWhiteSpace(regex))
         {
             return;
@@ -419,7 +439,8 @@ public partial class FilterViewModel : ObservableObject
             }
             catch (ArgumentException)
             {
-                continue;
+                ValidationErrorMessage = "Invalid regular expression. Fix the pattern before saving it.";
+                return;
             }
 
             RegexPatterns.Add(line);

--- a/src/BSH.MainApp/Views/FilterPages/ExcludeMaxFileSizePage.xaml
+++ b/src/BSH.MainApp/Views/FilterPages/ExcludeMaxFileSizePage.xaml
@@ -1,0 +1,22 @@
+<Page
+    x:Class="BSH.MainApp.Views.FilterPages.ExcludeMaxFileSizePage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <Grid Padding="8" RowSpacing="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <CheckBox Grid.Row="0"
+                  Content="Exclude files larger than this size"
+                  IsChecked="{Binding ExcludeFilesBigger, Mode=TwoWay}" />
+
+        <NumberBox Grid.Row="1"
+                   Header="Maximum file size"
+                   Minimum="0"
+                   SpinButtonPlacementMode="Inline"
+                   Value="{Binding ExcludeFileBigger, Mode=TwoWay}" />
+    </Grid>
+</Page>

--- a/src/BSH.MainApp/Views/FilterPages/ExcludeMaxFileSizePage.xaml.cs
+++ b/src/BSH.MainApp/Views/FilterPages/ExcludeMaxFileSizePage.xaml.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Microsoft.UI.Xaml.Controls;
+
+namespace BSH.MainApp.Views.FilterPages;
+
+public sealed partial class ExcludeMaxFileSizePage : Page
+{
+    public ExcludeMaxFileSizePage()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/BSH.MainApp/Views/SettingsPages/OptionsSettingsPage.xaml
+++ b/src/BSH.MainApp/Views/SettingsPages/OptionsSettingsPage.xaml
@@ -63,6 +63,31 @@
                                     </TextBlock>
                                 </StackPanel>
                             </toolkit:SettingsCard.Header>
+                            <StackPanel Spacing="8">
+                                <ListView Height="120"
+                                          ItemsSource="{Binding CompressionExclusions}"
+                                          SelectedItem="{Binding SelectedCompressionExclusion, Mode=TwoWay}">
+                                    <ListView.Header>
+                                        <TextBlock FontWeight="SemiBold">Excluded extensions</TextBlock>
+                                    </ListView.Header>
+                                </ListView>
+                                <Grid ColumnSpacing="8">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <TextBox PlaceholderText="Extension"
+                                             Text="{Binding CompressionExclusionInputText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                    <Button Grid.Column="1"
+                                            Content="Add"
+                                            Command="{Binding AddCompressionExclusionCommand}"
+                                            CommandParameter="{Binding CompressionExclusionInputText}" />
+                                    <Button Grid.Column="2"
+                                            Content="Remove"
+                                            Command="{Binding RemoveCompressionExclusionCommand}" />
+                                </Grid>
+                            </StackPanel>
                         </toolkit:SettingsCard>
 
                         <toolkit:SettingsCard>

--- a/src/BSH.MainApp/Views/SettingsPages/OptionsSettingsPage.xaml
+++ b/src/BSH.MainApp/Views/SettingsPages/OptionsSettingsPage.xaml
@@ -45,7 +45,9 @@
                         <toolkit:SettingsCard>
                             <toolkit:SettingsCard.Header>
                                 <StackPanel Margin="-12,0,0,0" Orientation="Vertical">
-                                    <RadioButton IsChecked="{Binding ModeType, Mode=TwoWay, Converter={StaticResource EnumComparisonConverter}, ConverterParameter={StaticResource ModeType_RegularCopy}}">
+                                    <RadioButton x:Name="RegularCopyRadioButton"
+                                                 IsChecked="{Binding ModeType, Mode=OneWay, Converter={StaticResource EnumComparisonConverter}, ConverterParameter={StaticResource ModeType_RegularCopy}}"
+                                                 Checked="ModeTypeRadioButton_Checked">
                                         No compression or encryption
                                     </RadioButton>
                                 </StackPanel>
@@ -55,7 +57,9 @@
                         <toolkit:SettingsCard>
                             <toolkit:SettingsCard.Header>
                                 <StackPanel Margin="-12,0,0,0" Orientation="Vertical">
-                                    <RadioButton IsChecked="{Binding ModeType, Mode=TwoWay, Converter={StaticResource EnumComparisonConverter}, ConverterParameter={StaticResource ModeType_Compression}}">
+                                    <RadioButton x:Name="CompressionRadioButton"
+                                                 IsChecked="{Binding ModeType, Mode=OneWay, Converter={StaticResource EnumComparisonConverter}, ConverterParameter={StaticResource ModeType_Compression}}"
+                                                 Checked="ModeTypeRadioButton_Checked">
                                         Compress backups
                                     </RadioButton>
                                     <TextBlock Margin="29,0,0,0" TextWrapping="WrapWholeWords">
@@ -93,7 +97,9 @@
                         <toolkit:SettingsCard>
                             <toolkit:SettingsCard.Header>
                                 <StackPanel Margin="-12,0,0,0" Orientation="Vertical">
-                                    <RadioButton IsChecked="{Binding ModeType, Mode=TwoWay, Converter={StaticResource EnumComparisonConverter}, ConverterParameter={StaticResource ModeType_Encryption}}">
+                                    <RadioButton x:Name="EncryptionRadioButton"
+                                                 IsChecked="{Binding ModeType, Mode=OneWay, Converter={StaticResource EnumComparisonConverter}, ConverterParameter={StaticResource ModeType_Encryption}}"
+                                                 Checked="ModeTypeRadioButton_Checked">
                                         Encrypt backups
                                     </RadioButton>
                                     <TextBlock Margin="29,0,0,0" TextWrapping="WrapWholeWords">

--- a/src/BSH.MainApp/Views/SettingsPages/OptionsSettingsPage.xaml.cs
+++ b/src/BSH.MainApp/Views/SettingsPages/OptionsSettingsPage.xaml.cs
@@ -9,9 +9,43 @@ namespace BSH.MainApp.Views.SettingsPages;
 public sealed partial class OptionsSettingsPage : Page
 {
     public SettingsViewModel ViewModel => (SettingsViewModel)DataContext;
+    private bool isSyncingModeType;
 
     public OptionsSettingsPage()
     {
         this.InitializeComponent();
+    }
+
+    private async void ModeTypeRadioButton_Checked(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+    {
+        if (isSyncingModeType || DataContext is not SettingsViewModel viewModel)
+        {
+            return;
+        }
+
+        var requestedModeType = sender switch
+        {
+            var radioButton when ReferenceEquals(radioButton, CompressionRadioButton) => ModeType.Compression,
+            var radioButton when ReferenceEquals(radioButton, EncryptionRadioButton) => ModeType.Encryption,
+            _ => ModeType.RegularCopy
+        };
+
+        await viewModel.ChangeModeTypeAsync(requestedModeType);
+        SyncModeTypeSelection(viewModel.ModeType);
+    }
+
+    private void SyncModeTypeSelection(ModeType modeType)
+    {
+        isSyncingModeType = true;
+        try
+        {
+            RegularCopyRadioButton.IsChecked = modeType == ModeType.RegularCopy;
+            CompressionRadioButton.IsChecked = modeType == ModeType.Compression;
+            EncryptionRadioButton.IsChecked = modeType == ModeType.Encryption;
+        }
+        finally
+        {
+            isSyncingModeType = false;
+        }
     }
 }

--- a/src/BSH.MainApp/Views/SettingsPages/SourcesSettingsPage.xaml
+++ b/src/BSH.MainApp/Views/SettingsPages/SourcesSettingsPage.xaml
@@ -48,6 +48,7 @@
                             <Grid Height="250">
                                 <Grid.RowDefinitions>
                                     <RowDefinition />
+                                    <RowDefinition Height="Auto" />
                                     <RowDefinition Height="40" />
                                 </Grid.RowDefinitions>
 
@@ -62,7 +63,12 @@
                                     </ListView.HeaderTemplate>
                                 </ListView>
 
-                                <Grid Grid.Row="1">
+                                <TextBlock Grid.Row="1"
+                                           Foreground="Red"
+                                           Text="{Binding SourceValidationErrorMessage}"
+                                           TextWrapping="Wrap" />
+
+                                <Grid Grid.Row="2">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition />
                                         <ColumnDefinition />

--- a/src/BSH.MainApp/Views/SettingsPages/TargetSettingsPage.xaml
+++ b/src/BSH.MainApp/Views/SettingsPages/TargetSettingsPage.xaml
@@ -38,9 +38,11 @@
                     <!-- target type selection -->
                     <StackPanel Orientation="Horizontal" Spacing="20">
                         <TextBlock HorizontalAlignment="Right" VerticalAlignment="Center" Grid.Row="0" Grid.Column="0" Text="Backup storage:" />
-                        <ComboBox VerticalAlignment="Center" Grid.Row="0" Grid.Column="1" Width="300"
+                        <ComboBox x:Name="MediaTypeComboBox"
+                            VerticalAlignment="Center" Grid.Row="0" Grid.Column="1" Width="300"
                             ItemsSource="{Binding MediaTypes}"
-                            SelectedItem="{Binding SelectedMediaType, Mode=TwoWay}">
+                            SelectedItem="{Binding SelectedMediaType, Mode=OneWay}"
+                            SelectionChanged="MediaTypeComboBox_SelectionChanged">
                             <ComboBox.ItemTemplate>
                                 <DataTemplate x:DataType="engine:MediaType">
                                     <TextBlock Text="{x:Bind viewmodels:SettingsViewModel.GetMediaTypeDisplayName((engine:MediaType))}" />

--- a/src/BSH.MainApp/Views/SettingsPages/TargetSettingsPage.xaml
+++ b/src/BSH.MainApp/Views/SettingsPages/TargetSettingsPage.xaml
@@ -67,7 +67,15 @@
 
                                         <TextBlock Grid.Column="0" Text="Storage path:" />
                                         <TextBox Grid.Column="1" Text="{Binding LocalDevicePath}" IsReadOnly="True" />
-                                        <Button Grid.Column="2" Content="Change" Command="{x:Bind ViewModel.ChangeLocalPathCommand}" />
+                                        <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="8">
+                                            <ProgressRing Width="20"
+                                                          Height="20"
+                                                          IsActive="{Binding IsMovingBackupTarget, Mode=OneWay}"
+                                                          Visibility="{Binding BackupTargetMoveProgressVisibility, Mode=OneWay}" />
+                                            <Button Content="Change"
+                                                    Command="{x:Bind ViewModel.ChangeLocalPathCommand}"
+                                                    IsEnabled="{Binding IsBackupTargetChangeEnabled, Mode=OneWay}" />
+                                        </StackPanel>
                                     </Grid>
 
                                     <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}">Network authentication</TextBlock>

--- a/src/BSH.MainApp/Views/SettingsPages/TargetSettingsPage.xaml.cs
+++ b/src/BSH.MainApp/Views/SettingsPages/TargetSettingsPage.xaml.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using BSH.MainApp.ViewModels;
+using Brightbits.BSH.Engine;
 using Microsoft.UI.Xaml.Controls;
 
 namespace BSH.MainApp.Views.SettingsPages;
@@ -13,5 +14,18 @@ public sealed partial class TargetSettingsPage : Page
     public TargetSettingsPage()
     {
         this.InitializeComponent();
+    }
+
+    private async void MediaTypeComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (DataContext is not SettingsViewModel viewModel ||
+            MediaTypeComboBox.SelectedItem is not MediaType mediaType ||
+            mediaType == viewModel.SelectedMediaType)
+        {
+            return;
+        }
+
+        await viewModel.ChangeSelectedMediaTypeAsync(mediaType);
+        MediaTypeComboBox.SelectedItem = viewModel.SelectedMediaType;
     }
 }

--- a/src/BSH.MainApp/Windows/FilterWindow.xaml
+++ b/src/BSH.MainApp/Windows/FilterWindow.xaml
@@ -38,6 +38,7 @@
                 <SelectorBarItem x:Name="FilesItem" Text="Files" />
                 <SelectorBarItem x:Name="FoldersItem" Text="Folders" />
                 <SelectorBarItem x:Name="FileTypesItem" Text="File types" />
+                <SelectorBarItem x:Name="MaxFileSizeItem" Text="Max file size" />
                 <SelectorBarItem x:Name="RegexItem" Text="Regular expressions" />
             </SelectorBar>
 

--- a/src/BSH.MainApp/Windows/FilterWindow.xaml.cs
+++ b/src/BSH.MainApp/Windows/FilterWindow.xaml.cs
@@ -54,6 +54,10 @@ public sealed partial class FilterWindow : WindowEx
         {
             pageType = typeof(Views.FilterPages.ExcludeFileTypesPage);
         }
+        else if (ReferenceEquals(selected, MaxFileSizeItem))
+        {
+            pageType = typeof(Views.FilterPages.ExcludeMaxFileSizePage);
+        }
         else
         {
             pageType = typeof(Views.FilterPages.ExcludeRegexPage);

--- a/src/BSH.Test/WinUiSettingsParityTests.cs
+++ b/src/BSH.Test/WinUiSettingsParityTests.cs
@@ -13,6 +13,7 @@ using Brightbits.BSH.Engine.Models;
 using Brightbits.BSH.Engine.Security;
 using BSH.MainApp.Contracts.Services;
 using BSH.MainApp.Models;
+using BSH.MainApp.Services;
 using BSH.MainApp.ViewModels;
 using BSH.MainApp.ViewModels.Windows;
 using Microsoft.UI.Xaml.Controls;
@@ -54,7 +55,7 @@ public class WinUiSettingsParityTests
         {
             ExcludeCompression = ".zip|rar"
         };
-        var viewModel = new SettingsViewModel(configuration, new TestPresentationService(), new TestJobService(), new TestQueryManager());
+        var viewModel = CreateSettingsViewModel(configuration);
 
         viewModel.OnNavigatedTo(null!);
         viewModel.AddCompressionExclusion("7z");
@@ -72,7 +73,7 @@ public class WinUiSettingsParityTests
         {
             SourceFolder = @"C:\Users\alex\Documents"
         };
-        var viewModel = new SettingsViewModel(configuration, new TestPresentationService(), new TestJobService(), new TestQueryManager());
+        var viewModel = CreateSettingsViewModel(configuration);
 
         viewModel.OnNavigatedTo(null!);
 
@@ -98,7 +99,7 @@ public class WinUiSettingsParityTests
             {
                 BackupFolder = oldPath
             };
-            var viewModel = new SettingsViewModel(configuration, new TestPresentationService(), new TestJobService(), new TestQueryManager());
+            var viewModel = CreateSettingsViewModel(configuration);
 
             await viewModel.MoveExistingLocalBackupDataAsync(newPath);
 
@@ -119,7 +120,7 @@ public class WinUiSettingsParityTests
     public void TargetSettingsPersistFtpAndUncValues()
     {
         var configuration = new TestConfigurationManager();
-        var viewModel = new SettingsViewModel(configuration, new TestPresentationService(), new TestJobService(), new TestQueryManager());
+        var viewModel = CreateSettingsViewModel(configuration);
 
         viewModel.OnNavigatedTo(null!);
 
@@ -192,6 +193,16 @@ public class WinUiSettingsParityTests
         public string UNCUsername { get; set; } = "";
 
         public Task InitializeAsync() => Task.CompletedTask;
+    }
+
+    private static SettingsViewModel CreateSettingsViewModel(TestConfigurationManager configuration)
+    {
+        return new SettingsViewModel(
+            configuration,
+            new TestPresentationService(),
+            new TestJobService(),
+            new TestQueryManager(),
+            new BackupTargetService());
     }
 
     private sealed class TestPresentationService : IPresentationService

--- a/src/BSH.Test/WinUiSettingsParityTests.cs
+++ b/src/BSH.Test/WinUiSettingsParityTests.cs
@@ -1,0 +1,258 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Brightbits.BSH.Engine;
+using Brightbits.BSH.Engine.Contracts;
+using Brightbits.BSH.Engine.Jobs;
+using Brightbits.BSH.Engine.Models;
+using Brightbits.BSH.Engine.Security;
+using BSH.MainApp.Contracts.Services;
+using BSH.MainApp.Models;
+using BSH.MainApp.ViewModels;
+using BSH.MainApp.ViewModels.Windows;
+using Microsoft.UI.Xaml.Controls;
+using NUnit.Framework;
+using Windows.UI.Popups;
+
+namespace BSH.Test;
+
+public class WinUiSettingsParityTests
+{
+    [Test]
+    public void FilterSettingsPersistMaxFileSizeAndRejectInvalidRegex()
+    {
+        var configuration = new TestConfigurationManager
+        {
+            SourceFolder = @"C:\Users\alex\Documents",
+            ExcludeFileBigger = "2048"
+        };
+        var viewModel = new FilterViewModel(configuration);
+
+        Assert.That(viewModel.ExcludeFilesBigger, Is.True);
+        Assert.That(viewModel.ExcludeFileBigger, Is.EqualTo(2048));
+
+        viewModel.AddRegexCommand.Execute("[broken");
+
+        Assert.That(viewModel.RegexPatterns, Is.Empty);
+        Assert.That(viewModel.ValidationErrorMessage, Does.Contain("regular expression"));
+
+        viewModel.ExcludeFilesBigger = false;
+        viewModel.SaveToConfiguration();
+
+        Assert.That(configuration.ExcludeFileBigger, Is.Empty);
+    }
+
+    [Test]
+    public void FilterSettingsPersistCompressionExclusions()
+    {
+        var configuration = new TestConfigurationManager
+        {
+            ExcludeCompression = ".zip|rar"
+        };
+        var viewModel = new SettingsViewModel(configuration, new TestPresentationService(), new TestJobService(), new TestQueryManager());
+
+        viewModel.OnNavigatedTo(null!);
+        viewModel.AddCompressionExclusion("7z");
+        viewModel.SelectedCompressionExclusion = "zip";
+        viewModel.RemoveCompressionExclusionCommand.Execute(null);
+
+        Assert.That(viewModel.CompressionExclusions, Is.EquivalentTo(new[] { "rar", "7z" }));
+        Assert.That(configuration.ExcludeCompression, Is.EqualTo("rar|7z"));
+    }
+
+    [Test]
+    public void SourceManagementRejectsDuplicateNamesAndRiskyRoots()
+    {
+        var configuration = new TestConfigurationManager
+        {
+            SourceFolder = @"C:\Users\alex\Documents"
+        };
+        var viewModel = new SettingsViewModel(configuration, new TestPresentationService(), new TestJobService(), new TestQueryManager());
+
+        viewModel.OnNavigatedTo(null!);
+
+        Assert.That(viewModel.TryAddSourceFolderPath(@"D:\Archive\Documents"), Is.False);
+        Assert.That(viewModel.SourceValidationErrorMessage, Does.Contain("name"));
+        Assert.That(viewModel.TryAddSourceFolderPath(@"C:\"), Is.False);
+        Assert.That(viewModel.SourceValidationErrorMessage, Does.Contain("drive root"));
+        Assert.That(configuration.SourceFolder, Is.EqualTo(@"C:\Users\alex\Documents"));
+    }
+
+    [Test]
+    public async Task MovingLocalTargetMovesBackupDataAndPersistsNewPath()
+    {
+        var root = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var oldPath = Path.Combine(root, "old");
+        var newPath = Path.Combine(root, "new");
+        Directory.CreateDirectory(oldPath);
+        File.WriteAllText(Path.Combine(oldPath, "backup.db"), "data");
+
+        try
+        {
+            var configuration = new TestConfigurationManager
+            {
+                BackupFolder = oldPath
+            };
+            var viewModel = new SettingsViewModel(configuration, new TestPresentationService(), new TestJobService(), new TestQueryManager());
+
+            await viewModel.MoveExistingLocalBackupDataAsync(newPath);
+
+            Assert.That(File.Exists(Path.Combine(newPath, "backup.db")), Is.True);
+            Assert.That(Directory.Exists(oldPath), Is.False);
+            Assert.That(configuration.BackupFolder, Is.EqualTo(newPath));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, true);
+            }
+        }
+    }
+
+    [Test]
+    public void TargetSettingsPersistFtpAndUncValues()
+    {
+        var configuration = new TestConfigurationManager();
+        var viewModel = new SettingsViewModel(configuration, new TestPresentationService(), new TestJobService(), new TestQueryManager());
+
+        viewModel.OnNavigatedTo(null!);
+
+        viewModel.LocalUNCUser = "user";
+        viewModel.LocalUNCPassword = "password";
+        viewModel.FtpRemoteHost = "ftp.example.test";
+        viewModel.FtpRemotePort = 2121;
+        viewModel.FtpRemoteUser = "ftp-user";
+        viewModel.FtpRemotePassword = "ftp-password";
+        viewModel.FtpRemotePath = "/backup";
+        viewModel.FtpRemoteEncoding = "UTF8";
+        viewModel.FtpRemoteEnforceUnencrypted = true;
+
+        Assert.That(configuration.UNCUsername, Is.EqualTo("user"));
+        Assert.That(Crypto.DecryptString(configuration.UNCPassword, System.Security.Cryptography.DataProtectionScope.LocalMachine), Is.EqualTo("password"));
+        Assert.That(configuration.FtpHost, Is.EqualTo("ftp.example.test"));
+        Assert.That(configuration.FtpPort, Is.EqualTo("2121"));
+        Assert.That(configuration.FtpUser, Is.EqualTo("ftp-user"));
+        Assert.That(configuration.FtpPass, Is.EqualTo("ftp-password"));
+        Assert.That(configuration.FtpFolder, Is.EqualTo("/backup"));
+        Assert.That(configuration.FtpCoding, Is.EqualTo("UTF8"));
+        Assert.That(configuration.FtpEncryptionMode, Is.EqualTo("3"));
+    }
+
+    private sealed class TestConfigurationManager : IConfigurationManager
+    {
+        public string AutoBackup { get; set; } = "";
+        public string BackupFolder { get; set; } = "";
+        public string BackupSize { get; set; } = "";
+        public int Compression { get; set; }
+        public string DbStatus { get; set; } = "";
+        public string DBVersion { get; set; } = "";
+        public string DeativateAutoBackupsWhenAkku { get; set; } = "1";
+        public string DoPastBackups { get; set; } = "";
+        public int Encrypt { get; set; }
+        public string EncryptPassMD5 { get; set; } = "";
+        public string ExcludeCompression { get; set; } = ".zip|.rar|.7zip";
+        public string ExcludeFile { get; set; } = "";
+        public string ExcludeFileBigger { get; set; } = "";
+        public string ExcludeFileTypes { get; set; } = "";
+        public string ExcludeFolder { get; set; } = "";
+        public string ExcludeMask { get; set; } = "";
+        public string FreeSpace { get; set; } = "";
+        public string FtpCoding { get; set; } = "ISO-8859-1";
+        public string FtpEncryptionMode { get; set; } = "";
+        public string FtpFolder { get; set; } = "";
+        public string FtpHost { get; set; } = "";
+        public string FtpPass { get; set; } = "";
+        public string FtpPort { get; set; } = "21";
+        public string FtpSslProtocols { get; set; } = "";
+        public string FtpUser { get; set; } = "";
+        public string InfoBackupDone { get; set; } = "";
+        public string IntervallAutoHourBackups { get; set; } = "";
+        public string IntervallDelete { get; set; } = "";
+        public string IsConfigured { get; set; } = "";
+        public string LastBackupDone { get; set; } = "";
+        public string LastVersionDate { get; set; } = "";
+        public string MediaVolumeSerial { get; set; } = "";
+        public string Medium { get; set; } = "";
+        public MediaType MediumType { get; set; } = MediaType.LocalDevice;
+        public string OldBackupPrevent { get; set; } = "";
+        public string RemindAfterDays { get; set; } = "7";
+        public string RemindSpace { get; set; } = "-1";
+        public string ScheduleFullBackup { get; set; } = "";
+        public string ShowLocalizedPath { get; set; } = "1";
+        public string ShowWaitOnMediaAutoBackups { get; set; } = "";
+        public string SourceFolder { get; set; } = "";
+        public TaskType TaskType { get; set; } = TaskType.Auto;
+        public string UNCPassword { get; set; } = "";
+        public string UNCUsername { get; set; } = "";
+
+        public Task InitializeAsync() => Task.CompletedTask;
+    }
+
+    private sealed class TestPresentationService : IPresentationService
+    {
+        public Task CloseBackupBrowserWindowAsync() => Task.CompletedTask;
+        public Task CloseMainWindowAsync() => Task.CompletedTask;
+        public Task<TaskCompleteAction> CloseStatusWindowAsync() => Task.FromResult(TaskCompleteAction.NoAction);
+        public Task<(string? password, bool persist)> RequestPasswordAsync() => Task.FromResult<(string?, bool)>(("password", false));
+        public Task<RequestOverwriteResult> RequestOverwriteAsync(FileTableRow localFile, FileTableRow remoteFile) => Task.FromResult(RequestOverwriteResult.Overwrite);
+        public Task ShowAboutWindowAsync() => Task.CompletedTask;
+        public Task ShowBackupBrowserWindowAsync() => Task.CompletedTask;
+        public Task<(bool, BSH.MainApp.ViewModels.Windows.NewBackupViewModel)> ShowCreateBackupWindowAsync() => throw new NotImplementedException();
+        public Task<(bool, BSH.MainApp.ViewModels.Windows.EditBackupViewModel)> ShowEditBackupWindowAsync(BSH.MainApp.ViewModels.Windows.EditBackupViewModel backupViewModel) => throw new NotImplementedException();
+        public Task<bool> ShowDeleteBackupWindowAsync() => Task.FromResult(true);
+        public Task ShowErrorInsufficientDiskSpaceAsync() => Task.CompletedTask;
+        public Task ShowMainWindowAsync() => Task.CompletedTask;
+        public Task ShowStatusWindowAsync() => Task.CompletedTask;
+        public Task<ContentDialogResult> ShowMessageBoxAsync(string title, string content, IList<IUICommand>? commands, uint defaultCommandIndex = 0, uint cancelCommandIndex = 1) => Task.FromResult(ContentDialogResult.Primary);
+        public Task ShowExcludeFileFolderWindowAsync() => Task.CompletedTask;
+        public Task ShowScheduleEditorWindowAsync() => Task.CompletedTask;
+    }
+
+    private sealed class TestJobService : IJobService
+    {
+        public bool IsCancellationRequested => false;
+        public void Cancel() { }
+        public Task<bool> CheckMediaAsync(ActionType action, bool silent = false) => Task.FromResult(true);
+        public Task<bool> CreateBackupAsync(string title, string description, bool statusDialog = true, bool fullBackup = false, bool shutdownPC = false, bool shutdownApp = false, string sourceFolders = "") => Task.FromResult(true);
+        public Task DeleteBackupAsync(string version, bool statusDialog = true) => Task.CompletedTask;
+        public Task DeleteBackupsAsync(List<string> versions, bool statusDialog = true) => Task.CompletedTask;
+        public Task DeleteSingleFileAsync(string fileFilter, string folderFilter, bool statusDialog = true) => Task.CompletedTask;
+        public CancellationToken GetNewCancellationToken() => CancellationToken.None;
+        public Task<bool> RequestPassword() => Task.FromResult(true);
+        public Task RestoreBackupAsync(string version, List<string> files, string destination, bool statusDialog = true) => Task.CompletedTask;
+        public Task RestoreBackupAsync(string version, string file, string destination, bool statusDialog = true) => Task.CompletedTask;
+        public Task ModifyBackupAsync(bool statusDialog = true) => Task.CompletedTask;
+    }
+
+    private sealed class TestQueryManager : IQueryManager
+    {
+        public Task<string> GetBackVersionWhereFileAsync(string startVersion, string searchString) => Task.FromResult("");
+        public Task<string> GetBackVersionWhereFilesInFolderAsync(string startVersion, string path) => Task.FromResult("");
+        public string GetFileNameFromDrive(FileTableRow file) => "";
+        public Task<(string, bool)> GetFileNameFromDriveAsync(int versionId, string fileName, string filePath, string password) => Task.FromResult(("", false));
+        public Task<FileDetails> GetFileDetailsAsync(string version, string fileName, string filePath) => throw new NotImplementedException();
+        public Task<List<FileTableRow>> GetFilesByVersionAsync(string version, string path) => Task.FromResult(new List<FileTableRow>());
+        public Task<List<string>> GetFolderListAsync(string version, string path) => Task.FromResult(new List<string>());
+        public Task<string> GetFullRestoreFolderAsync(string folder, string version) => Task.FromResult("");
+        public Task<VersionDetails> GetLastBackupAsync() => throw new NotImplementedException();
+        public Task<VersionDetails> GetLastFullBackupAsync() => throw new NotImplementedException();
+        public Task<string> GetLocalizedPathAsync(string path) => Task.FromResult(path);
+        public Task<string> GetNextVersionWhereFileAsync(string startVersion, string searchString) => Task.FromResult("");
+        public Task<string> GetNextVersionWhereFilesInFolderAsync(string startVersion, string path) => Task.FromResult("");
+        public Task<int> GetNumberOfVersionsAsync() => Task.FromResult(0);
+        public Task<int> GetNumberOfFilesAsync() => Task.FromResult(0);
+        public Task<double> GetTotalFileSizeAsync() => Task.FromResult(0d);
+        public Task<VersionDetails> GetOldestBackupAsync() => throw new NotImplementedException();
+        public Task<VersionDetails> GetVersionByIdAsync(string id) => throw new NotImplementedException();
+        public List<VersionDetails> GetVersions(bool desc = true) => new();
+        public Task<List<FileTableRow>> GetVersionsByFileAsync(string fileName, string filePath) => Task.FromResult(new List<FileTableRow>());
+        public Task<List<FileTableRow>> SearchFilesByVersionAsync(string version, string searchTerm, int limit = 500) => Task.FromResult(new List<FileTableRow>());
+        public Task<bool> HasChangesOrNewAsync(string path, string versionId) => Task.FromResult(false);
+    }
+}

--- a/src/BSH.Test/WinUiSettingsParityTests.cs
+++ b/src/BSH.Test/WinUiSettingsParityTests.cs
@@ -58,11 +58,11 @@ public class WinUiSettingsParityTests
 
         viewModel.OnNavigatedTo(null!);
         viewModel.AddCompressionExclusion("7z");
-        viewModel.SelectedCompressionExclusion = "zip";
+        viewModel.SelectedCompressionExclusion = ".zip";
         viewModel.RemoveCompressionExclusionCommand.Execute(null);
 
-        Assert.That(viewModel.CompressionExclusions, Is.EquivalentTo(new[] { "rar", "7z" }));
-        Assert.That(configuration.ExcludeCompression, Is.EqualTo("rar|7z"));
+        Assert.That(viewModel.CompressionExclusions, Is.EquivalentTo(new[] { ".rar", ".7z" }));
+        Assert.That(configuration.ExcludeCompression, Is.EqualTo(".rar|.7z"));
     }
 
     [Test]


### PR DESCRIPTION
Close the WinUI settings gaps for backup sources, targets, storage options, and filters. This slice should make the existing settings pages functionally comparable to the legacy configuration page for everyday configuration changes.

Fixes #527 