### PR TITLE
Honor WinUI status completion actions

### DIFF
--- a/src/BSH.MainApp/App.xaml.cs
+++ b/src/BSH.MainApp/App.xaml.cs
@@ -98,6 +98,7 @@ public partial class App : Application
             services.AddSingleton<Func<IWaitForMediaService>>(x => () => x.GetRequiredService<IWaitForMediaService>());
             services.AddSingleton<IScheduledBackupService, ScheduledBackupService>();
             services.AddSingleton<IOrchestrationService, OrchestrationService>();
+            services.AddSingleton<ICompletionActionService, CompletionActionService>();
             services.AddSingleton<IJobService, JobService>();
             services.AddSingleton<IPresentationService, PresentationService>();
 

--- a/src/BSH.MainApp/Contracts/Services/ICompletionActionService.cs
+++ b/src/BSH.MainApp/Contracts/Services/ICompletionActionService.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using BSH.MainApp.Models;
+
+namespace BSH.MainApp.Contracts.Services;
+
+public interface ICompletionActionService
+{
+    Task ExecuteAsync(TaskCompleteAction action);
+}

--- a/src/BSH.MainApp/Services/CompletionActionService.cs
+++ b/src/BSH.MainApp/Services/CompletionActionService.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Diagnostics;
+using BSH.MainApp.Contracts.Services;
+using BSH.MainApp.Models;
+using Serilog;
+
+namespace BSH.MainApp.Services;
+
+public sealed class CompletionActionService : ICompletionActionService
+{
+    private readonly ILogger logger = Log.ForContext<CompletionActionService>();
+
+    public Task ExecuteAsync(TaskCompleteAction action)
+    {
+        switch (action)
+        {
+            case TaskCompleteAction.ShutdownPC:
+                logger.Debug("Computer will be shutdown after task has finished.");
+                Process.Start("shutdown.exe", "-s -t 60 -c \"Backup Service Home 3 task finished.\"");
+                break;
+            case TaskCompleteAction.HibernatePC:
+                logger.Debug("Computer will be hibernated after task has finished.");
+                Process.Start("rundll32.exe", "powrprof.dll,SetSuspendState");
+                break;
+            case TaskCompleteAction.NoAction:
+                logger.Debug("No completion action selected after task has finished.");
+                break;
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/BSH.MainApp/Services/JobService.cs
+++ b/src/BSH.MainApp/Services/JobService.cs
@@ -21,6 +21,7 @@ public class JobService : IJobService, IDisposable
     private readonly IConfigurationManager configurationManager;
     private readonly IStatusService statusService;
     private readonly IPresentationService presentationService;
+    private readonly ICompletionActionService completionActionService;
     private readonly Func<IWaitForMediaService> waitForMediaServiceFactory;
     private readonly JobRuntime jobRuntime;
     private readonly JobSessionRunner jobSessionRunner;
@@ -39,6 +40,7 @@ public class JobService : IJobService, IDisposable
         IConfigurationManager configurationManager,
         IStatusService statusService,
         IPresentationService presentationService,
+        ICompletionActionService completionActionService,
         ILocalSettingsService localSettingsService,
         Func<IWaitForMediaService> waitForMediaServiceFactory)
     {
@@ -48,6 +50,7 @@ public class JobService : IJobService, IDisposable
         this.configurationManager = configurationManager;
         this.statusService = statusService;
         this.presentationService = presentationService;
+        this.completionActionService = completionActionService;
         this.waitForMediaServiceFactory = waitForMediaServiceFactory;
 
         this.jobRuntime = new JobRuntime(
@@ -60,7 +63,7 @@ public class JobService : IJobService, IDisposable
                 return await waitForMediaService.ExecuteAsync(silent, cancellationTokenSource);
             },
             this.RequestPassword);
-        this.presenter = new WinUIJobSessionPresenter(this.presentationService, this.statusService, this.Cancel);
+        this.presenter = new WinUIJobSessionPresenter(this.presentationService, this.statusService, this.Cancel, this.completionActionService);
         var storedPasswordAdapter = new WinUIStoredPasswordAdapter(localSettingsService);
         this.jobSessionRunner = new JobSessionRunner(
             backupService,
@@ -123,7 +126,7 @@ public class JobService : IJobService, IDisposable
             return false;
         }
 
-        await presenter.CompleteAsync(triggerShutdown: shutdownPC);
+        await presenter.CompleteAsync(triggerShutdown: shutdownPC && !result.Canceled, honorCompletionActions: !result.Canceled);
         return !result.Canceled;
     }
 
@@ -146,7 +149,7 @@ public class JobService : IJobService, IDisposable
             return;
         }
 
-        await presenter.CompleteAsync();
+        await presenter.CompleteAsync(honorCompletionActions: !result.Canceled);
     }
 
     /// <summary>
@@ -167,7 +170,7 @@ public class JobService : IJobService, IDisposable
             return;
         }
 
-        await presenter.CompleteAsync();
+        await presenter.CompleteAsync(honorCompletionActions: !result.Canceled);
     }
 
     /// <summary>
@@ -186,7 +189,7 @@ public class JobService : IJobService, IDisposable
             return;
         }
 
-        await presenter.CompleteAsync();
+        await presenter.CompleteAsync(honorCompletionActions: !result.Canceled);
     }
 
     /// <summary>
@@ -204,7 +207,7 @@ public class JobService : IJobService, IDisposable
             return;
         }
 
-        await presenter.CompleteAsync();
+        await presenter.CompleteAsync(honorCompletionActions: !result.Canceled);
     }
 
     /// <summary>
@@ -225,7 +228,7 @@ public class JobService : IJobService, IDisposable
             return;
         }
 
-        await presenter.CompleteAsync();
+        await presenter.CompleteAsync(honorCompletionActions: !result.Canceled);
     }
 
     /// <summary>
@@ -243,7 +246,7 @@ public class JobService : IJobService, IDisposable
             return;
         }
 
-        await presenter.CompleteAsync();
+        await presenter.CompleteAsync(honorCompletionActions: !result.Canceled);
     }
 
     /// <summary>

--- a/src/BSH.MainApp/Services/PresentationService.cs
+++ b/src/BSH.MainApp/Services/PresentationService.cs
@@ -37,17 +37,19 @@ public class PresentationService : IPresentationService
 
     public async Task<TaskCompleteAction> CloseStatusWindowAsync()
     {
+        var action = TaskCompleteAction.NoAction;
         if (statusWindow != null)
         {
             await statusWindow.DispatcherQueue.EnqueueAsync(() =>
             {
+                action = statusWindow.ViewModel.SelectedCompletionAction;
                 statusWindow.Close();
             });
 
             App.GetService<IStatusService>().RemoveObserver(statusWindow.ViewModel);
             statusWindow = null;
         }
-        return TaskCompleteAction.NoAction;
+        return action;
     }
 
     public async Task ShowMainWindowAsync()

--- a/src/BSH.MainApp/Services/WinUIJobSessionPresenter.cs
+++ b/src/BSH.MainApp/Services/WinUIJobSessionPresenter.cs
@@ -19,18 +19,24 @@ namespace BSH.MainApp.Services;
 public sealed class WinUIJobSessionPresenter : IJobSessionPresenter
 {
     private readonly Action cancelAction;
+    private readonly ICompletionActionService completionActionService;
     private readonly IPresentationService presentationService;
     private readonly IStatusService statusService;
     private CancellationToken cancellationToken;
     private bool statusWindowShown;
 
-    public WinUIJobSessionPresenter(IPresentationService presentationService, IStatusService statusService, Action cancelAction)
+    public WinUIJobSessionPresenter(
+        IPresentationService presentationService,
+        IStatusService statusService,
+        Action cancelAction,
+        ICompletionActionService? completionActionService = null)
     {
         ArgumentNullException.ThrowIfNull(presentationService);
         ArgumentNullException.ThrowIfNull(statusService);
         ArgumentNullException.ThrowIfNull(cancelAction);
 
         this.cancelAction = cancelAction;
+        this.completionActionService = completionActionService ?? new CompletionActionService();
         this.presentationService = presentationService;
         this.statusService = statusService;
     }
@@ -43,15 +49,37 @@ public sealed class WinUIJobSessionPresenter : IJobSessionPresenter
 
     public async Task CompleteAsync(bool triggerShutdown = false, bool triggerHibernate = false, bool honorCompletionActions = true)
     {
-        _ = triggerShutdown;
-        _ = triggerHibernate;
-        _ = honorCompletionActions;
-
+        var action = TaskCompleteAction.NoAction;
         if (statusWindowShown)
         {
-            await presentationService.CloseStatusWindowAsync();
+            action = await presentationService.CloseStatusWindowAsync();
             statusWindowShown = false;
         }
+
+        var completionAction = ResolveCompletionAction(triggerShutdown, triggerHibernate, honorCompletionActions, action);
+        if (completionAction != TaskCompleteAction.NoAction)
+        {
+            await completionActionService.ExecuteAsync(completionAction);
+        }
+    }
+
+    private static TaskCompleteAction ResolveCompletionAction(
+        bool triggerShutdown,
+        bool triggerHibernate,
+        bool honorCompletionActions,
+        TaskCompleteAction selectedAction)
+    {
+        if (triggerShutdown)
+        {
+            return TaskCompleteAction.ShutdownPC;
+        }
+
+        if (triggerHibernate)
+        {
+            return TaskCompleteAction.HibernatePC;
+        }
+
+        return honorCompletionActions ? selectedAction : TaskCompleteAction.NoAction;
     }
 
     public Task ShowErrorTaskRunningAsync()

--- a/src/BSH.MainApp/ViewModels/Windows/StatusViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/Windows/StatusViewModel.cs
@@ -14,7 +14,7 @@ namespace BSH.MainApp.ViewModels.Windows;
 
 public partial class StatusViewModel : ObservableObject, IStatusReport
 {
-    private readonly DispatcherQueue dispatcherQueue;
+    private readonly DispatcherQueue? dispatcherQueue;
 
     [ObservableProperty]
     private string statusTitle = "";
@@ -31,9 +31,24 @@ public partial class StatusViewModel : ObservableObject, IStatusReport
     [ObservableProperty]
     private int currentProgress = 0;
 
-    public StatusViewModel()
+    [ObservableProperty]
+    private int selectedCompletionActionIndex = 0;
+
+    public TaskCompleteAction SelectedCompletionAction => SelectedCompletionActionIndex switch
     {
-        this.dispatcherQueue = App.GetService<DispatcherQueue>();
+        1 => TaskCompleteAction.ShutdownPC,
+        2 => TaskCompleteAction.HibernatePC,
+        _ => TaskCompleteAction.NoAction
+    };
+
+    public StatusViewModel()
+        : this(App.GetService<DispatcherQueue>())
+    {
+    }
+
+    public StatusViewModel(DispatcherQueue? dispatcherQueue)
+    {
+        this.dispatcherQueue = dispatcherQueue;
     }
 
     public void ReportAction(ActionType action, bool silent)
@@ -52,7 +67,7 @@ public partial class StatusViewModel : ObservableObject, IStatusReport
 
     public void ReportFileProgress(string file)
     {
-        dispatcherQueue.TryEnqueue(() =>
+        UpdateOnUiThread(() =>
         {
             CurrentFileText = file;
         });
@@ -60,7 +75,7 @@ public partial class StatusViewModel : ObservableObject, IStatusReport
 
     public void ReportProgress(int total, int current)
     {
-        dispatcherQueue.TryEnqueue(() =>
+        UpdateOnUiThread(() =>
         {
             TotalProgress = total;
             CurrentProgress = current;
@@ -69,7 +84,7 @@ public partial class StatusViewModel : ObservableObject, IStatusReport
 
     public void ReportStatus(string title, string text)
     {
-        dispatcherQueue.TryEnqueue(() =>
+        UpdateOnUiThread(() =>
         {
             StatusTitle = title;
             StatusText = text;
@@ -80,5 +95,18 @@ public partial class StatusViewModel : ObservableObject, IStatusReport
     public void Cancel()
     {
         App.GetService<IJobService>().Cancel();
+    }
+
+    partial void OnSelectedCompletionActionIndexChanged(int value)
+    {
+        OnPropertyChanged(nameof(SelectedCompletionAction));
+    }
+
+    private void UpdateOnUiThread(Action action)
+    {
+        if (dispatcherQueue == null || !dispatcherQueue.TryEnqueue(() => action()))
+        {
+            action();
+        }
     }
 }

--- a/src/BSH.MainApp/Windows/StatusWindow.xaml
+++ b/src/BSH.MainApp/Windows/StatusWindow.xaml
@@ -9,7 +9,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     Title="{x:Bind ViewModel.StatusTitle, Mode=OneWay}"
-    Height="300" Width="600" IsResizable="False" IsMaximizable="False" IsMinimizable="False" IsAlwaysOnTop="True">
+    Height="340" Width="600" IsResizable="False" IsMaximizable="False" IsMinimizable="False" IsAlwaysOnTop="True">
 
     <Grid Background="White">
         <Grid.RowDefinitions>
@@ -28,6 +28,14 @@
                 <TextBlock Text="files processed" />
             </StackPanel>
             <TextBlock Text="{x:Bind ViewModel.CurrentFileText, Mode=OneWay}" />
+            <StackPanel Orientation="Horizontal" Spacing="8">
+                <TextBlock VerticalAlignment="Center" Text="After completion" />
+                <ComboBox Width="180" SelectedIndex="{x:Bind ViewModel.SelectedCompletionActionIndex, Mode=TwoWay}">
+                    <ComboBoxItem Content="No action" />
+                    <ComboBoxItem Content="Shutdown" />
+                    <ComboBoxItem Content="Hibernate" />
+                </ComboBox>
+            </StackPanel>
         </StackPanel>
 
         <Grid Grid.Row="1" Background="#fafafa" Padding="30,10" BorderBrush="#f0f0f0" BorderThickness="0,1,0,0">

--- a/src/BSH.Test/WinUiPresentationParityTests.cs
+++ b/src/BSH.Test/WinUiPresentationParityTests.cs
@@ -21,6 +21,19 @@ namespace BSH.Test;
 
 public class WinUiPresentationParityTests
 {
+    [TestCase(0, TaskCompleteAction.NoAction)]
+    [TestCase(1, TaskCompleteAction.ShutdownPC)]
+    [TestCase(2, TaskCompleteAction.HibernatePC)]
+    public void StatusViewModelMapsSelectedCompletionAction(int selectedIndex, TaskCompleteAction expectedAction)
+    {
+        var viewModel = new StatusViewModel(null)
+        {
+            SelectedCompletionActionIndex = selectedIndex
+        };
+
+        Assert.That(viewModel.SelectedCompletionAction, Is.EqualTo(expectedAction));
+    }
+
     [Test]
     public void MainWindowSupportMenuDelegatesToPresentationService()
     {
@@ -76,6 +89,69 @@ public class WinUiPresentationParityTests
             silent: true);
 
         Assert.That(presentationService.ExceptionListRequests, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task WinUiJobSessionPresenterExecutesSelectedStatusCompletionAction()
+    {
+        var presentationService = new TestPresentationService
+        {
+            CloseStatusWindowResult = TaskCompleteAction.HibernatePC
+        };
+        var completionActionService = new TestCompletionActionService();
+        var presenter = new WinUIJobSessionPresenter(
+            presentationService,
+            new StatusService(new TestConfigurationManager(), presentationService),
+            () => { },
+            completionActionService);
+
+        await presenter.ShowStatusWindowAsync();
+        await presenter.CompleteAsync();
+
+        Assert.That(presentationService.CloseStatusWindowCalls, Is.EqualTo(1));
+        Assert.That(completionActionService.Actions, Is.EqualTo(new[] { TaskCompleteAction.HibernatePC }));
+    }
+
+    [TestCase(true, false, TaskCompleteAction.ShutdownPC)]
+    [TestCase(false, true, TaskCompleteAction.HibernatePC)]
+    public async Task WinUiJobSessionPresenterExecutesExplicitCompletionActions(
+        bool triggerShutdown,
+        bool triggerHibernate,
+        TaskCompleteAction expectedAction)
+    {
+        var presentationService = new TestPresentationService();
+        var completionActionService = new TestCompletionActionService();
+        var presenter = new WinUIJobSessionPresenter(
+            presentationService,
+            new StatusService(new TestConfigurationManager(), presentationService),
+            () => { },
+            completionActionService);
+
+        await presenter.CompleteAsync(triggerShutdown: triggerShutdown, triggerHibernate: triggerHibernate);
+
+        Assert.That(presentationService.CloseStatusWindowCalls, Is.EqualTo(0));
+        Assert.That(completionActionService.Actions, Is.EqualTo(new[] { expectedAction }));
+    }
+
+    [Test]
+    public async Task WinUiJobSessionPresenterDoesNotExecuteSelectedActionWhenCompletionActionsAreSuppressed()
+    {
+        var presentationService = new TestPresentationService
+        {
+            CloseStatusWindowResult = TaskCompleteAction.ShutdownPC
+        };
+        var completionActionService = new TestCompletionActionService();
+        var presenter = new WinUIJobSessionPresenter(
+            presentationService,
+            new StatusService(new TestConfigurationManager(), presentationService),
+            () => { },
+            completionActionService);
+
+        await presenter.ShowStatusWindowAsync();
+        await presenter.CompleteAsync(honorCompletionActions: false);
+
+        Assert.That(presentationService.CloseStatusWindowCalls, Is.EqualTo(1));
+        Assert.That(completionActionService.Actions, Is.Empty);
     }
 
     private sealed class TestConfigurationManager : IConfigurationManager
@@ -135,11 +211,17 @@ public class WinUiPresentationParityTests
         public int ExceptionListRequests { get; private set; }
         public int HelpSupportCalls { get; private set; }
         public int ResetConfigurationCalls { get; private set; }
+        public int CloseStatusWindowCalls { get; private set; }
+        public TaskCompleteAction CloseStatusWindowResult { get; set; } = TaskCompleteAction.NoAction;
         public IReadOnlyCollection<FileExceptionEntry>? LastExceptionList { get; private set; }
 
         public Task CloseBackupBrowserWindowAsync() => Task.CompletedTask;
         public Task CloseMainWindowAsync() => Task.CompletedTask;
-        public Task<TaskCompleteAction> CloseStatusWindowAsync() => Task.FromResult(TaskCompleteAction.NoAction);
+        public Task<TaskCompleteAction> CloseStatusWindowAsync()
+        {
+            CloseStatusWindowCalls++;
+            return Task.FromResult(CloseStatusWindowResult);
+        }
         public Task OpenCurrentEventLogAsync() { EventLogCalls++; return Task.CompletedTask; }
         public Task OpenHelpSupportAsync() { HelpSupportCalls++; return Task.CompletedTask; }
         public Task<(string? password, bool persist)> RequestPasswordAsync() => Task.FromResult<(string?, bool)>((null, false));
@@ -164,5 +246,16 @@ public class WinUiPresentationParityTests
         public Task<ContentDialogResult> ShowMessageBoxAsync(string title, string content, IList<IUICommand>? commands, uint defaultCommandIndex = 0, uint cancelCommandIndex = 1) => Task.FromResult(ContentDialogResult.None);
         public Task ShowExcludeFileFolderWindowAsync() => Task.CompletedTask;
         public Task ShowScheduleEditorWindowAsync() => Task.CompletedTask;
+    }
+
+    private sealed class TestCompletionActionService : ICompletionActionService
+    {
+        public List<TaskCompleteAction> Actions { get; } = new();
+
+        public Task ExecuteAsync(TaskCompleteAction action)
+        {
+            Actions.Add(action);
+            return Task.CompletedTask;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add WinUI status-window completion choices for no action, shutdown, and hibernate.
- Return the selected completion action when the status window closes.
- Route WinUI job completion through a dedicated completion-action service so shutdown and hibernate can be executed after successful tasks.
- Suppress completion actions when the job is canceled.
- Add focused tests for status-action mapping and presenter completion behavior.

## Testing
- `dotnet build "Backup Service Home 3.sln" --no-restore` passed.
- `dotnet test "Backup Service Home 3.sln" --no-restore` passed.
- Added unit coverage for completion-action mapping and WinUI job presenter behavior.