### PR TITLE
Refactor scheduled backup logic to use typed schedule settings

### DIFF
--- a/src/BSH.Engine/Services/SchedulePolicy.cs
+++ b/src/BSH.Engine/Services/SchedulePolicy.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Brightbits.BSH.Engine.Models;
+
+namespace Brightbits.BSH.Engine.Services;
+
+public sealed class SchedulePolicy
+{
+    private readonly ScheduleSettings settings;
+
+    public SchedulePolicy(ScheduleSettings settings)
+    {
+        this.settings = settings ?? throw new ArgumentNullException(nameof(settings));
+    }
+
+    public bool ShouldPerformFullBackup(DateTime? lastFullBackup, DateTime now)
+    {
+        var intervalDays = Math.Max(1, settings.ScheduledFullBackupDays);
+        return settings.EnableScheduledFullBackups
+            && lastFullBackup.HasValue
+            && now.Subtract(lastFullBackup.Value) >= TimeSpan.FromDays(intervalDays);
+    }
+
+    public IReadOnlyList<VersionDetails> GetVersionsToDelete(
+        IEnumerable<VersionDetails> versions,
+        DateTime now)
+    {
+        return settings.RetentionMode switch
+        {
+            ScheduleRetentionMode.Automatic => GetAutomaticVersionsToDelete(versions, now),
+            ScheduleRetentionMode.Interval => GetIntervalVersionsToDelete(versions, now),
+            _ => Array.Empty<VersionDetails>(),
+        };
+    }
+
+    public IReadOnlyList<VersionDetails> GetAutomaticVersionsToDelete(
+        IEnumerable<VersionDetails> versions,
+        DateTime now)
+    {
+        var versionList = versions.ToList();
+        var hourlyBackupThreshold = TimeSpan.FromHours(Math.Max(1, settings.AutomaticHourlyBackupThreshold));
+        var result = new List<VersionDetails>();
+
+        foreach (var version in versionList)
+        {
+            if (version.Stable || now.Subtract(version.CreationDate) <= hourlyBackupThreshold)
+            {
+                continue;
+            }
+
+            if (now.Subtract(version.CreationDate) > TimeSpan.FromDays(
+                DateTime.DaysInMonth(version.CreationDate.Year, version.CreationDate.Month)))
+            {
+                if (versionList.Any(x =>
+                    version.CreationDate != x.CreationDate
+                    && version.CreationDate.Year == x.CreationDate.Year
+                    && version.CreationDate.Month == x.CreationDate.Month
+                    && version.CreationDate.Day - (int)version.CreationDate.DayOfWeek == x.CreationDate.Day - (int)x.CreationDate.DayOfWeek
+                    && version.CreationDate.DayOfWeek < x.CreationDate.DayOfWeek))
+                {
+                    result.Add(version);
+                }
+            }
+            else if (versionList.Any(x =>
+                version.CreationDate != x.CreationDate
+                && version.CreationDate.Year == x.CreationDate.Year
+                && version.CreationDate.Month == x.CreationDate.Month
+                && version.CreationDate.Day == x.CreationDate.Day
+                && version.CreationDate.TimeOfDay < x.CreationDate.TimeOfDay))
+            {
+                result.Add(version);
+            }
+        }
+
+        return result;
+    }
+
+    private IReadOnlyList<VersionDetails> GetIntervalVersionsToDelete(
+        IEnumerable<VersionDetails> versions,
+        DateTime now)
+    {
+        var retentionInterval = Math.Max(1, settings.RetentionInterval);
+        var retentionAge = settings.RetentionIntervalUnit switch
+        {
+            ScheduleRetentionIntervalUnit.Hour => TimeSpan.FromHours(retentionInterval),
+            ScheduleRetentionIntervalUnit.Week => TimeSpan.FromDays(retentionInterval * 7d),
+            _ => TimeSpan.FromDays(retentionInterval),
+        };
+
+        return versions
+            .Where(version => !version.Stable && now.Subtract(version.CreationDate) > retentionAge)
+            .ToList();
+    }
+}

--- a/src/BSH.Engine/Services/SchedulePolicy.cs
+++ b/src/BSH.Engine/Services/SchedulePolicy.cs
@@ -17,6 +17,8 @@ public sealed class SchedulePolicy
         this.settings = settings ?? throw new ArgumentNullException(nameof(settings));
     }
 
+    public bool ScheduledFullBackupsEnabled => settings.EnableScheduledFullBackups;
+
     public bool ShouldPerformFullBackup(DateTime? lastFullBackup, DateTime now)
     {
         var intervalDays = Math.Max(1, settings.ScheduledFullBackupDays);
@@ -43,40 +45,42 @@ public sealed class SchedulePolicy
     {
         var versionList = versions.ToList();
         var hourlyBackupThreshold = TimeSpan.FromHours(Math.Max(1, settings.AutomaticHourlyBackupThreshold));
-        var result = new List<VersionDetails>();
+        var candidates = versionList
+            .Where(version => !version.Stable && now.Subtract(version.CreationDate) > hourlyBackupThreshold)
+            .ToList();
 
-        foreach (var version in versionList)
-        {
-            if (version.Stable || now.Subtract(version.CreationDate) <= hourlyBackupThreshold)
-            {
-                continue;
-            }
+        var dailyCandidates = candidates
+            .Where(version => !UsesWeeklyRetention(version, now));
+        var weeklyCandidates = candidates
+            .Where(version => UsesWeeklyRetention(version, now));
 
-            if (now.Subtract(version.CreationDate) > TimeSpan.FromDays(
-                DateTime.DaysInMonth(version.CreationDate.Year, version.CreationDate.Month)))
-            {
-                if (versionList.Any(x =>
-                    version.CreationDate != x.CreationDate
-                    && version.CreationDate.Year == x.CreationDate.Year
-                    && version.CreationDate.Month == x.CreationDate.Month
-                    && version.CreationDate.Day - (int)version.CreationDate.DayOfWeek == x.CreationDate.Day - (int)x.CreationDate.DayOfWeek
-                    && version.CreationDate.DayOfWeek < x.CreationDate.DayOfWeek))
-                {
-                    result.Add(version);
-                }
-            }
-            else if (versionList.Any(x =>
-                version.CreationDate != x.CreationDate
-                && version.CreationDate.Year == x.CreationDate.Year
-                && version.CreationDate.Month == x.CreationDate.Month
-                && version.CreationDate.Day == x.CreationDate.Day
-                && version.CreationDate.TimeOfDay < x.CreationDate.TimeOfDay))
-            {
-                result.Add(version);
-            }
-        }
+        return GetSupersededVersions(dailyCandidates, versionList, version => version.CreationDate.Date)
+            .Concat(GetSupersededVersions(weeklyCandidates, versionList, version => GetWeekStart(version.CreationDate)))
+            .ToList();
+    }
 
-        return result;
+    private static IEnumerable<VersionDetails> GetSupersededVersions(
+        IEnumerable<VersionDetails> candidates,
+        IEnumerable<VersionDetails> allVersions,
+        Func<VersionDetails, DateTime> getRetentionPeriod)
+    {
+        var newestVersionByPeriod = allVersions
+            .GroupBy(getRetentionPeriod)
+            .ToDictionary(group => group.Key, group => group.Max(version => version.CreationDate));
+
+        return candidates.Where(version =>
+            version.CreationDate < newestVersionByPeriod[getRetentionPeriod(version)]);
+    }
+
+    private static bool UsesWeeklyRetention(VersionDetails version, DateTime now)
+    {
+        return now.Subtract(version.CreationDate) > TimeSpan.FromDays(
+            DateTime.DaysInMonth(version.CreationDate.Year, version.CreationDate.Month));
+    }
+
+    private static DateTime GetWeekStart(DateTime date)
+    {
+        return date.Date.AddDays(-(int)date.DayOfWeek);
     }
 
     private IReadOnlyList<VersionDetails> GetIntervalVersionsToDelete(

--- a/src/BSH.Engine/Services/ScheduleSettingsService.cs
+++ b/src/BSH.Engine/Services/ScheduleSettingsService.cs
@@ -67,11 +67,17 @@ public sealed class ScheduleSettingsService
         }
 
         var parts = interval.Split('|');
+        if (parts.Length != 2
+            || !TryParseRetentionUnit(parts[0], out var unit)
+            || !TryParsePositiveInt(parts[1], out var retentionInterval))
+        {
+            settings.RetentionMode = ScheduleRetentionMode.None;
+            return;
+        }
+
         settings.RetentionMode = ScheduleRetentionMode.Interval;
-        settings.RetentionInterval = parts.Length > 1 ? ParsePositiveInt(parts[1], 1) : 1;
-        settings.RetentionIntervalUnit = parts.Length > 0
-            ? ParseRetentionUnit(parts[0])
-            : ScheduleRetentionIntervalUnit.Day;
+        settings.RetentionInterval = retentionInterval;
+        settings.RetentionIntervalUnit = unit;
     }
 
     private ScheduleSettings LoadPolicySettings()
@@ -93,8 +99,14 @@ public sealed class ScheduleSettingsService
         }
 
         var parts = fullBackup.Split('|');
-        settings.EnableScheduledFullBackups = parts.Length > 0 && parts[0] == "day";
-        settings.ScheduledFullBackupDays = parts.Length > 1 ? ParsePositiveInt(parts[1], 1) : 1;
+        if (parts.Length != 2 || parts[0] != "day" || !TryParsePositiveInt(parts[1], out var intervalDays))
+        {
+            settings.EnableScheduledFullBackups = false;
+            return;
+        }
+
+        settings.EnableScheduledFullBackups = true;
+        settings.ScheduledFullBackupDays = intervalDays;
     }
 
     private static string BuildRetentionConfig(ScheduleSettings settings)
@@ -107,14 +119,17 @@ public sealed class ScheduleSettingsService
         };
     }
 
-    private static ScheduleRetentionIntervalUnit ParseRetentionUnit(string unit)
+    private static bool TryParseRetentionUnit(string value, out ScheduleRetentionIntervalUnit unit)
     {
-        return unit switch
+        unit = value switch
         {
             "hour" => ScheduleRetentionIntervalUnit.Hour,
+            "day" => ScheduleRetentionIntervalUnit.Day,
             "week" => ScheduleRetentionIntervalUnit.Week,
             _ => ScheduleRetentionIntervalUnit.Day,
         };
+
+        return value is "hour" or "day" or "week";
     }
 
     private static string FormatRetentionUnit(ScheduleRetentionIntervalUnit unit)
@@ -129,8 +144,13 @@ public sealed class ScheduleSettingsService
 
     private static int ParsePositiveInt(string value, int fallback)
     {
-        return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) && parsed > 0
+        return TryParsePositiveInt(value, out var parsed)
             ? parsed
             : fallback;
+    }
+
+    private static bool TryParsePositiveInt(string value, out int parsed)
+    {
+        return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out parsed) && parsed > 0;
     }
 }

--- a/src/BSH.Engine/Services/ScheduleSettingsService.cs
+++ b/src/BSH.Engine/Services/ScheduleSettingsService.cs
@@ -26,15 +26,16 @@ public sealed class ScheduleSettingsService
 
     public async Task<ScheduleSettings> LoadAsync()
     {
-        var settings = new ScheduleSettings();
+        var settings = LoadPolicySettings();
         settings.Entries.AddRange(await scheduleRepository.GetSchedulesAsync());
-
-        LoadRetention(settings);
-        settings.AutomaticHourlyBackupThreshold = ParsePositiveInt(configurationManager.IntervallAutoHourBackups, 24);
-        LoadScheduledFullBackup(settings);
         settings.PerformMissedBackupsLater = configurationManager.DoPastBackups == "1";
 
         return settings;
+    }
+
+    public SchedulePolicy LoadPolicy()
+    {
+        return new SchedulePolicy(LoadPolicySettings());
     }
 
     public async Task SaveAsync(ScheduleSettings settings)
@@ -71,6 +72,15 @@ public sealed class ScheduleSettingsService
         settings.RetentionIntervalUnit = parts.Length > 0
             ? ParseRetentionUnit(parts[0])
             : ScheduleRetentionIntervalUnit.Day;
+    }
+
+    private ScheduleSettings LoadPolicySettings()
+    {
+        var settings = new ScheduleSettings();
+        LoadRetention(settings);
+        settings.AutomaticHourlyBackupThreshold = ParsePositiveInt(configurationManager.IntervallAutoHourBackups, 24);
+        LoadScheduledFullBackup(settings);
+        return settings;
     }
 
     private void LoadScheduledFullBackup(ScheduleSettings settings)

--- a/src/BSH.Main/Dialogs/SubDialogs/frmEditScheduler.cs
+++ b/src/BSH.Main/Dialogs/SubDialogs/frmEditScheduler.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using System.Collections.Generic;
 using System.Windows.Forms;
 using Brightbits.BSH.Engine.Models;
 using BSH.Main.Utils;
@@ -19,10 +18,9 @@ public partial class frmEditScheduler
 
     private async void frmEditScheduler_Load(object sender, EventArgs e)
     {
-        // Zeitplaner lesen
-        var schedules = await BackupLogic.ScheduleRepository.GetSchedulesAsync();
+        var settings = await BackupLogic.ScheduleSettingsService.LoadAsync();
         lwTimeSchedule.Items.Clear();
-        foreach (var schedule in schedules)
+        foreach (var schedule in settings.Entries)
         {
             try
             {
@@ -72,33 +70,30 @@ public partial class frmEditScheduler
         }
 
         // Löschintervalle festlegen
-        switch (BackupLogic.ConfigurationManager.IntervallDelete ?? "")
+        switch (settings.RetentionMode)
         {
-            case var @case when @case == "":
+            case ScheduleRetentionMode.None:
                 rdDontDelete.Checked = true;
                 break;
 
-            case "auto":
+            case ScheduleRetentionMode.Automatic:
                 rdDeleteAuto.Checked = true;
                 break;
 
-            default:
+            case ScheduleRetentionMode.Interval:
                 rdDeleteIntervall.Checked = true;
-
-                // Intervall auslesen
-                var Intervall = BackupLogic.ConfigurationManager.IntervallDelete.Split('|');
-                txtIntervall.Text = Intervall[1];
-                switch (Intervall[0] ?? "")
+                txtIntervall.Text = settings.RetentionInterval.ToString();
+                switch (settings.RetentionIntervalUnit)
                 {
-                    case "hour":
+                    case ScheduleRetentionIntervalUnit.Hour:
                         cboIntervall.SelectedIndex = 0;
                         break;
 
-                    case "day":
+                    case ScheduleRetentionIntervalUnit.Day:
                         cboIntervall.SelectedIndex = 1;
                         break;
 
-                    case "week":
+                    case ScheduleRetentionIntervalUnit.Week:
                         cboIntervall.SelectedIndex = 2;
                         break;
                 }
@@ -106,19 +101,14 @@ public partial class frmEditScheduler
                 break;
         }
 
-        nudIntervallHourBackups.Value = decimal.Parse(BackupLogic.ConfigurationManager.IntervallAutoHourBackups);
+        nudIntervallHourBackups.Value = settings.AutomaticHourlyBackupThreshold;
 
         // Vollsicherung
-        if (!string.IsNullOrEmpty(BackupLogic.ConfigurationManager.ScheduleFullBackup))
+        if (settings.EnableScheduledFullBackups)
         {
             chkFullBackup.Checked = true;
-            var Item = BackupLogic.ConfigurationManager.ScheduleFullBackup.Split('|');
-            if (Item[0] == "day")
-            {
-                cboFullBackup.SelectedIndex = 0;
-            }
-
-            nudFullBackup.Value = int.Parse(Item[1]);
+            cboFullBackup.SelectedIndex = 0;
+            nudFullBackup.Value = settings.ScheduledFullBackupDays;
         }
         else
         {
@@ -184,7 +174,8 @@ public partial class frmEditScheduler
 
     private async void cmdOK_Click(object sender, EventArgs e)
     {
-        var schedules = new List<ScheduleEntry>();
+        var settings = await BackupLogic.ScheduleSettingsService.LoadAsync();
+        settings.Entries.Clear();
 
         // Automatische Backups
         foreach (ListViewItem entry in lwTimeSchedule.Items)
@@ -193,76 +184,55 @@ public partial class frmEditScheduler
             switch (entry.SubItems[0].Tag)
             {
                 case 0:
-                    schedules.Add(new ScheduleEntry() { Type = 1, Date = parsedDate });
+                    settings.Entries.Add(new ScheduleEntry() { Type = 1, Date = parsedDate });
                     break;
 
                 case 1:
-                    schedules.Add(new ScheduleEntry() { Type = 2, Date = parsedDate });
+                    settings.Entries.Add(new ScheduleEntry() { Type = 2, Date = parsedDate });
                     break;
 
                 case 2:
-                    schedules.Add(new ScheduleEntry() { Type = 3, Date = parsedDate });
+                    settings.Entries.Add(new ScheduleEntry() { Type = 3, Date = parsedDate });
                     break;
 
                 case 3:
-                    schedules.Add(new ScheduleEntry() { Type = 4, Date = parsedDate });
+                    settings.Entries.Add(new ScheduleEntry() { Type = 4, Date = parsedDate });
                     break;
 
                 case 4:
-                    schedules.Add(new ScheduleEntry() { Type = 5, Date = parsedDate });
+                    settings.Entries.Add(new ScheduleEntry() { Type = 5, Date = parsedDate });
                     break;
             }
         }
-
-        await BackupLogic.ScheduleRepository.ReplaceSchedulesAsync(schedules);
 
         // Löschintervalle speichern
         if (rdDontDelete.Checked)
         {
-            BackupLogic.ConfigurationManager.IntervallDelete = "";
+            settings.RetentionMode = ScheduleRetentionMode.None;
         }
         else if (rdDeleteIntervall.Checked)
         {
-            if (!string.IsNullOrEmpty(txtIntervall.Text) && !string.IsNullOrEmpty(cboIntervall.Text))
+            settings.RetentionMode = ScheduleRetentionMode.Interval;
+            settings.RetentionInterval = int.TryParse(txtIntervall.Text, out var interval) ? interval : 1;
+            settings.RetentionIntervalUnit = cboIntervall.SelectedIndex switch
             {
-                // Manuelles Intervall
-                switch (cboIntervall.SelectedIndex)
-                {
-                    case 0:
-                        // Stündlich
-                        BackupLogic.ConfigurationManager.IntervallDelete = "hour|" + txtIntervall.Text;
-                        break;
-
-                    case 1:
-                        // Täglich
-                        BackupLogic.ConfigurationManager.IntervallDelete = "day|" + txtIntervall.Text;
-                        break;
-
-                    case 2:
-                        // Wöchentlich
-                        BackupLogic.ConfigurationManager.IntervallDelete = "week|" + txtIntervall.Text;
-                        break;
-                }
-            }
+                0 => ScheduleRetentionIntervalUnit.Hour,
+                2 => ScheduleRetentionIntervalUnit.Week,
+                _ => ScheduleRetentionIntervalUnit.Day,
+            };
         }
         else if (rdDeleteAuto.Checked)
         {
-            BackupLogic.ConfigurationManager.IntervallDelete = "auto";
-            BackupLogic.ConfigurationManager.IntervallAutoHourBackups = nudIntervallHourBackups.Value.ToString();
+            settings.RetentionMode = ScheduleRetentionMode.Automatic;
         }
 
+        settings.AutomaticHourlyBackupThreshold = decimal.ToInt32(nudIntervallHourBackups.Value);
+
         // Vollsicherung nach Sicherung oder Tag anlegen
-        if (chkFullBackup.Checked)
-        {
-            if (cboFullBackup.SelectedIndex == 0)
-            {
-                BackupLogic.ConfigurationManager.ScheduleFullBackup = "day|" + nudFullBackup.Value.ToString();
-            }
-        }
-        else
-        {
-            BackupLogic.ConfigurationManager.ScheduleFullBackup = "";
-        }
+        settings.EnableScheduledFullBackups = chkFullBackup.Checked && cboFullBackup.SelectedIndex == 0;
+        settings.ScheduledFullBackupDays = decimal.ToInt32(nudFullBackup.Value);
+
+        await BackupLogic.ScheduleSettingsService.SaveAsync(settings);
 
         Close();
     }

--- a/src/BSH.Main/Modules/BackupLogic.cs
+++ b/src/BSH.Main/Modules/BackupLogic.cs
@@ -641,9 +641,11 @@ static class BackupLogic
         // Priorität heruntersetzen
         Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.BelowNormal;
 
-        var lastFullBackup = await QueryManager.GetLastFullBackupAsync();
-        var FullBackup = ScheduleSettingsService.LoadPolicy()
-            .ShouldPerformFullBackup(lastFullBackup?.CreationDate, DateTime.Now);
+        var schedulePolicy = ScheduleSettingsService.LoadPolicy();
+        var lastFullBackup = schedulePolicy.ScheduledFullBackupsEnabled
+            ? await QueryManager.GetLastFullBackupAsync()
+            : null;
+        var FullBackup = schedulePolicy.ShouldPerformFullBackup(lastFullBackup?.CreationDate, DateTime.Now);
 
         try
         {

--- a/src/BSH.Main/Modules/BackupLogic.cs
+++ b/src/BSH.Main/Modules/BackupLogic.cs
@@ -60,6 +60,11 @@ static class BackupLogic
         get; private set;
     }
 
+    public static ScheduleSettingsService ScheduleSettingsService
+    {
+        get; private set;
+    }
+
     public static IVersionQueryRepository VersionQueryRepository
     {
         get; private set;
@@ -87,6 +92,7 @@ static class BackupLogic
         ConfigurationManager = null;
         QueryManager = null;
         ScheduleRepository = null;
+        ScheduleSettingsService = null;
         VersionQueryRepository = null;
         BackupMutationRepository = null;
         BackupService = null;
@@ -139,6 +145,7 @@ static class BackupLogic
         var storageFactory = new StorageFactory(ConfigurationManager);
         QueryManager = new QueryManager(DbClientFactory, ConfigurationManager, storageFactory);
         ScheduleRepository = new ScheduleRepository(DbClientFactory);
+        ScheduleSettingsService = new ScheduleSettingsService(ConfigurationManager, ScheduleRepository);
         VersionQueryRepository = new VersionQueryRepository();
         BackupMutationRepository = new BackupMutationRepository(DbClientFactory);
         fileCollectorServiceFactory = new FileCollectorServiceFactory();
@@ -408,66 +415,10 @@ static class BackupLogic
         }
     }
 
-    private static List<VersionDetails> GetAutomaticVersionsToDelete()
-    {
-        var listDelete = new List<VersionDetails>();
-        var listVersions = QueryManager.GetVersions();
-        var hourlyBackupThreshold = int.TryParse(ConfigurationManager.IntervallAutoHourBackups, out var threshold) && threshold > 0
-            ? threshold
-            : 24;
-
-        foreach (var version in listVersions)
-        {
-            // ignore fixed versions
-            if (version.Stable)
-            {
-                continue;
-            }
-
-            // keep hourly backups for the configured automatic-retention threshold
-            if (DateTime.Now.Subtract(version.CreationDate) <= new TimeSpan(hourlyBackupThreshold, 0, 0))
-            {
-                continue;
-            }
-
-            // version older than 1 month
-            if (DateTime.Now.Subtract(version.CreationDate) > new TimeSpan(DateTime.DaysInMonth(version.CreationDate.Year, version.CreationDate.Month), 0, 0, 0))
-            {
-                // keep if last backup of the week
-                if (listVersions.Exists(x =>
-                    version.CreationDate != x.CreationDate &&
-                    version.CreationDate.Year == x.CreationDate.Year &&
-                    version.CreationDate.Month == x.CreationDate.Month &&
-                    version.CreationDate.Day - (int)version.CreationDate.DayOfWeek == x.CreationDate.Day - (int)x.CreationDate.DayOfWeek &&
-                    version.CreationDate.DayOfWeek < x.CreationDate.DayOfWeek)
-                    )
-                {
-                    listDelete.Add(version);
-                }
-            }
-            else
-            {
-                // keep if last backup on that day
-                if (listVersions.Exists(x =>
-                    version.CreationDate != x.CreationDate &&
-                    version.CreationDate.Year == x.CreationDate.Year &&
-                    version.CreationDate.Month == x.CreationDate.Month &&
-                    version.CreationDate.Day == x.CreationDate.Day &&
-                    version.CreationDate.TimeOfDay < x.CreationDate.TimeOfDay)
-                    )
-                {
-                    listDelete.Add(version);
-                }
-            }
-        }
-
-        return listDelete;
-    }
-
     private static async Task RemoveOldBackups()
     {
-        // get versions to clean
-        var listDelete = GetAutomaticVersionsToDelete();
+        var listDelete = ScheduleSettingsService.LoadPolicy()
+            .GetAutomaticVersionsToDelete(QueryManager.GetVersions(), DateTime.Now);
 
         // delete old versions
         foreach (var version in listDelete)
@@ -690,22 +641,9 @@ static class BackupLogic
         // Priorität heruntersetzen
         Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.BelowNormal;
 
-        // Vollsicherung durchführen?
-        var FullBackup = false;
-        if (!string.IsNullOrEmpty(ConfigurationManager.ScheduleFullBackup))
-        {
-            // Letzte Vollsicherung ermitteln
-            var Item = ConfigurationManager.ScheduleFullBackup.Split('|');
-            if (Item[0] == "day")
-            {
-                var lastFullBackup = await QueryManager.GetLastFullBackupAsync();
-                if (lastFullBackup != null)
-                {
-                    var Diff = DateTime.Now.Subtract(lastFullBackup.CreationDate);
-                    FullBackup = Diff.Days >= Convert.ToInt32(Item[1]);
-                }
-            }
-        }
+        var lastFullBackup = await QueryManager.GetLastFullBackupAsync();
+        var FullBackup = ScheduleSettingsService.LoadPolicy()
+            .ShouldPerformFullBackup(lastFullBackup?.CreationDate, DateTime.Now);
 
         try
         {
@@ -750,55 +688,9 @@ static class BackupLogic
 
     private static List<VersionDetails> GetScheduledVersionsToDelete()
     {
-        if (ConfigurationManager.IntervallDelete == "auto")
-        {
-            return GetAutomaticVersionsToDelete();
-        }
-
-        if (string.IsNullOrEmpty(ConfigurationManager.IntervallDelete))
-        {
-            return new List<VersionDetails>();
-        }
-
-        return GetCustomVersionsToDelete(ConfigurationManager.IntervallDelete);
-    }
-
-    private static List<VersionDetails> GetCustomVersionsToDelete(string intervalConfig)
-    {
-        var listDelete = new List<VersionDetails>();
-        var intervals = intervalConfig.Split('|');
-        var listVersions = QueryManager.GetVersions();
-
-        foreach (var version in listVersions)
-        {
-            if (version.Stable || listDelete.Contains(version))
-            {
-                continue;
-            }
-
-            if (ShouldDeleteVersion(version, intervals))
-            {
-                listDelete.Add(version);
-            }
-        }
-
-        return listDelete;
-    }
-
-    private static bool ShouldDeleteVersion(VersionDetails version, string[] intervals)
-    {
-        if (intervals.Length < 2)
-        {
-            return false;
-        }
-
-        return intervals[0] switch
-        {
-            "hour" => DateTime.Now.Subtract(version.CreationDate) > new TimeSpan(Convert.ToInt32(intervals[1]), 0, 0),
-            "day" => DateTime.Now.Subtract(version.CreationDate) > new TimeSpan(Convert.ToInt32(intervals[1]), 0, 0, 0),
-            "week" => DateTime.Now.Subtract(version.CreationDate) > new TimeSpan((int)Math.Round(Convert.ToDouble(intervals[1]) * 7d), 0, 0, 0),
-            _ => false
-        };
+        return ScheduleSettingsService.LoadPolicy()
+            .GetVersionsToDelete(QueryManager.GetVersions(), DateTime.Now)
+            .ToList();
     }
 
     #endregion

--- a/src/BSH.MainApp/Services/ScheduledBackupService.cs
+++ b/src/BSH.MainApp/Services/ScheduledBackupService.cs
@@ -318,9 +318,11 @@ public class ScheduledBackupService : IScheduledBackupService
         // Priorität heruntersetzen
         Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.BelowNormal;
 
-        var lastFullBackup = await queryManager.GetLastFullBackupAsync();
-        var fullBackupOption = scheduleSettingsService.LoadPolicy()
-            .ShouldPerformFullBackup(lastFullBackup?.CreationDate, DateTime.Now);
+        var schedulePolicy = scheduleSettingsService.LoadPolicy();
+        var lastFullBackup = schedulePolicy.ScheduledFullBackupsEnabled
+            ? await queryManager.GetLastFullBackupAsync()
+            : null;
+        var fullBackupOption = schedulePolicy.ShouldPerformFullBackup(lastFullBackup?.CreationDate, DateTime.Now);
 
         // Backup durchführen
         var task = jobService.CreateBackupAsync("Automatische Sicherung", "", false, fullBackupOption);

--- a/src/BSH.MainApp/Services/ScheduledBackupService.cs
+++ b/src/BSH.MainApp/Services/ScheduledBackupService.cs
@@ -21,6 +21,7 @@ public class ScheduledBackupService : IScheduledBackupService
     private readonly IQueryManager queryManager;
     private readonly IScheduleRepository scheduleRepository;
     private readonly ISchedulerAdapterFactory schedulerAdapterFactory;
+    private readonly ScheduleSettingsService scheduleSettingsService;
 
     private ISchedulerAdapter schedulerService;
 
@@ -29,13 +30,15 @@ public class ScheduledBackupService : IScheduledBackupService
         IJobService jobService,
         IQueryManager queryManager,
         IScheduleRepository scheduleRepository,
-        ISchedulerAdapterFactory schedulerAdapterFactory)
+        ISchedulerAdapterFactory schedulerAdapterFactory,
+        ScheduleSettingsService scheduleSettingsService)
     {
         this.configurationManager = configurationManager;
         this.jobService = jobService;
         this.queryManager = queryManager;
         this.scheduleRepository = scheduleRepository;
         this.schedulerAdapterFactory = schedulerAdapterFactory;
+        this.scheduleSettingsService = scheduleSettingsService;
     }
 
     public async Task InitializeAsync()
@@ -123,66 +126,10 @@ public class ScheduledBackupService : IScheduledBackupService
             TaskContinuationOptions.None);
     }
 
-    private List<VersionDetails> GetAutomaticVersionsToDelete()
-    {
-        var listDelete = new List<VersionDetails>();
-        var listVersions = queryManager.GetVersions();
-        var hourlyBackupThreshold = int.TryParse(configurationManager.IntervallAutoHourBackups, out var threshold) && threshold > 0
-            ? threshold
-            : 24;
-
-        foreach (var version in listVersions)
-        {
-            // ignore fixed versions
-            if (version.Stable)
-            {
-                continue;
-            }
-
-            // keep hourly backups for the configured automatic-retention threshold
-            if (DateTime.Now.Subtract(version.CreationDate) <= new TimeSpan(hourlyBackupThreshold, 0, 0))
-            {
-                continue;
-            }
-
-            // version older than 1 month
-            if (DateTime.Now.Subtract(version.CreationDate) > new TimeSpan(DateTime.DaysInMonth(version.CreationDate.Year, version.CreationDate.Month), 0, 0, 0))
-            {
-                // keep if last backup of the week
-                if (listVersions.Any(x =>
-                    version.CreationDate != x.CreationDate &&
-                    version.CreationDate.Year == x.CreationDate.Year &&
-                    version.CreationDate.Month == x.CreationDate.Month &&
-                    version.CreationDate.Day - (int)version.CreationDate.DayOfWeek == x.CreationDate.Day - (int)x.CreationDate.DayOfWeek &&
-                    version.CreationDate.DayOfWeek < x.CreationDate.DayOfWeek)
-                    )
-                {
-                    listDelete.Add(version);
-                }
-            }
-            else
-            {
-                // keep if last backup on that day
-                if (listVersions.Any(x =>
-                    version.CreationDate != x.CreationDate &&
-                    version.CreationDate.Year == x.CreationDate.Year &&
-                    version.CreationDate.Month == x.CreationDate.Month &&
-                    version.CreationDate.Day == x.CreationDate.Day &&
-                    version.CreationDate.TimeOfDay < x.CreationDate.TimeOfDay)
-                    )
-                {
-                    listDelete.Add(version);
-                }
-            }
-        }
-
-        return listDelete;
-    }
-
     private async Task RemoveOldBackups()
     {
-        // get versions to clean
-        var listDelete = GetAutomaticVersionsToDelete();
+        var listDelete = scheduleSettingsService.LoadPolicy()
+            .GetAutomaticVersionsToDelete(queryManager.GetVersions(), DateTime.Now);
 
         // delete old versions
         foreach (var version in listDelete)
@@ -371,22 +318,9 @@ public class ScheduledBackupService : IScheduledBackupService
         // Priorität heruntersetzen
         Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.BelowNormal;
 
-        // Vollsicherung durchführen?
-        var fullBackupOption = false;
-        if (!string.IsNullOrEmpty(configurationManager.ScheduleFullBackup))
-        {
-            // Letzte Vollsicherung ermitteln
-            var Item = configurationManager.ScheduleFullBackup.Split('|');
-            if (Item[0] == "day")
-            {
-                var lastFullBackup = await queryManager.GetLastFullBackupAsync();
-                if (lastFullBackup != null)
-                {
-                    var Diff = DateTime.Now.Subtract(lastFullBackup.CreationDate);
-                    fullBackupOption = Diff.Days >= Convert.ToInt32(Item[1]);
-                }
-            }
-        }
+        var lastFullBackup = await queryManager.GetLastFullBackupAsync();
+        var fullBackupOption = scheduleSettingsService.LoadPolicy()
+            .ShouldPerformFullBackup(lastFullBackup?.CreationDate, DateTime.Now);
 
         // Backup durchführen
         var task = jobService.CreateBackupAsync("Automatische Sicherung", "", false, fullBackupOption);
@@ -412,59 +346,8 @@ public class ScheduledBackupService : IScheduledBackupService
 
         try
         {
-            if (configurationManager.IntervallDelete == "auto")
-            {
-                // automatic deletion
-                listDelete.AddRange(GetAutomaticVersionsToDelete());
-            }
-            else if (string.IsNullOrEmpty(configurationManager.IntervallDelete))
-            {
-                // don't delete anything
-            }
-            else
-            {
-                // custom intervals
-                var intervals = configurationManager.IntervallDelete.Split('|');
-                var listVersions = queryManager.GetVersions();
-
-                foreach (var version in listVersions)
-                {
-                    // ignore fixed versions
-                    if (version.Stable)
-                    {
-                        continue;
-                    }
-
-                    // Löschung
-                    switch (intervals[0] ?? "")
-                    {
-                        case "hour":
-                            if (DateTime.Now.Subtract(version.CreationDate) > new TimeSpan(Convert.ToInt32(intervals[1]), 0, 0) && !listDelete.Contains(version))
-                            {
-                                listDelete.Add(version);
-                            }
-
-                            break;
-
-                        case "day":
-                            if (DateTime.Now.Subtract(version.CreationDate) > new TimeSpan(Convert.ToInt32(intervals[1]), 0, 0, 0) && !listDelete.Contains(version))
-                            {
-                                listDelete.Add(version);
-                            }
-
-                            break;
-
-                        case "week":
-
-                            if (DateTime.Now.Subtract(version.CreationDate) > new TimeSpan((int)Math.Round(Convert.ToDouble(intervals[1]) * 7d), 0, 0, 0) && !listDelete.Contains(version))
-                            {
-                                listDelete.Add(version);
-                            }
-
-                            break;
-                    }
-                }
-            }
+            listDelete.AddRange(scheduleSettingsService.LoadPolicy()
+                .GetVersionsToDelete(queryManager.GetVersions(), DateTime.Now));
         }
         catch (Exception ex)
         {

--- a/src/BSH.Test/SchedulePolicyTests.cs
+++ b/src/BSH.Test/SchedulePolicyTests.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Brightbits.BSH.Engine.Models;
+using Brightbits.BSH.Engine.Services;
+using NUnit.Framework;
+
+namespace BSH.Test;
+
+public class SchedulePolicyTests
+{
+    private static readonly DateTime Now = new(2026, 6, 15, 23, 0, 0);
+
+    [Test]
+    public void ShouldPerformFullBackupUsesTypedScheduleSettings()
+    {
+        var policy = new SchedulePolicy(new ScheduleSettings
+        {
+            EnableScheduledFullBackups = true,
+            ScheduledFullBackupDays = 7
+        });
+
+        Assert.That(policy.ShouldPerformFullBackup(Now.AddDays(-7), Now), Is.True);
+        Assert.That(policy.ShouldPerformFullBackup(Now.AddDays(-6), Now), Is.False);
+        Assert.That(policy.ShouldPerformFullBackup(null, Now), Is.False);
+    }
+
+    [Test]
+    public void GetVersionsToDeleteUsesTypedIntervalRetention()
+    {
+        var oldVersion = CreateVersion("old", Now.AddDays(-15));
+        var recentVersion = CreateVersion("recent", Now.AddDays(-13));
+        var stableVersion = CreateVersion("stable", Now.AddDays(-30), stable: true);
+        var policy = new SchedulePolicy(new ScheduleSettings
+        {
+            RetentionMode = ScheduleRetentionMode.Interval,
+            RetentionIntervalUnit = ScheduleRetentionIntervalUnit.Week,
+            RetentionInterval = 2
+        });
+
+        var result = policy.GetVersionsToDelete(new[] { oldVersion, recentVersion, stableVersion }, Now);
+
+        Assert.That(result.Select(x => x.Id), Is.EqualTo(new[] { "old" }));
+    }
+
+    [Test]
+    public void GetAutomaticVersionsToDeleteUsesTypedHourlyThreshold()
+    {
+        var supersededHourlyVersion = CreateVersion("old-hour", Now.AddHours(-37));
+        var latestDailyVersion = CreateVersion("latest-day", Now.AddHours(-36));
+        var policy = new SchedulePolicy(new ScheduleSettings
+        {
+            RetentionMode = ScheduleRetentionMode.Automatic,
+            AutomaticHourlyBackupThreshold = 36
+        });
+
+        var result = policy.GetVersionsToDelete(
+            new[] { supersededHourlyVersion, latestDailyVersion },
+            Now);
+
+        Assert.That(result.Select(x => x.Id), Is.EqualTo(new[] { "old-hour" }));
+    }
+
+    private static VersionDetails CreateVersion(string id, DateTime creationDate, bool stable = false)
+    {
+        return new VersionDetails
+        {
+            Id = id,
+            CreationDate = creationDate,
+            Stable = stable
+        };
+    }
+}

--- a/src/BSH.Test/SchedulePolicyTests.cs
+++ b/src/BSH.Test/SchedulePolicyTests.cs
@@ -29,6 +29,16 @@ public class SchedulePolicyTests
     }
 
     [Test]
+    public void ScheduledFullBackupsEnabledExposesWhetherHistoryIsRequired()
+    {
+        Assert.That(new SchedulePolicy(new ScheduleSettings()).ScheduledFullBackupsEnabled, Is.False);
+        Assert.That(new SchedulePolicy(new ScheduleSettings
+        {
+            EnableScheduledFullBackups = true
+        }).ScheduledFullBackupsEnabled, Is.True);
+    }
+
+    [Test]
     public void GetVersionsToDeleteUsesTypedIntervalRetention()
     {
         var oldVersion = CreateVersion("old", Now.AddDays(-15));
@@ -62,6 +72,39 @@ public class SchedulePolicyTests
             Now);
 
         Assert.That(result.Select(x => x.Id), Is.EqualTo(new[] { "old-hour" }));
+    }
+
+    [Test]
+    public void GetAutomaticVersionsToDeleteKeepsNewestVersionAcrossMonthBoundaryWeek()
+    {
+        var now = new DateTime(2026, 7, 15, 23, 0, 0);
+        var olderVersion = CreateVersion("may", new DateTime(2026, 5, 31, 8, 0, 0));
+        var newerVersion = CreateVersion("june", new DateTime(2026, 6, 1, 8, 0, 0));
+        var policy = new SchedulePolicy(new ScheduleSettings
+        {
+            RetentionMode = ScheduleRetentionMode.Automatic,
+            AutomaticHourlyBackupThreshold = 1
+        });
+
+        var result = policy.GetVersionsToDelete(new[] { olderVersion, newerVersion }, now);
+
+        Assert.That(result.Select(x => x.Id), Is.EqualTo(new[] { "may" }));
+    }
+
+    [Test]
+    public void GetAutomaticVersionsToDeleteKeepsStableVersionAsPeriodWinner()
+    {
+        var oldVersion = CreateVersion("old", Now.AddHours(-38));
+        var stableVersion = CreateVersion("stable", Now.AddHours(-37), stable: true);
+        var policy = new SchedulePolicy(new ScheduleSettings
+        {
+            RetentionMode = ScheduleRetentionMode.Automatic,
+            AutomaticHourlyBackupThreshold = 24
+        });
+
+        var result = policy.GetVersionsToDelete(new[] { oldVersion, stableVersion }, Now);
+
+        Assert.That(result.Select(x => x.Id), Is.EqualTo(new[] { "old" }));
     }
 
     private static VersionDetails CreateVersion(string id, DateTime creationDate, bool stable = false)

--- a/src/BSH.Test/ScheduleSettingsServiceTests.cs
+++ b/src/BSH.Test/ScheduleSettingsServiceTests.cs
@@ -112,7 +112,7 @@ public class ScheduleSettingsServiceTests
     }
 
     [Test]
-    public async Task LoadAsyncUsesSafeDefaultsForMalformedPolicySettings()
+    public async Task LoadAsyncDisablesMalformedDestructivePolicySettings()
     {
         configurationManager.IntervallDelete = "week|invalid";
         configurationManager.IntervallAutoHourBackups = "invalid";
@@ -120,12 +120,9 @@ public class ScheduleSettingsServiceTests
 
         var settings = await scheduleSettingsService.LoadAsync();
 
-        Assert.That(settings.RetentionMode, Is.EqualTo(ScheduleRetentionMode.Interval));
-        Assert.That(settings.RetentionIntervalUnit, Is.EqualTo(ScheduleRetentionIntervalUnit.Week));
-        Assert.That(settings.RetentionInterval, Is.EqualTo(1));
+        Assert.That(settings.RetentionMode, Is.EqualTo(ScheduleRetentionMode.None));
         Assert.That(settings.AutomaticHourlyBackupThreshold, Is.EqualTo(24));
-        Assert.That(settings.EnableScheduledFullBackups, Is.True);
-        Assert.That(settings.ScheduledFullBackupDays, Is.EqualTo(1));
+        Assert.That(settings.EnableScheduledFullBackups, Is.False);
     }
 
     [Test]

--- a/src/BSH.Test/ScheduleSettingsServiceTests.cs
+++ b/src/BSH.Test/ScheduleSettingsServiceTests.cs
@@ -112,6 +112,23 @@ public class ScheduleSettingsServiceTests
     }
 
     [Test]
+    public async Task LoadAsyncUsesSafeDefaultsForMalformedPolicySettings()
+    {
+        configurationManager.IntervallDelete = "week|invalid";
+        configurationManager.IntervallAutoHourBackups = "invalid";
+        configurationManager.ScheduleFullBackup = "day|invalid";
+
+        var settings = await scheduleSettingsService.LoadAsync();
+
+        Assert.That(settings.RetentionMode, Is.EqualTo(ScheduleRetentionMode.Interval));
+        Assert.That(settings.RetentionIntervalUnit, Is.EqualTo(ScheduleRetentionIntervalUnit.Week));
+        Assert.That(settings.RetentionInterval, Is.EqualTo(1));
+        Assert.That(settings.AutomaticHourlyBackupThreshold, Is.EqualTo(24));
+        Assert.That(settings.EnableScheduledFullBackups, Is.True);
+        Assert.That(settings.ScheduledFullBackupDays, Is.EqualTo(1));
+    }
+
+    [Test]
     public void BuildScheduleDateUsesKindSpecificDateParts()
     {
         var baseDate = new DateTimeOffset(new DateTime(2026, 6, 1, 8, 0, 0));


### PR DESCRIPTION
## Summary
- Introduce `SchedulePolicy` to centralize full-backup and retention decisions behind typed `ScheduleSettings`
- Update engine and main app flows to load and apply policy settings instead of parsing legacy string config values inline
- Switch scheduler UI save/load paths to read and persist structured schedule settings
- Add unit coverage for the new policy behavior

## Testing
- Added NUnit tests for full-backup timing and retention deletion rules in `SchedulePolicy`
- Not run (not requested)