### PR TITLE
Add AGENTS.md with Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# AGENTS.md
+
+Backup Service Home 3 is a **Windows-only** .NET 10 desktop backup application (C#).
+It has two UI shells (WinUI 3 `BSH.MainApp`, legacy WinForms `BSH.Main`), a shared
+`BSH.Engine`, a VSS Windows service (`BSH.Service`), preview/control libraries, and an
+NUnit test project (`BSH.Test`). See `src/ARCHITECTURE.md` for the full codemap. The
+official build/test/release pipeline runs exclusively on `windows-latest`
+(`.github/workflows/dotnet-desktop-build.yml`).
+
+## Cursor Cloud specific instructions
+
+The Cursor Cloud VM is **Linux**, but every project targets a Windows TFM
+(`net10.0-windows` / `net10.0-windows10.0.22621.0`). Full development (running the GUI
+shells, running the test suite, VSS, MSIX packaging) requires Windows. This environment
+supports building most of the solution and running the core engine's data/security
+layers, which is enough for engine-level development.
+
+### Toolchain
+- .NET SDK `10.0.302` (pinned in `src/global.json`) is installed at `~/.dotnet` and added
+  to `PATH`/`DOTNET_ROOT` via `~/.bashrc`. The startup update script runs `dotnet restore`.
+- Run all `dotnet` commands from the `src/` directory (that is where the `.sln` lives).
+
+### Building on Linux (key gotchas)
+- Windows-targeted projects need `-p:EnableWindowsTargeting=true` on every
+  `restore`/`build`, otherwise you get `NETSDK1100`.
+- Build the solution with `-p:Platform=x64`. Do **not** use `-a x64` on the solution: it
+  sets a RID and fails with `NETSDK1134` ("Building a solution with a specific
+  RuntimeIdentifier is not supported"). `-a x64` is fine on a single project.
+- These build successfully on Linux: `BSH.Engine`, `BSH.Service`, `BSH.Service.Shared`,
+  `BSH.Controls`, `BSH.Main`, `SmartPreview`, `PreviewHandlerFramework`,
+  `PreviewHandlerHost`.
+- `BSH.MainApp` (WinUI 3) does **not** build on Linux — its XAML compiler
+  (`Microsoft.UI.Xaml.Markup.Compiler`) is Windows-only. Because `BSH.Test` references
+  `BSH.MainApp`, the test project cannot build on Linux either.
+- A full solution/project **build** rewrites `packages.lock.json` files to add `linux-x64`
+  RID entries. A plain `dotnet restore` does not. Revert any `packages.lock.json` changes
+  before committing (`git checkout -- src/**/packages.lock.json`); they are Linux build
+  artifacts, not intended changes. CI restores with `--locked-mode -a x64` on Windows.
+
+### Tests on Linux
+- The NUnit suite cannot run here: (1) `BSH.Test` references the WinUI app (won't build),
+  and (2) `net*-windows` assemblies are stamped with a Windows `TargetPlatform`, which
+  NUnit honors by **skipping every test** on non-Windows ("Only supported on Windows7.0").
+- Run `dotnet test -p:Platform=x64` on Windows for the real suite.
+
+### What runs on Linux vs. what needs Windows
+- Runs on Linux: `BSH.Engine` core data/security layers — SQLite DB creation +
+  migrations (`DbClientFactory`), `ConfigurationManager`, `QueryManager`,
+  `Security.Hash` (MD5), `Security.Encryption` (AES). `System.Data.SQLite.Core` ships a
+  `linux-x64` native interop, so the SQLite layer works.
+- Needs Windows: a full `BackupJob.BackupAsync` (calls `kernel32!SetThreadExecutionState`
+  via `Win32Stuff.KeepSystemAwake`), VSS (`AlphaVSS` + named-pipe RPC to `BSH.Service`),
+  FTP password crypto (DPAPI `ProtectedData` in `Security/Network.cs`), USB watch (WMI),
+  and all WinForms/WPF/WinUI runtime.
+
+### Lint / format
+- Roslyn analyzers (`Microsoft.CodeAnalysis.NetAnalyzers`) run during `dotnet build`; the
+  authoritative static analysis in CI is SonarCloud. `dotnet format` is available but the
+  repo is not clean against its whitespace/style rules, so `dotnet format
+  --verify-no-changes` is not the project's lint gate — rely on the build analyzers.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this repository on the Cursor Cloud (Linux) VM and documents durable, non-obvious guidance for future agents in a new `AGENTS.md`.

Backup Service Home 3 is a **Windows-only** .NET 10 desktop app (WinUI 3 + WinForms + a VSS Windows service). Its official build/test/release pipeline runs exclusively on `windows-latest`. This PR does not change any product code — it only adds `AGENTS.md`.

## What was set up in the environment
- Installed .NET SDK `10.0.302` (pinned by `src/global.json`) to `~/.dotnet`, with `PATH`/`DOTNET_ROOT` persisted in `~/.bashrc`.
- Startup update script: `dotnet restore` of the solution.

## What works on Linux vs. needs Windows
- Builds on Linux (with `-p:EnableWindowsTargeting=true`): `BSH.Engine`, `BSH.Service`, `BSH.Service.Shared`, `BSH.Controls`, `BSH.Main`, `SmartPreview`, `PreviewHandlerFramework`, `PreviewHandlerHost`.
- Does **not** build on Linux: `BSH.MainApp` (WinUI 3 XAML compiler is Windows-only), and therefore `BSH.Test` (references `BSH.MainApp`).
- The engine's core data/security layers **run** on Linux (SQLite DB + migrations, `ConfigurationManager`, `QueryManager`, `Security.Hash` MD5, `Security.Encryption` AES). A full backup and the GUI shells require Windows (`kernel32!SetThreadExecutionState`, VSS, DPAPI, WinForms/WPF/WinUI runtime).

## Hello-world verification
A temporary console harness (not committed) exercised the core engine end-to-end on Linux:
- SQLite backup database created (schema + migrations)
- ConfigurationManager persistence round-trip (MediumType/TaskType)
- MD5 hashing and AES file encrypt/decrypt round-trip
- QueryManager version query
- BackupJob reaches the expected Windows-only `kernel32` boundary

See `AGENTS.md` → `## Cursor Cloud specific instructions` for full details and gotchas (e.g. `-p:Platform=x64` vs `-a x64`, reverting `packages.lock.json` build artifacts, why NUnit skips all tests on Linux).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10b46311-b856-486e-9957-23466035c4c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10b46311-b856-486e-9957-23466035c4c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

