### PR TITLE
feat: abort backup early when free space is clearly insufficient

### DIFF
--- a/src/BSH.Engine/Jobs/BackupJob.cs
+++ b/src/BSH.Engine/Jobs/BackupJob.cs
@@ -196,6 +196,28 @@ public class BackupJob : Job
             // report progress
             _logger.Information("{numFiles} files and {numFolders} folders are collected for backup.", files.Count, emptyFolder.Count);
 
+            // rough free-space preflight before heavy copy work
+            var freeSpaceBytes = storage.GetFreeSpace();
+            if (DiskSpacePreflight.ShouldAbortBackup(freeSpaceBytes, files.Select(f => f.FileSize)))
+            {
+                var estimatedBytes = DiskSpacePreflight.EstimateRequiredBytes(files.Select(f => f.FileSize));
+                _logger.Error(
+                    "Insufficient free space on backup device before copy. Estimated need ~{estimatedBytes} bytes, available {freeSpaceBytes} bytes. Aborting.",
+                    estimatedBytes,
+                    freeSpaceBytes);
+
+                ReportStatus(Resources.STATUS_CANCELLED_SHORT, Resources.STATUS_CANCELLED_ERROR);
+                await RequestShowErrorInsufficientDiskSpaceAsync();
+
+                storage.DeleteDirectory(newVersionDate);
+                storage.Dispose();
+                dbClient.RollbackTransaction();
+                Win32Stuff.AllowSystemSleep();
+
+                ReportState(JobState.ERROR);
+                return;
+            }
+
             ReportStatus(Resources.STATUS_BACKUP_COPY_SHORT, Resources.STATUS_BACKUP_COPY_TEXT);
             ReportProgress(files.Count, 0);
 

--- a/src/BSH.Engine/Jobs/BackupJob.cs
+++ b/src/BSH.Engine/Jobs/BackupJob.cs
@@ -196,25 +196,11 @@ public class BackupJob : Job
             // report progress
             _logger.Information("{numFiles} files and {numFolders} folders are collected for backup.", files.Count, emptyFolder.Count);
 
-            // rough free-space preflight before heavy copy work
             var freeSpaceBytes = storage.GetFreeSpace();
-            if (DiskSpacePreflight.ShouldAbortBackup(freeSpaceBytes, files.Select(f => f.FileSize)))
+            var estimatedBytes = DiskSpacePreflight.EstimateRequiredBytes(files.Select(f => f.FileSize));
+            if (DiskSpacePreflight.IsClearlyInsufficient(freeSpaceBytes, estimatedBytes))
             {
-                var estimatedBytes = DiskSpacePreflight.EstimateRequiredBytes(files.Select(f => f.FileSize));
-                _logger.Error(
-                    "Insufficient free space on backup device before copy. Estimated need ~{estimatedBytes} bytes, available {freeSpaceBytes} bytes. Aborting.",
-                    estimatedBytes,
-                    freeSpaceBytes);
-
-                ReportStatus(Resources.STATUS_CANCELLED_SHORT, Resources.STATUS_CANCELLED_ERROR);
-                await RequestShowErrorInsufficientDiskSpaceAsync();
-
-                storage.DeleteDirectory(newVersionDate);
-                storage.Dispose();
-                dbClient.RollbackTransaction();
-                Win32Stuff.AllowSystemSleep();
-
-                ReportState(JobState.ERROR);
+                await AbortForInsufficientDiskSpaceAsync(dbClient, newVersionDate, estimatedBytes, freeSpaceBytes);
                 return;
             }
 
@@ -308,19 +294,9 @@ public class BackupJob : Job
                 // cancellation token requested?
                 if (token.IsCancellationRequested || cancel)
                 {
-                    // report progress
                     _logger.Information("Cancellation of backup job requested. Rollback all transfers.");
                     ReportStatus(Resources.STATUS_CANCELLED_SHORT, Resources.STATUS_CANCELLED_TEXT);
-
-                    // undo
-                    storage.DeleteDirectory(newVersionDate);
-                    storage.Dispose();
-
-                    dbClient.RollbackTransaction();
-
-                    // standby
-                    Win32Stuff.AllowSystemSleep();
-
+                    RollbackIncompleteVersion(dbClient, newVersionDate);
                     ReportState(JobState.CANCELED);
                     return;
                 }
@@ -334,19 +310,9 @@ public class BackupJob : Job
                 // can we still write to device?
                 if (!storage.CanWriteToStorage())
                 {
-                    // report progress
                     _logger.Error("Cannot write to backup device. Rollback all transfers.");
                     ReportStatus(Resources.STATUS_CANCELLED_SHORT, Resources.STATUS_CANCELLED_ERROR);
-
-                    // undo
-                    storage.DeleteDirectory(newVersionDate);
-                    storage.Dispose();
-
-                    dbClient.RollbackTransaction();
-
-                    // standby
-                    Win32Stuff.AllowSystemSleep();
-
+                    RollbackIncompleteVersion(dbClient, newVersionDate);
                     ReportExceptions(FileErrorList);
                     ReportState(JobState.ERROR);
                     return;
@@ -414,6 +380,31 @@ public class BackupJob : Job
         ReportState(FileErrorList.Count > 0 ? JobState.ERROR : JobState.FINISHED);
 
         _logger.Information("Backup job finished.");
+    }
+
+    private async Task AbortForInsufficientDiskSpaceAsync(
+        DbClient dbClient,
+        string versionDate,
+        long estimatedBytes,
+        long freeSpaceBytes)
+    {
+        _logger.Error(
+            "Insufficient free space on backup device before copy. Estimated need ~{estimatedBytes} bytes, available {freeSpaceBytes} bytes. Aborting.",
+            estimatedBytes,
+            freeSpaceBytes);
+
+        ReportStatus(Resources.STATUS_CANCELLED_SHORT, Resources.STATUS_CANCELLED_ERROR);
+        await RequestShowErrorInsufficientDiskSpaceAsync();
+        RollbackIncompleteVersion(dbClient, versionDate);
+        ReportState(JobState.ERROR);
+    }
+
+    private void RollbackIncompleteVersion(DbClient dbClient, string versionDate)
+    {
+        storage.DeleteDirectory(versionDate);
+        storage.Dispose();
+        dbClient.RollbackTransaction();
+        Win32Stuff.AllowSystemSleep();
     }
 
     private async Task ProcessEmptyFolders(DbClient dbClient, long newVersionId, List<FolderTableRow> emptyFolder)

--- a/src/BSH.Engine/Utils/DiskSpacePreflight.cs
+++ b/src/BSH.Engine/Utils/DiskSpacePreflight.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Collections.Generic;
+
+namespace Brightbits.BSH.Engine.Utils;
+
+/// <summary>
+/// Rough disk-space estimate and gate before a backup starts copying files.
+/// Exact size is hard (compression); this only aborts when free space is known
+/// and clearly below the estimated need.
+/// </summary>
+public static class DiskSpacePreflight
+{
+    /// <summary>
+    /// Small overhead for database updates, directory entries, and rounding.
+    /// </summary>
+    public const long DefaultSlackBytes = 16L * 1024 * 1024;
+
+    public static long EstimateRequiredBytes(IEnumerable<double> fileSizes, long? slackBytes = null)
+    {
+        ArgumentNullException.ThrowIfNull(fileSizes);
+
+        var slack = slackBytes ?? DefaultSlackBytes;
+        if (slack < 0)
+        {
+            slack = 0;
+        }
+
+        long total = 0;
+        foreach (var size in fileSizes)
+        {
+            if (size > 0)
+            {
+                total += (long)size;
+            }
+        }
+
+        return total + slack;
+    }
+
+    /// <summary>
+    /// Returns true only when free space is known (positive) and below the estimate.
+    /// Zero or negative free space means unknown (FTP/WebDAV/error) — soft skip.
+    /// </summary>
+    public static bool IsClearlyInsufficient(long freeSpaceBytes, long estimatedRequiredBytes)
+    {
+        if (freeSpaceBytes <= 0)
+        {
+            return false;
+        }
+
+        return estimatedRequiredBytes > freeSpaceBytes;
+    }
+
+    public static bool ShouldAbortBackup(long freeSpaceBytes, IEnumerable<double> fileSizes, long? slackBytes = null)
+    {
+        var estimated = EstimateRequiredBytes(fileSizes, slackBytes);
+        return IsClearlyInsufficient(freeSpaceBytes, estimated);
+    }
+}

--- a/src/BSH.Engine/Utils/DiskSpacePreflight.cs
+++ b/src/BSH.Engine/Utils/DiskSpacePreflight.cs
@@ -18,17 +18,11 @@ public static class DiskSpacePreflight
     /// </summary>
     public const long DefaultSlackBytes = 16L * 1024 * 1024;
 
-    public static long EstimateRequiredBytes(IEnumerable<double> fileSizes, long? slackBytes = null)
+    public static long EstimateRequiredBytes(IEnumerable<double> fileSizes, long slackBytes = DefaultSlackBytes)
     {
         ArgumentNullException.ThrowIfNull(fileSizes);
 
-        var slack = slackBytes ?? DefaultSlackBytes;
-        if (slack < 0)
-        {
-            slack = 0;
-        }
-
-        long total = 0;
+        long total = slackBytes > 0 ? slackBytes : 0;
         foreach (var size in fileSizes)
         {
             if (size > 0)
@@ -37,26 +31,13 @@ public static class DiskSpacePreflight
             }
         }
 
-        return total + slack;
+        return total;
     }
 
     /// <summary>
-    /// Returns true only when free space is known (positive) and below the estimate.
+    /// True only when free space is known (positive) and below the estimate.
     /// Zero or negative free space means unknown (FTP/WebDAV/error) — soft skip.
     /// </summary>
     public static bool IsClearlyInsufficient(long freeSpaceBytes, long estimatedRequiredBytes)
-    {
-        if (freeSpaceBytes <= 0)
-        {
-            return false;
-        }
-
-        return estimatedRequiredBytes > freeSpaceBytes;
-    }
-
-    public static bool ShouldAbortBackup(long freeSpaceBytes, IEnumerable<double> fileSizes, long? slackBytes = null)
-    {
-        var estimated = EstimateRequiredBytes(fileSizes, slackBytes);
-        return IsClearlyInsufficient(freeSpaceBytes, estimated);
-    }
+        => freeSpaceBytes > 0 && estimatedRequiredBytes > freeSpaceBytes;
 }

--- a/src/BSH.Test/DiskSpacePreflightTests.cs
+++ b/src/BSH.Test/DiskSpacePreflightTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Alexander Seeliger. All Rights Reserved.
 // Licensed under the Apache License, Version 2.0.
 
-using System.Collections.Generic;
 using Brightbits.BSH.Engine.Utils;
 using NUnit.Framework;
 
@@ -38,6 +37,14 @@ public class DiskSpacePreflightTests
     }
 
     [Test]
+    public void EstimateRequiredBytes_TreatsNegativeSlackAsZero()
+    {
+        var estimate = DiskSpacePreflight.EstimateRequiredBytes(new[] { 100d }, slackBytes: -5);
+
+        Assert.That(estimate, Is.EqualTo(100));
+    }
+
+    [Test]
     public void IsClearlyInsufficient_ReturnsFalse_WhenFreeSpaceUnknown()
     {
         Assert.That(DiskSpacePreflight.IsClearlyInsufficient(0, estimatedRequiredBytes: 1_000_000), Is.False);
@@ -56,26 +63,5 @@ public class DiskSpacePreflightTests
     {
         Assert.That(DiskSpacePreflight.IsClearlyInsufficient(4_999, estimatedRequiredBytes: 5_000), Is.True);
         Assert.That(DiskSpacePreflight.IsClearlyInsufficient(100, estimatedRequiredBytes: 1_000_000), Is.True);
-    }
-
-    [Test]
-    public void ShouldAbortBackup_CombinesEstimateAndFreeSpaceCheck()
-    {
-        var fileSizes = new List<double> { 8_000, 2_000 };
-
-        Assert.That(
-            DiskSpacePreflight.ShouldAbortBackup(freeSpaceBytes: 0, fileSizes, slackBytes: 100),
-            Is.False,
-            "Unknown free space must soft-skip");
-
-        Assert.That(
-            DiskSpacePreflight.ShouldAbortBackup(freeSpaceBytes: 50_000, fileSizes, slackBytes: 100),
-            Is.False,
-            "Enough free space must allow backup");
-
-        Assert.That(
-            DiskSpacePreflight.ShouldAbortBackup(freeSpaceBytes: 5_000, fileSizes, slackBytes: 100),
-            Is.True,
-            "Clearly insufficient free space must abort");
     }
 }

--- a/src/BSH.Test/DiskSpacePreflightTests.cs
+++ b/src/BSH.Test/DiskSpacePreflightTests.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Collections.Generic;
+using Brightbits.BSH.Engine.Utils;
+using NUnit.Framework;
+
+namespace BSH.Test;
+
+public class DiskSpacePreflightTests
+{
+    [Test]
+    public void EstimateRequiredBytes_SumsFileSizesAndAddsSlack()
+    {
+        var estimate = DiskSpacePreflight.EstimateRequiredBytes(
+            new[] { 1000d, 2000d, 3000d },
+            slackBytes: 100);
+
+        Assert.That(estimate, Is.EqualTo(6100));
+    }
+
+    [Test]
+    public void EstimateRequiredBytes_IgnoresNonPositiveSizes()
+    {
+        var estimate = DiskSpacePreflight.EstimateRequiredBytes(
+            new[] { 500d, 0d, -10d },
+            slackBytes: 50);
+
+        Assert.That(estimate, Is.EqualTo(550));
+    }
+
+    [Test]
+    public void EstimateRequiredBytes_UsesDefaultSlackWhenNotSpecified()
+    {
+        var estimate = DiskSpacePreflight.EstimateRequiredBytes(new[] { 1024d });
+
+        Assert.That(estimate, Is.EqualTo(1024 + DiskSpacePreflight.DefaultSlackBytes));
+    }
+
+    [Test]
+    public void IsClearlyInsufficient_ReturnsFalse_WhenFreeSpaceUnknown()
+    {
+        Assert.That(DiskSpacePreflight.IsClearlyInsufficient(0, estimatedRequiredBytes: 1_000_000), Is.False);
+        Assert.That(DiskSpacePreflight.IsClearlyInsufficient(-1, estimatedRequiredBytes: 1_000_000), Is.False);
+    }
+
+    [Test]
+    public void IsClearlyInsufficient_ReturnsFalse_WhenEnoughSpace()
+    {
+        Assert.That(DiskSpacePreflight.IsClearlyInsufficient(10_000, estimatedRequiredBytes: 5_000), Is.False);
+        Assert.That(DiskSpacePreflight.IsClearlyInsufficient(5_000, estimatedRequiredBytes: 5_000), Is.False);
+    }
+
+    [Test]
+    public void IsClearlyInsufficient_ReturnsTrue_WhenClearlyShort()
+    {
+        Assert.That(DiskSpacePreflight.IsClearlyInsufficient(4_999, estimatedRequiredBytes: 5_000), Is.True);
+        Assert.That(DiskSpacePreflight.IsClearlyInsufficient(100, estimatedRequiredBytes: 1_000_000), Is.True);
+    }
+
+    [Test]
+    public void ShouldAbortBackup_CombinesEstimateAndFreeSpaceCheck()
+    {
+        var fileSizes = new List<double> { 8_000, 2_000 };
+
+        Assert.That(
+            DiskSpacePreflight.ShouldAbortBackup(freeSpaceBytes: 0, fileSizes, slackBytes: 100),
+            Is.False,
+            "Unknown free space must soft-skip");
+
+        Assert.That(
+            DiskSpacePreflight.ShouldAbortBackup(freeSpaceBytes: 50_000, fileSizes, slackBytes: 100),
+            Is.False,
+            "Enough free space must allow backup");
+
+        Assert.That(
+            DiskSpacePreflight.ShouldAbortBackup(freeSpaceBytes: 5_000, fileSizes, slackBytes: 100),
+            Is.True,
+            "Clearly insufficient free space must abort");
+    }
+}


### PR DESCRIPTION
## Summary
- Add a rough disk-space preflight after file collection: sum candidate sizes + 16 MiB slack, abort only when free space is known and clearly short (0/negative = unknown soft-skip for FTP/WebDAV).
- Reuse the existing insufficient-space UI path; extract shared `RollbackIncompleteVersion` so abort/cancel/error cleanup is not duplicated in `BackupAsync`.
- Slim the preflight API to `EstimateRequiredBytes` + `IsClearlyInsufficient` (no thin wrapper / double estimate).

Closes #181

## Test plan
- [ ] Unit tests: `DiskSpacePreflightTests` (estimate, unknown free space soft-skip, clearly short abort)
- [ ] Local disk backup with artificially low free space → early abort + insufficient-space UI, no half-copied version
- [ ] Local disk backup with ample free space → proceeds normally
- [ ] FTP/WebDAV target (`GetFreeSpace` returns 0) → preflight soft-skips, backup continues