### PR TITLE
chore: reduce CI build warnings (assessment + targeted fixes)

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -250,3 +250,33 @@ dotnet_style_qualification_for_property = false:suggestion
 dotnet_style_qualification_for_field = false:suggestion
 dotnet_style_qualification_for_method = false:suggestion
 dotnet_style_qualification_for_event = false:suggestion
+
+# WinForms/WinUI designer stubs: the components field is often unused when there is no IContainer usage.
+[*.{Designer.cs,designer.cs}]
+dotnet_diagnostic.CS0649.severity = none
+
+# Win32 / COM interop names intentionally match native APIs (RECT, LOGFONT, MSG, etc.).
+[**/COMInterop/**.cs]
+dotnet_diagnostic.S101.severity = none
+dotnet_diagnostic.S2342.severity = none
+dotnet_diagnostic.S2346.severity = none
+
+[**/Win32.cs]
+dotnet_diagnostic.S101.severity = none
+dotnet_diagnostic.S2342.severity = none
+dotnet_diagnostic.S2346.severity = none
+dotnet_diagnostic.S1939.severity = none
+dotnet_diagnostic.S4200.severity = none
+
+[**/WinInvoke32.cs]
+dotnet_diagnostic.S101.severity = none
+dotnet_diagnostic.S4200.severity = none
+dotnet_diagnostic.S1118.severity = none
+
+# Existing encrypted backups require PBKDF2 with 1000 iterations; raising it would break decrypt.
+[**/Security/Encryption.cs]
+dotnet_diagnostic.S5344.severity = none
+
+# Generated WinUI binding code; obsolescence of Window.Icon is upstream.
+[**/XamlTypeInfo.g.cs]
+dotnet_diagnostic.CS0618.severity = none

--- a/src/BSH.Engine/BSH.Engine.csproj
+++ b/src/BSH.Engine/BSH.Engine.csproj
@@ -61,9 +61,6 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" />
     <PackageReference Include="System.Management" Version="10.0.1" />
-    <PackageReference Include="System.Net.Primitives">
-      <Version>4.3.1</Version>
-    </PackageReference>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.1" />
     <PackageReference Include="ServiceWire" Version="5.6.0" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.1" />

--- a/src/BSH.Engine/Security/Encryption.cs
+++ b/src/BSH.Engine/Security/Encryption.cs
@@ -19,12 +19,13 @@ public class Encryption
             using var InFileStream = new FileStream(sourceFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             using FileStream OutFileStream = new(targetFile, FileMode.Create);
 
-            var key = new Rfc2898DeriveBytes(password, mKeySalt, 1000, HashAlgorithmName.SHA1);
-            var iv = new Rfc2898DeriveBytes(password, mIVSalt, 1000, HashAlgorithmName.SHA1);
+            // Iteration count must stay at 1000 to remain compatible with existing encrypted backups.
+            var key = Rfc2898DeriveBytes.Pbkdf2(password, mKeySalt, 1000, HashAlgorithmName.SHA1, 32);
+            var iv = Rfc2898DeriveBytes.Pbkdf2(password, mIVSalt, 1000, HashAlgorithmName.SHA1, 16);
 
             var aes = Aes.Create();
 
-            using var CryptStream = new CryptoStream(OutFileStream, aes.CreateEncryptor(key.GetBytes(32), iv.GetBytes(16)), CryptoStreamMode.Write); // 16,24,32
+            using var CryptStream = new CryptoStream(OutFileStream, aes.CreateEncryptor(key, iv), CryptoStreamMode.Write); // 16,24,32
             InFileStream.CopyTo(CryptStream, bufferSize);
 
             return true;
@@ -42,11 +43,12 @@ public class Encryption
             using var InFileStream = new FileStream(sourceFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             using var OutFileStream = new FileStream(targetFile, FileMode.Create);
 
-            var key = new Rfc2898DeriveBytes(password, mKeySalt, 1000, HashAlgorithmName.SHA1);
-            var iv = new Rfc2898DeriveBytes(password, mIVSalt, 1000, HashAlgorithmName.SHA1);
+            // Iteration count must stay at 1000 to remain compatible with existing encrypted backups.
+            var key = Rfc2898DeriveBytes.Pbkdf2(password, mKeySalt, 1000, HashAlgorithmName.SHA1, 32);
+            var iv = Rfc2898DeriveBytes.Pbkdf2(password, mIVSalt, 1000, HashAlgorithmName.SHA1, 16);
 
             var aes = Aes.Create();
-            using var CryptStream = new CryptoStream(OutFileStream, aes.CreateDecryptor(key.GetBytes(32), iv.GetBytes(16)), CryptoStreamMode.Write);
+            using var CryptStream = new CryptoStream(OutFileStream, aes.CreateDecryptor(key, iv), CryptoStreamMode.Write);
 
             InFileStream.CopyTo(CryptStream, bufferSize);
 

--- a/src/BSH.Engine/packages.lock.json
+++ b/src/BSH.Engine/packages.lock.json
@@ -92,16 +92,6 @@
           "System.CodeDom": "10.0.1"
         }
       },
-      "System.Net.Primitives": {
-        "type": "Direct",
-        "requested": "[4.3.1, )",
-        "resolved": "4.3.1",
-        "contentHash": "OHzPhSme78BbmLe9UBxHM69ZYjClS5URuhce6Ta4ikiLgaUGiG/X84fZpI6zy7CsUH5R9cYzI2tv9dWPqdTkUg==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.1",
-          "Microsoft.NETCore.Targets": "1.1.3"
-        }
-      },
       "System.Security.Cryptography.ProtectedData": {
         "type": "Direct",
         "requested": "[10.0.1, )",
@@ -144,16 +134,6 @@
         "type": "Transitive",
         "resolved": "10.0.0",
         "contentHash": "inRnbpCS0nwO/RuoZIAqxQUuyjaknOOnCEZB55KSMMjRhl0RQDttSmLSGsUJN3RQ3ocf5NDLFd2mOQViHqMK5w=="
-      },
-      "Microsoft.NETCore.Platforms": {
-        "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "TMBuzAHpTenGbGgk0SMTwyEkyijY/Eae4ZGsFNYJvAr/LDn1ku3Etp3FPxChmDp5HHF3kzJuoaa08N0xjqAJfQ=="
-      },
-      "Microsoft.NETCore.Targets": {
-        "type": "Transitive",
-        "resolved": "1.1.3",
-        "contentHash": "3Wrmi0kJDzClwAC+iBdUBpEKmEle8FQNsCs77fkiOIw/9oYA07bL1EZNX0kQ2OMN3xpwvl0vAtOCYY3ndDNlhQ=="
       },
       "Stub.System.Data.SQLite.Core.NetStandard": {
         "type": "Transitive",

--- a/src/BSH.Main/Dialogs/frmMainTabs/ucDoConfigure.cs
+++ b/src/BSH.Main/Dialogs/frmMainTabs/ucDoConfigure.cs
@@ -299,8 +299,8 @@ public partial class ucDoConfigure : IMainTabs
                     // start backup
                     await BackupLogic.StartSystemAsync(true);
 
-                    // create first backup
-                    BackupLogic.BackupController.CreateBackupAsync(Resources.BACKUP_TITLE_FIRST, "", false);
+                    // create first backup (fire-and-forget; balloon notifies the user)
+                    _ = BackupLogic.BackupController.CreateBackupAsync(Resources.BACKUP_TITLE_FIRST, "", false);
                     NotificationController.Current.ShowIconBalloon(5000, Resources.INFO_BACKUP_FIRST_RUN_TITLE, Resources.INFO_BACKUP_FIRST_RUN_TEXT, ToolTipIcon.Info);
                 }
 

--- a/src/BSH.Main/Program.cs
+++ b/src/BSH.Main/Program.cs
@@ -206,8 +206,8 @@ static class Program
             Task.Run(BackupLogic.CommandAutoDelete).GetAwaiter().GetResult();
         }
 
-        // create manual backup
-        BackupLogic.BackupController.CreateBackupAsync(opts.Title, opts.Description, true, shutdownPC: opts.ShutdownPC, shutdownApp: opts.ShutdownApp);
+        // create manual backup (runs while Application.Run keeps the process alive)
+        _ = BackupLogic.BackupController.CreateBackupAsync(opts.Title, opts.Description, true, shutdownPC: opts.ShutdownPC, shutdownApp: opts.ShutdownApp);
 
         return 0;
     }

--- a/src/BSH.Test/BSH.Test.csproj
+++ b/src/BSH.Test/BSH.Test.csproj
@@ -8,8 +8,9 @@
     <Configurations>Debug;Release;Windows 10</Configurations>
     <IsPublishable>False</IsPublishable>
     <WindowsAppSdkBootstrapInitialize>true</WindowsAppSdkBootstrapInitialize>
-    <Nullable>enable</Nullable>
     <Version>3.9.0.3</Version>
+    <!-- Tests use ? annotations when calling nullable-enabled app code, but the project itself is not nullable-enabled. -->
+    <NoWarn>$(NoWarn);CS8632</NoWarn>
   </PropertyGroup>
   <!-- in .csproj -->
   <PropertyGroup>

--- a/src/BSH.Test/BSH.Test.csproj
+++ b/src/BSH.Test/BSH.Test.csproj
@@ -8,6 +8,7 @@
     <Configurations>Debug;Release;Windows 10</Configurations>
     <IsPublishable>False</IsPublishable>
     <WindowsAppSdkBootstrapInitialize>true</WindowsAppSdkBootstrapInitialize>
+    <Nullable>enable</Nullable>
     <Version>3.9.0.3</Version>
   </PropertyGroup>
   <!-- in .csproj -->


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

Reviewed the latest successful main CI run: [Build pull requests #29660094533](https://github.com/alexsee/bsh3/actions/runs/29660094533) (~596 unique warnings; many appear twice in the log because restore/build/Sonar each emit them).

PR CI after first fix pass: [run 29662227451](https://github.com/alexsee/bsh3/actions/runs/29662227451) — build succeeded.

## Assessment summary

| Bucket | Approx. unique (main) | Severity | Recommendation |
|---|---:|---|---|
| Sonar analyzer (`S*`) via SonarScanner | ~350 | Mostly style / maintainability | Track in SonarCloud; fix gradually or tune Quality Profile. Do **not** mass-refactor in one PR. |
| C# nullable (`CS86xx`, `CS8765`) | ~50 | Medium | Gradual nullable annotation work in MainApp/Service. |
| Designer unused field (`CS0649`) | 17 | Low / noise | Suppress for `*.Designer.cs` (done). |
| Test `?` without nullable context (`CS8632`) | 27 | Low | `NoWarn` CS8632 in test project (done). Enabling `<Nullable>` traded these for more CS8618/CS8625 in mocks. |
| Obsolete crypto ctor (`SYSLIB0060`) | 4 | Medium (API obsolescence) | Migrate to `Pbkdf2` with same params (done). |
| Unused package (`NU1510`) | 1 | Low | Remove `System.Net.Primitives` (done). |
| Unawaited tasks (`CS4014`) | 2 | Medium (intentional fire-and-forget) | Mark with `_ =` (done). |
| Generated obsolete Icon (`CS0618`) | 1 | Low / upstream | Suppress for `XamlTypeInfo.g.cs` (done). |
| Node `DEP0040` / `DEP0169` | Actions tooling | None for us | Ignore (GitHub Actions / cache action internals). |

### Sonar hotspots (highest volume, mostly not urgent)

- **S6678** (~112): log message template placeholders should be PascalCase (`{fileName}` → `{FileName}`). Safe mechanical cleanup later.
- **S3776** (~54): cognitive complexity (BackupJob, CPSD, RestoreJob, …). Real refactors; leave for focused PRs.
- **S2325** (~46): members that can be `static`. Easy cleanup later.
- **S1075** (~44): hardcoded path delimiters. Often intentional on Windows.
- **S1192** (~42): duplicated string literals. Nice-to-have constants.
- **S101 / S2342 / S4200**: Win32/COM naming & P/Invoke visibility. Renaming would fight native API names — suppressed for interop files (done).
- **S5344 / S4790**: crypto strength (PBKDF2 iterations / MD5). **Do not “fix” blindly** — changing iterations/hash breaks existing encrypted backups. S5344 suppressed for `Encryption.cs` with comment (done).
- **S3881 / S2486 / S108**: dispose pattern / empty catches in VSS code. Worth a dedicated cleanup, not urgent for CI noise.

### Remaining C# nullable work (not in this PR)

`CS8618` / `CS860*` / `CS8765` in `BSH.MainApp` and `BSH.Service` are real but touch many models/viewmodels. Best fixed project-by-project with `string?` / `event EventHandler?` / `required` where appropriate.

## What this PR changes

1. Remove unused `System.Net.Primitives` package (**NU1510**).
2. Switch `Encryption` to `Rfc2898DeriveBytes.Pbkdf2(...)` (**SYSLIB0060**), keeping **1000 iterations + SHA1** for backup compatibility.
3. Suppress **CS8632** in `BSH.Test` (tests already use `?` when calling nullable app APIs).
4. Mark intentional fire-and-forget `CreateBackupAsync` calls with `_ =` (**CS4014**).
5. `.editorconfig` suppressions for Designer `CS0649`, Win32/COM Sonar naming noise, Encryption `S5344`, and generated `CS0618`.

## Suggested follow-ups (separate PRs)

1. Mechanical **S6678** log placeholder PascalCase rename.
2. Nullable annotation pass on `BSH.Service` VSS types (`CS8618`/`CS8625`).
3. SonarCloud Quality Profile: demote Win32 naming / complexity rules if CI log noise is the main concern.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f772e-aedf-7156-aecc-d86b40299541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f772e-aedf-7156-aecc-d86b40299541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

