### PR TITLE
test: RestoreJob coverage + release CI test gate

### DIFF
--- a/.github/workflows/dotnet-desktop-release.yml
+++ b/.github/workflows/dotnet-desktop-release.yml
@@ -47,6 +47,114 @@ jobs:
       run: dotnet restore "Backup Service Home 3.sln" --locked-mode -a x64
       working-directory: ./src
 
+    - name: Install Windows App Runtime for tests
+      shell: pwsh
+      working-directory: ./src
+      run: |
+        $ErrorActionPreference = "Stop"
+        $PSNativeCommandUseErrorActionPreference = $true
+
+        # WinUI tests run inside testhost.exe. Register the exact Windows App
+        # Runtime version restored from the NuGet lock file before loading them.
+        $lockFile = Get-Content "BSH.MainApp\packages.lock.json" -Raw |
+          ConvertFrom-Json
+
+        $runtimeVersions = @(
+          $lockFile.dependencies.PSObject.Properties.Value |
+            ForEach-Object {
+              $runtimeDependency =
+                $_.PSObject.Properties["Microsoft.WindowsAppSDK.Runtime"]
+
+              if ($runtimeDependency) {
+                $runtimeDependency.Value.resolved
+              }
+            } |
+            Sort-Object -Unique
+        )
+
+        if ($runtimeVersions.Count -ne 1) {
+          throw "Expected exactly one Microsoft.WindowsAppSDK.Runtime version, found: $($runtimeVersions -join ', ')"
+        }
+
+        $runtimeMsixPath = Join-Path $env:USERPROFILE `
+          ".nuget\packages\microsoft.windowsappsdk.runtime\$($runtimeVersions[0])\tools\MSIX\win10-x64"
+
+        $inventoryPath = Join-Path $runtimeMsixPath "MSIX.inventory"
+
+        if (-not (Test-Path $inventoryPath)) {
+          throw "Windows App Runtime package inventory was not found at $inventoryPath"
+        }
+
+        $runtimePackages = @{}
+
+        foreach ($inventoryEntry in Get-Content $inventoryPath) {
+          $packageFile, $packageFullName = $inventoryEntry -split "=", 2
+          $runtimePackages[$packageFile] = $packageFullName
+        }
+
+        $frameworkPackage = @(
+          $runtimePackages.Keys |
+            Where-Object {
+              $_ -match '^Microsoft\.WindowsAppRuntime\.\d+\.msix$'
+            }
+        )
+
+        $installOrder = @(
+          $frameworkPackage
+          @(
+            $runtimePackages.Keys |
+              Where-Object { $_ -match '\.Main\.\d+\.msix$' }
+          )
+          @(
+            $runtimePackages.Keys |
+              Where-Object { $_ -match '\.Singleton\.\d+\.msix$' }
+          )
+          @(
+            $runtimePackages.Keys |
+              Where-Object { $_ -match '\.DDLM\.\d+\.msix$' }
+          )
+        )
+
+        if ($installOrder.Count -ne $runtimePackages.Count) {
+          throw "Could not determine a safe installation order for every Windows App Runtime package."
+        }
+
+        $installedPackages = @(
+          Get-AppxPackage |
+            Select-Object -ExpandProperty PackageFullName
+        )
+
+        foreach ($packageFile in $installOrder) {
+          if ($installedPackages -contains $runtimePackages[$packageFile]) {
+            continue
+          }
+
+          Add-AppxPackage -Path (Join-Path $runtimeMsixPath $packageFile)
+        }
+
+    - name: Build and test
+      shell: pwsh
+      working-directory: ./src
+      run: |
+        $ErrorActionPreference = "Stop"
+        $PSNativeCommandUseErrorActionPreference = $true
+
+        dotnet build "Backup Service Home 3.sln" `
+          --configuration Release `
+          --no-restore `
+          -p:Platform=x64
+
+        # Fail the release before packaging if the suite is red.
+        dotnet test "$env:Test_Project_Path" `
+          --configuration Release `
+          --no-build `
+          --no-restore `
+          -p:Platform=x64 `
+          --blame-hang `
+          --blame-hang-timeout 2m
+      env:
+        Test_Project_Path: BSH.Test\BSH.Test.csproj
+
     - name: Build the application
       run: |
         dotnet publish -c Release -o ../output -a x64 --self-contained --no-restore /p:Version=$env:BUILD_VERSION /p:FileVersion=$env:INFO_VERSION

--- a/src/BSH.Test/Integration/FileSystemRestoreIntegrationTests.cs
+++ b/src/BSH.Test/Integration/FileSystemRestoreIntegrationTests.cs
@@ -14,6 +14,7 @@ using Brightbits.BSH.Engine.Database;
 using Brightbits.BSH.Engine.Jobs;
 using Brightbits.BSH.Engine.Providers.Ports;
 using Brightbits.BSH.Engine.Repo;
+using Brightbits.BSH.Engine.Security;
 using Brightbits.BSH.Engine.Services.FileCollector;
 using Brightbits.BSH.Engine.Storage;
 using BSH.Test.Mocks;
@@ -131,7 +132,7 @@ public class FileSystemRestoreIntegrationTests
     public async Task BackupAndRestore_EncryptedContentMatches()
     {
         configurationManager.Encrypt = 1;
-        configurationManager.EncryptPassMD5 = Brightbits.BSH.Engine.Security.Hash.GetMD5Hash(Password);
+        configurationManager.EncryptPassMD5 = Hash.GetMD5Hash(Password);
         WriteSourceFile("secret.txt", SampleContent + "-encrypted");
 
         await RunBackupAsync(password: Password);

--- a/src/BSH.Test/Integration/FileSystemRestoreIntegrationTests.cs
+++ b/src/BSH.Test/Integration/FileSystemRestoreIntegrationTests.cs
@@ -1,0 +1,245 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Brightbits.BSH.Engine;
+using Brightbits.BSH.Engine.Contracts;
+using Brightbits.BSH.Engine.Contracts.Database;
+using Brightbits.BSH.Engine.Contracts.Repo;
+using Brightbits.BSH.Engine.Contracts.Services;
+using Brightbits.BSH.Engine.Database;
+using Brightbits.BSH.Engine.Jobs;
+using Brightbits.BSH.Engine.Providers.Ports;
+using Brightbits.BSH.Engine.Repo;
+using Brightbits.BSH.Engine.Services.FileCollector;
+using Brightbits.BSH.Engine.Storage;
+using BSH.Test.Mocks;
+using NUnit.Framework;
+
+namespace BSH.Test.Integration;
+
+/// <summary>
+/// Real filesystem backup ↔ restore round-trips via <see cref="FileSystemStorage"/>.
+/// </summary>
+[Category("Integration")]
+public class FileSystemRestoreIntegrationTests
+{
+    private const string TestDbName = "testdb_fs_restore.db";
+    private const string SampleContent = "backup-service-home-integration-content-0123456789";
+    private const string Password = "test123";
+
+    private string rootDir;
+    private string sourceDir;
+    private string backupDir;
+    private string restoreDir;
+    private string dbPath;
+
+    private IDbClientFactory dbClientFactory;
+    private IConfigurationManager configurationManager;
+    private IQueryManager queryManager;
+    private IVersionQueryRepository versionQueryRepository;
+    private IBackupMutationRepository backupMutationRepository;
+    private IFileCollectorServiceFactory fileCollectorServiceFactory;
+    private VssClientMock vssClient;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        if (dbClientFactory != null)
+        {
+            DbClientFactory.ClosePool();
+            dbClientFactory = null;
+        }
+
+        rootDir = Path.Combine(Path.GetTempPath(), "BSH.Test", "fs-" + Guid.NewGuid().ToString("N"));
+        sourceDir = Path.Combine(rootDir, "source");
+        backupDir = Path.Combine(rootDir, "backup");
+        restoreDir = Path.Combine(rootDir, "restore");
+        dbPath = Path.Combine(rootDir, TestDbName);
+
+        Directory.CreateDirectory(sourceDir);
+        Directory.CreateDirectory(backupDir);
+        Directory.CreateDirectory(restoreDir);
+
+        dbClientFactory = new DbClientFactory();
+        await dbClientFactory.InitializeAsync(dbPath);
+
+        configurationManager = new ConfigurationManager(dbClientFactory);
+        await configurationManager.InitializeAsync();
+        configurationManager.BackupFolder = backupDir;
+        configurationManager.SourceFolder = sourceDir;
+        configurationManager.MediaVolumeSerial = "";
+        configurationManager.OldBackupPrevent = "0";
+
+        versionQueryRepository = new VersionQueryRepository();
+        backupMutationRepository = new BackupMutationRepository(dbClientFactory);
+        fileCollectorServiceFactory = new FileCollectorServiceFactory();
+        vssClient = new VssClientMock();
+
+        var storageFactory = new StorageFactory(configurationManager);
+        queryManager = new QueryManager(dbClientFactory, configurationManager, storageFactory);
+    }
+
+    [TearDown]
+    public void Cleanup()
+    {
+        DbClientFactory.ClosePool();
+
+        try
+        {
+            if (!string.IsNullOrEmpty(rootDir) && Directory.Exists(rootDir))
+            {
+                Directory.Delete(rootDir, recursive: true);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup on Windows file locks.
+        }
+    }
+
+    [Test]
+    public async Task BackupAndRestore_PlainContentMatches()
+    {
+        var sourceFile = WriteSourceFile("notes.txt", SampleContent);
+
+        await RunBackupAsync();
+        await RunRestoreAsync(overwrite: FileOverwrite.Overwrite);
+
+        var restoredFile = Path.Combine(restoreDir, Path.GetFileName(sourceFile));
+        Assert.That(File.Exists(restoredFile), Is.True);
+        Assert.That(File.ReadAllText(restoredFile), Is.EqualTo(SampleContent));
+    }
+
+    [Test]
+    public async Task BackupAndRestore_CompressedContentMatches()
+    {
+        configurationManager.Compression = 1;
+        WriteSourceFile("report.txt", SampleContent + "-compressed");
+
+        await RunBackupAsync();
+        await RunRestoreAsync(overwrite: FileOverwrite.Overwrite);
+
+        var restoredFile = Path.Combine(restoreDir, "report.txt");
+        Assert.That(File.ReadAllText(restoredFile), Is.EqualTo(SampleContent + "-compressed"));
+    }
+
+    [Test]
+    public async Task BackupAndRestore_EncryptedContentMatches()
+    {
+        configurationManager.Encrypt = 1;
+        configurationManager.EncryptPassMD5 = Brightbits.BSH.Engine.Security.Hash.GetMD5Hash(Password);
+        WriteSourceFile("secret.txt", SampleContent + "-encrypted");
+
+        await RunBackupAsync(password: Password);
+
+        var restoreJob = CreateRestoreJob(CreateStorage(), password: Password);
+        await restoreJob.RestoreAsync(CancellationToken.None);
+
+        Assert.That(restoreJob.FileErrorList, Is.Empty);
+        Assert.That(File.ReadAllText(Path.Combine(restoreDir, "secret.txt")), Is.EqualTo(SampleContent + "-encrypted"));
+    }
+
+    [Test]
+    public async Task IncrementalBackup_RestoreOlderAndNewerVersions()
+    {
+        var sourceFile = WriteSourceFile("doc.txt", "version-one-content-abcdefghijklmnopqrstuvwxyz");
+
+        await RunBackupAsync();
+        var version1 = await queryManager.GetLastBackupAsync();
+        Assert.That(version1, Is.Not.Null);
+
+        // Version dates are second-precision; wait so storage folders stay unique.
+        await Task.Delay(1100);
+
+        File.WriteAllText(sourceFile, "version-two-content-abcdefghijklmnopqrstuvwxyz");
+        File.SetLastWriteTimeUtc(sourceFile, DateTime.UtcNow.AddMinutes(1));
+
+        await RunBackupAsync();
+        var version2 = await queryManager.GetLastBackupAsync();
+        Assert.That(version2, Is.Not.Null);
+        Assert.That(version2.Id, Is.Not.EqualTo(version1.Id));
+
+        var restoreV1Dir = Path.Combine(restoreDir, "v1");
+        var restoreV2Dir = Path.Combine(restoreDir, "v2");
+        Directory.CreateDirectory(restoreV1Dir);
+        Directory.CreateDirectory(restoreV2Dir);
+
+        var storage = CreateStorage();
+        var restoreV1 = CreateRestoreJob(storage, version: int.Parse(version1.Id), destination: restoreV1Dir);
+        await restoreV1.RestoreAsync(CancellationToken.None);
+        Assert.That(restoreV1.FileErrorList, Is.Empty);
+        Assert.That(File.ReadAllText(Path.Combine(restoreV1Dir, "doc.txt")), Is.EqualTo("version-one-content-abcdefghijklmnopqrstuvwxyz"));
+
+        var restoreV2 = CreateRestoreJob(storage, version: int.Parse(version2.Id), destination: restoreV2Dir);
+        await restoreV2.RestoreAsync(CancellationToken.None);
+        Assert.That(restoreV2.FileErrorList, Is.Empty);
+        Assert.That(File.ReadAllText(Path.Combine(restoreV2Dir, "doc.txt")), Is.EqualTo("version-two-content-abcdefghijklmnopqrstuvwxyz"));
+    }
+
+    private async Task RunBackupAsync(string password = null)
+    {
+        var backupJob = new BackupJob(
+            CreateStorage(),
+            dbClientFactory,
+            queryManager,
+            configurationManager,
+            fileCollectorServiceFactory,
+            vssClient,
+            versionQueryRepository,
+            backupMutationRepository)
+        {
+            SourceFolder = sourceDir,
+            Title = "Integration",
+            Description = "",
+            Password = password,
+        };
+
+        await backupJob.BackupAsync(CancellationToken.None);
+
+        Assert.That(backupJob.FileErrorList, Is.Empty, "Backup reported file errors.");
+        var version = await queryManager.GetLastBackupAsync();
+        Assert.That(version, Is.Not.Null, "Backup did not create a version.");
+    }
+
+    private async Task RunRestoreAsync(FileOverwrite overwrite)
+    {
+        var restoreJob = CreateRestoreJob(CreateStorage(), overwrite: overwrite);
+        await restoreJob.RestoreAsync(CancellationToken.None);
+        Assert.That(restoreJob.FileErrorList, Is.Empty, "Restore reported file errors.");
+    }
+
+    private RestoreJob CreateRestoreJob(
+        IStorageProvider storage,
+        int version = 1,
+        string destination = null,
+        string password = null,
+        FileOverwrite overwrite = FileOverwrite.Overwrite)
+    {
+        return new RestoreJob(
+            storage,
+            dbClientFactory,
+            queryManager,
+            configurationManager,
+            versionQueryRepository)
+        {
+            Version = version,
+            File = @"\",
+            Destination = destination ?? restoreDir,
+            FileOverwrite = overwrite,
+            Password = password,
+        };
+    }
+
+    private IStorageProvider CreateStorage() => new FileSystemStorage(configurationManager);
+
+    private string WriteSourceFile(string fileName, string content)
+    {
+        var path = Path.Combine(sourceDir, fileName);
+        File.WriteAllText(path, content);
+        return path;
+    }
+}

--- a/src/BSH.Test/Mocks/StorageMock.cs
+++ b/src/BSH.Test/Mocks/StorageMock.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Alexander Seeliger. All Rights Reserved.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Brightbits.BSH.Engine.Providers.Ports;
 
@@ -13,25 +16,37 @@ namespace BSH.Test.Mocks
         private readonly bool failAllCopies;
         private readonly bool pathTooLong;
         private readonly bool throwIoOnFirstRegularCopy;
+        private readonly string throwOnRemoteContaining;
+        private readonly CancellationTokenSource cancelOnCopy;
         private int regularCopyAttempts;
 
         public StorageMock(
             bool failCheckMedium = false,
             bool failAllCopies = false,
             bool pathTooLong = false,
-            bool throwIoOnFirstRegularCopy = false)
+            bool throwIoOnFirstRegularCopy = false,
+            string throwOnRemoteContaining = null,
+            CancellationTokenSource cancelOnCopy = null)
         {
             this.failCheckMedium = failCheckMedium;
             this.failAllCopies = failAllCopies;
             this.pathTooLong = pathTooLong;
             this.throwIoOnFirstRegularCopy = throwIoOnFirstRegularCopy;
+            this.throwOnRemoteContaining = throwOnRemoteContaining;
+            this.cancelOnCopy = cancelOnCopy;
         }
 
         public StorageProviderKind Kind => StorageProviderKind.LocalFileSystem;
         public int CopyFileToStorageCalls { get; private set; }
         public int CopyFileToStorageCompressedCalls { get; private set; }
         public int CopyFileToStorageEncryptedCalls { get; private set; }
+        public int CopyFileFromStorageCalls { get; private set; }
+        public int CopyFileFromStorageCompressedCalls { get; private set; }
+        public int CopyFileFromStorageEncryptedCalls { get; private set; }
         public string LastRemoteFile { get; private set; }
+        public List<string> CopiedFromStorageRemoteFiles { get; } = [];
+        public List<string> CopiedFromStorageCompressedRemoteFiles { get; } = [];
+        public List<string> CopiedFromStorageEncryptedRemoteFiles { get; } = [];
 
         public bool CanWriteToStorage()
         {
@@ -45,17 +60,26 @@ namespace BSH.Test.Mocks
 
         public bool CopyFileFromStorage(string localFile, string remoteFile)
         {
-            return !failAllCopies;
+            return RecordCopyFromStorage(
+                CopiedFromStorageRemoteFiles,
+                () => CopyFileFromStorageCalls++,
+                remoteFile);
         }
 
         public bool CopyFileFromStorageCompressed(string localFile, string remoteFile)
         {
-            return !failAllCopies;
+            return RecordCopyFromStorage(
+                CopiedFromStorageCompressedRemoteFiles,
+                () => CopyFileFromStorageCompressedCalls++,
+                remoteFile);
         }
 
         public bool CopyFileFromStorageEncrypted(string localFile, string remoteFile, string password)
         {
-            return !failAllCopies;
+            return RecordCopyFromStorage(
+                CopiedFromStorageEncryptedRemoteFiles,
+                () => CopyFileFromStorageEncryptedCalls++,
+                remoteFile);
         }
 
         public bool CopyFileToStorage(string localFile, string remoteFile)
@@ -141,6 +165,21 @@ namespace BSH.Test.Mocks
         public bool UploadDatabaseFile(string databaseFile)
         {
             return true;
+        }
+
+        private bool RecordCopyFromStorage(List<string> remoteFiles, Action incrementCalls, string remoteFile)
+        {
+            if (!string.IsNullOrEmpty(throwOnRemoteContaining) &&
+                remoteFile.Contains(throwOnRemoteContaining, StringComparison.Ordinal))
+            {
+                throw new IOException("Simulated restore failure");
+            }
+
+            cancelOnCopy?.Cancel();
+            incrementCalls();
+            LastRemoteFile = remoteFile;
+            remoteFiles.Add(remoteFile);
+            return !failAllCopies;
         }
     }
 }

--- a/src/BSH.Test/RestoreTests.cs
+++ b/src/BSH.Test/RestoreTests.cs
@@ -18,13 +18,25 @@ using Brightbits.BSH.Engine.Models;
 using Brightbits.BSH.Engine.Providers.Ports;
 using Brightbits.BSH.Engine.Repo;
 using Brightbits.BSH.Engine.Storage;
+using BSH.Test.Mocks;
 using NUnit.Framework;
 
 namespace BSH.Test;
 
+/// <summary>
+/// Unit tests for <see cref="RestoreJob"/> using <see cref="StorageMock"/>.
+/// Content round-trips against real storage live in Integration tests.
+/// </summary>
 public class RestoreTests
 {
     private const string TestDbName = "testdb_restore.db";
+
+    /// <summary>
+    /// Synthetic destination used by most tests. RestoreJob may attempt
+    /// Directory.CreateDirectory / timestamp updates; those failures are ignored.
+    /// No files are written by StorageMock.
+    /// </summary>
+    private const string SyntheticDestination = @"Z:\BSH.Test.Restore";
 
     private IDbClientFactory dbClientFactory;
     private IConfigurationManager configurationManager;
@@ -71,7 +83,7 @@ public class RestoreTests
     [Test]
     public void TestFailMedium()
     {
-        var storage = new RecordingRestoreStorage(failCheckMedium: true);
+        var storage = new StorageMock(failCheckMedium: true);
         var restoreJob = CreateRestoreJob(storage);
 
         Assert.ThrowsAsync<DeviceNotReadyException>(async () => await restoreJob.RestoreAsync(CancellationToken.None));
@@ -86,21 +98,20 @@ public class RestoreTests
         await SeedFileForVersionAsync(2, 2, 1, "compressed.txt", @"\docs\", 2, "");
         await SeedFileForVersionAsync(3, 3, 1, "encrypted-long.txt", @"\docs\", 6, "very-long-file-name");
 
-        var destination = CreateTempDestination();
-        var storage = new RecordingRestoreStorage();
-        var restoreJob = CreateRestoreJob(storage, destination: destination, file: @"\");
+        var storage = new StorageMock();
+        var restoreJob = CreateRestoreJob(storage, file: @"\");
         restoreJob.Password = "test123";
 
         await restoreJob.RestoreAsync(CancellationToken.None);
 
         Assert.That(restoreJob.FileErrorList, Is.Empty);
-        Assert.That(storage.CopiedPlain, Has.Count.EqualTo(1));
-        Assert.That(storage.CopiedCompressed, Has.Count.EqualTo(1));
-        Assert.That(storage.CopiedEncrypted, Has.Count.EqualTo(1));
+        Assert.That(storage.CopyFileFromStorageCalls, Is.EqualTo(1));
+        Assert.That(storage.CopyFileFromStorageCompressedCalls, Is.EqualTo(1));
+        Assert.That(storage.CopyFileFromStorageEncryptedCalls, Is.EqualTo(1));
 
-        Assert.That(storage.CopiedPlain[0].RemoteFile, Is.EqualTo(versionDate + @"\docs\" + "plain.txt"));
-        Assert.That(storage.CopiedCompressed[0].RemoteFile, Is.EqualTo(versionDate + @"\docs\" + "compressed.txt"));
-        Assert.That(storage.CopiedEncrypted[0].RemoteFile, Is.EqualTo(Path.Combine(versionDate, "_LONGFILES_", "very-long-file-name")));
+        Assert.That(storage.CopiedFromStorageRemoteFiles[0], Is.EqualTo(versionDate + @"\docs\" + "plain.txt"));
+        Assert.That(storage.CopiedFromStorageCompressedRemoteFiles[0], Is.EqualTo(versionDate + @"\docs\" + "compressed.txt"));
+        Assert.That(storage.CopiedFromStorageEncryptedRemoteFiles[0], Is.EqualTo(Path.Combine(versionDate, "_LONGFILES_", "very-long-file-name")));
     }
 
     [Test]
@@ -111,14 +122,14 @@ public class RestoreTests
         await SeedFileForVersionAsync(1, 1, 1, "plain.txt", @"\docs\", 1, "");
         await SeedFileForVersionAsync(2, 2, 1, "other.txt", @"\docs\", 1, "");
 
-        var destination = CreateTempDestination();
-        var storage = new RecordingRestoreStorage();
-        var restoreJob = CreateRestoreJob(storage, destination: destination, file: @"\docs\plain.txt");
+        var storage = new StorageMock();
+        var restoreJob = CreateRestoreJob(storage, file: @"\docs\plain.txt");
 
         await restoreJob.RestoreAsync(CancellationToken.None);
 
-        Assert.That(storage.CopiedPlain, Has.Count.EqualTo(1));
-        Assert.That(storage.CopiedPlain[0].RemoteFile, Does.Contain("plain.txt"));
+        Assert.That(storage.CopyFileFromStorageCalls, Is.EqualTo(1));
+        Assert.That(storage.CopiedFromStorageRemoteFiles[0], Does.Contain("plain.txt"));
+        Assert.That(storage.CopiedFromStorageRemoteFiles[0], Does.Not.Contain("other.txt"));
     }
 
     [Test]
@@ -128,39 +139,32 @@ public class RestoreTests
         await SeedVersionAsync(1, versionDate);
         await SeedFileForVersionAsync(1, 1, 1, "plain.txt", @"\docs\", 1, "");
 
-        var destination = CreateTempDestination();
-        Directory.CreateDirectory(destination);
-        var existingPath = Path.Combine(destination, "plain.txt");
-        File.WriteAllText(existingPath, "local-content");
+        // RestoreJob gates overwrite on File.Exists — only local touch needed for this path.
+        var destination = CreateExistingDestinationFile("plain.txt");
 
-        var storage = new RecordingRestoreStorage();
+        var storage = new StorageMock();
         var restoreJob = CreateRestoreJob(storage, destination: destination, file: @"\", overwrite: FileOverwrite.DontCopy);
 
         await restoreJob.RestoreAsync(CancellationToken.None);
 
-        Assert.That(storage.CopiedPlain, Is.Empty);
-        Assert.That(File.ReadAllText(existingPath), Is.EqualTo("local-content"));
+        Assert.That(storage.CopyFileFromStorageCalls, Is.EqualTo(0));
     }
 
     [Test]
-    public async Task TestOverwritePolicyReplacesExistingFile()
+    public async Task TestOverwritePolicyCopiesWhenExistingFilePresent()
     {
         const string versionDate = "01-01-2021 00-00-00";
         await SeedVersionAsync(1, versionDate);
         await SeedFileForVersionAsync(1, 1, 1, "plain.txt", @"\docs\", 1, "");
 
-        var destination = CreateTempDestination();
-        Directory.CreateDirectory(destination);
-        var existingPath = Path.Combine(destination, "plain.txt");
-        File.WriteAllText(existingPath, "local-content");
+        var destination = CreateExistingDestinationFile("plain.txt");
 
-        var storage = new RecordingRestoreStorage(writeRestoredContent: "restored-content");
+        var storage = new StorageMock();
         var restoreJob = CreateRestoreJob(storage, destination: destination, file: @"\", overwrite: FileOverwrite.Overwrite);
 
         await restoreJob.RestoreAsync(CancellationToken.None);
 
-        Assert.That(storage.CopiedPlain, Has.Count.EqualTo(1));
-        Assert.That(File.ReadAllText(existingPath), Is.EqualTo("restored-content"));
+        Assert.That(storage.CopyFileFromStorageCalls, Is.EqualTo(1));
     }
 
     [Test]
@@ -170,12 +174,9 @@ public class RestoreTests
         await SeedVersionAsync(1, versionDate);
         await SeedFileForVersionAsync(1, 1, 1, "plain.txt", @"\docs\", 1, "");
 
-        var destination = CreateTempDestination();
-        Directory.CreateDirectory(destination);
-        var existingPath = Path.Combine(destination, "plain.txt");
-        File.WriteAllText(existingPath, "local-content");
+        var destination = CreateExistingDestinationFile("plain.txt");
 
-        var storage = new RecordingRestoreStorage();
+        var storage = new StorageMock();
         var restoreJob = CreateRestoreJob(storage, destination: destination, file: @"\", overwrite: FileOverwrite.Ask);
         var observer = new JobReportStub { OverwriteResult = RequestOverwriteResult.NoOverwrite };
         restoreJob.AddObserver(observer);
@@ -183,8 +184,7 @@ public class RestoreTests
         await restoreJob.RestoreAsync(CancellationToken.None);
 
         Assert.That(observer.RequestOverwriteCalls, Is.EqualTo(1));
-        Assert.That(storage.CopiedPlain, Is.Empty);
-        Assert.That(File.ReadAllText(existingPath), Is.EqualTo("local-content"));
+        Assert.That(storage.CopyFileFromStorageCalls, Is.EqualTo(0));
     }
 
     [Test]
@@ -194,10 +194,9 @@ public class RestoreTests
         await SeedVersionAsync(1, versionDate);
         await SeedFileForVersionAsync(1, 1, 1, "plain.txt", @"\docs\", 1, "");
 
-        var destination = CreateTempDestination();
         using var cts = new CancellationTokenSource();
-        var storage = new RecordingRestoreStorage(cancelOnCopy: cts);
-        var restoreJob = CreateRestoreJob(storage, destination: destination, file: @"\");
+        var storage = new StorageMock(cancelOnCopy: cts);
+        var restoreJob = CreateRestoreJob(storage, file: @"\");
         var observer = new JobReportStub();
         restoreJob.AddObserver(observer);
 
@@ -215,17 +214,16 @@ public class RestoreTests
         await SeedFileForVersionAsync(1, 1, 1, "fails.txt", @"\docs\", 1, "");
         await SeedFileForVersionAsync(2, 2, 1, "ok.txt", @"\docs\", 1, "");
 
-        var destination = CreateTempDestination();
-        var storage = new RecordingRestoreStorage(throwOnRemoteContaining: "fails.txt");
-        var restoreJob = CreateRestoreJob(storage, destination: destination, file: @"\");
+        var storage = new StorageMock(throwOnRemoteContaining: "fails.txt");
+        var restoreJob = CreateRestoreJob(storage, file: @"\");
         var observer = new JobReportStub();
         restoreJob.AddObserver(observer);
 
         await restoreJob.RestoreAsync(CancellationToken.None);
 
         Assert.That(restoreJob.FileErrorList.Count, Is.EqualTo(1));
-        Assert.That(storage.CopiedPlain, Has.Count.EqualTo(1));
-        Assert.That(storage.CopiedPlain[0].RemoteFile, Does.Contain("ok.txt"));
+        Assert.That(storage.CopyFileFromStorageCalls, Is.EqualTo(1));
+        Assert.That(storage.CopiedFromStorageRemoteFiles[0], Does.Contain("ok.txt"));
         Assert.That(observer.ReportedStates, Does.Contain(JobState.ERROR));
     }
 
@@ -246,24 +244,23 @@ public class RestoreTests
         await dbClientFactory.ExecuteNonQueryAsync(
             "INSERT INTO filelink (fileversionID, versionID) VALUES (2, 2)");
 
-        var destination = CreateTempDestination();
-        var storage = new RecordingRestoreStorage();
+        var storage = new StorageMock();
 
-        var restoreV1 = CreateRestoreJob(storage, version: 1, destination: destination, file: @"\");
+        var restoreV1 = CreateRestoreJob(storage, version: 1, file: @"\");
         await restoreV1.RestoreAsync(CancellationToken.None);
 
-        var restoreV2 = CreateRestoreJob(storage, version: 2, destination: destination, file: @"\", overwrite: FileOverwrite.Overwrite);
+        var restoreV2 = CreateRestoreJob(storage, version: 2, file: @"\", overwrite: FileOverwrite.Overwrite);
         await restoreV2.RestoreAsync(CancellationToken.None);
 
-        Assert.That(storage.CopiedPlain, Has.Count.EqualTo(2));
-        Assert.That(storage.CopiedPlain[0].RemoteFile, Is.EqualTo(versionDate1 + @"\docs\" + "doc.txt"));
-        Assert.That(storage.CopiedPlain[1].RemoteFile, Is.EqualTo(versionDate2 + @"\docs\" + "doc.txt"));
+        Assert.That(storage.CopyFileFromStorageCalls, Is.EqualTo(2));
+        Assert.That(storage.CopiedFromStorageRemoteFiles[0], Is.EqualTo(versionDate1 + @"\docs\" + "doc.txt"));
+        Assert.That(storage.CopiedFromStorageRemoteFiles[1], Is.EqualTo(versionDate2 + @"\docs\" + "doc.txt"));
     }
 
     private RestoreJob CreateRestoreJob(
         IStorageProvider storage,
         int version = 1,
-        string destination = null,
+        string destination = SyntheticDestination,
         string file = @"\",
         FileOverwrite overwrite = FileOverwrite.Overwrite)
     {
@@ -305,11 +302,15 @@ public class RestoreTests
             $"INSERT INTO filelink (fileversionID, versionID) VALUES ({fileVersionId}, {versionId})");
     }
 
-    private static string CreateTempDestination()
+    /// <summary>
+    /// Creates a real destination file only where RestoreJob checks File.Exists for overwrite policy.
+    /// </summary>
+    private static string CreateExistingDestinationFile(string fileName)
     {
-        var path = Path.Combine(Path.GetTempPath(), "BSH.Test", "restore-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(path);
-        return path;
+        var destination = Path.Combine(Path.GetTempPath(), "BSH.Test", "restore-unit-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(destination);
+        File.WriteAllText(Path.Combine(destination, fileName), "existing");
+        return destination;
     }
 
     private sealed class JobReportStub : IJobReport
@@ -330,99 +331,6 @@ public class RestoreTests
         {
             RequestOverwriteCalls++;
             return Task.FromResult(OverwriteResult);
-        }
-    }
-
-    private sealed class RecordingRestoreStorage : IStorageProvider
-    {
-        private readonly bool failCheckMedium;
-        private readonly string throwOnRemoteContaining;
-        private readonly string writeRestoredContent;
-        private readonly CancellationTokenSource cancelOnCopy;
-
-        public RecordingRestoreStorage(
-            bool failCheckMedium = false,
-            string throwOnRemoteContaining = null,
-            string writeRestoredContent = null,
-            CancellationTokenSource cancelOnCopy = null)
-        {
-            this.failCheckMedium = failCheckMedium;
-            this.throwOnRemoteContaining = throwOnRemoteContaining;
-            this.writeRestoredContent = writeRestoredContent;
-            this.cancelOnCopy = cancelOnCopy;
-        }
-
-        public StorageProviderKind Kind => StorageProviderKind.LocalFileSystem;
-        public List<(string LocalFile, string RemoteFile)> CopiedPlain { get; } = [];
-        public List<(string LocalFile, string RemoteFile)> CopiedCompressed { get; } = [];
-        public List<(string LocalFile, string RemoteFile, string Password)> CopiedEncrypted { get; } = [];
-
-        public Task<bool> CheckMedium(bool quickCheck = false) => Task.FromResult(!failCheckMedium);
-        public void Open() { }
-        public bool CanWriteToStorage() => true;
-        public bool CopyFileToStorage(string localFile, string remoteFile) => true;
-        public bool CopyFileToStorageCompressed(string localFile, string remoteFile) => true;
-        public bool CopyFileToStorageEncrypted(string localFile, string remoteFile, string password) => true;
-        public bool DecryptOnStorage(string remoteFile, string password) => true;
-        public bool DeleteFileFromStorage(string remoteFile) => true;
-        public bool DeleteFileFromStorageCompressed(string remoteFile) => true;
-        public bool DeleteFileFromStorageEncrypted(string remoteFile) => true;
-        public bool DeleteDirectory(string remoteDirectory) => true;
-        public bool RenameDirectory(string remoteDirectorySource, string remoteDirectoryTarget) => true;
-        public bool UploadDatabaseFile(string databaseFile) => true;
-        public void UpdateStorageVersion(int versionId) { }
-        public bool IsPathTooLong(string path, bool compression, bool encryption) => false;
-        public long GetFreeSpace() => 0;
-        public void Dispose() { }
-
-        public bool CopyFileFromStorage(string localFile, string remoteFile)
-        {
-            return CopyFromStorage(CopiedPlain, localFile, remoteFile);
-        }
-
-        public bool CopyFileFromStorageCompressed(string localFile, string remoteFile)
-        {
-            return CopyFromStorage(CopiedCompressed, localFile, remoteFile);
-        }
-
-        public bool CopyFileFromStorageEncrypted(string localFile, string remoteFile, string password)
-        {
-            if (!string.IsNullOrEmpty(throwOnRemoteContaining) && remoteFile.Contains(throwOnRemoteContaining, StringComparison.Ordinal))
-            {
-                throw new IOException("Simulated restore failure");
-            }
-
-            cancelOnCopy?.Cancel();
-            WriteRestoredContentIfRequested(localFile);
-            CopiedEncrypted.Add((localFile, remoteFile, password));
-            return true;
-        }
-
-        private bool CopyFromStorage(
-            List<(string LocalFile, string RemoteFile)> target,
-            string localFile,
-            string remoteFile)
-        {
-            if (!string.IsNullOrEmpty(throwOnRemoteContaining) && remoteFile.Contains(throwOnRemoteContaining, StringComparison.Ordinal))
-            {
-                throw new IOException("Simulated restore failure");
-            }
-
-            cancelOnCopy?.Cancel();
-            WriteRestoredContentIfRequested(localFile);
-            target.Add((localFile, remoteFile));
-            return true;
-        }
-
-        private void WriteRestoredContentIfRequested(string localFile)
-        {
-            if (writeRestoredContent == null)
-            {
-                return;
-            }
-
-            Directory.CreateDirectory(Path.GetDirectoryName(localFile)!);
-            File.WriteAllText(localFile, writeRestoredContent);
         }
     }
 }

--- a/src/BSH.Test/RestoreTests.cs
+++ b/src/BSH.Test/RestoreTests.cs
@@ -1,0 +1,428 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Brightbits.BSH.Engine;
+using Brightbits.BSH.Engine.Contracts;
+using Brightbits.BSH.Engine.Contracts.Database;
+using Brightbits.BSH.Engine.Contracts.Repo;
+using Brightbits.BSH.Engine.Database;
+using Brightbits.BSH.Engine.Exceptions;
+using Brightbits.BSH.Engine.Jobs;
+using Brightbits.BSH.Engine.Models;
+using Brightbits.BSH.Engine.Providers.Ports;
+using Brightbits.BSH.Engine.Repo;
+using Brightbits.BSH.Engine.Storage;
+using NUnit.Framework;
+
+namespace BSH.Test;
+
+public class RestoreTests
+{
+    private const string TestDbName = "testdb_restore.db";
+
+    private IDbClientFactory dbClientFactory;
+    private IConfigurationManager configurationManager;
+    private IQueryManager queryManager;
+    private IVersionQueryRepository versionQueryRepository;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        if (dbClientFactory != null)
+        {
+            DbClientFactory.ClosePool();
+            dbClientFactory = null;
+        }
+
+        if (File.Exists(TestDbName))
+        {
+            File.Delete(TestDbName);
+        }
+
+        dbClientFactory = new DbClientFactory();
+        await dbClientFactory.InitializeAsync(Path.Combine(Environment.CurrentDirectory, TestDbName));
+
+        configurationManager = new ConfigurationManager(dbClientFactory);
+        await configurationManager.InitializeAsync();
+
+        versionQueryRepository = new VersionQueryRepository();
+
+        var storageFactory = new StorageFactory(configurationManager);
+        queryManager = new QueryManager(dbClientFactory, configurationManager, storageFactory);
+    }
+
+    [TearDown]
+    public void Cleanup()
+    {
+        DbClientFactory.ClosePool();
+
+        if (File.Exists(TestDbName))
+        {
+            File.Delete(TestDbName);
+        }
+    }
+
+    [Test]
+    public void TestFailMedium()
+    {
+        var storage = new RecordingRestoreStorage(failCheckMedium: true);
+        var restoreJob = CreateRestoreJob(storage);
+
+        Assert.ThrowsAsync<DeviceNotReadyException>(async () => await restoreJob.RestoreAsync(CancellationToken.None));
+    }
+
+    [Test]
+    public async Task TestRestoreRoutesByFileType()
+    {
+        const string versionDate = "01-01-2021 00-00-00";
+        await SeedVersionAsync(1, versionDate);
+        await SeedFileForVersionAsync(1, 1, 1, "plain.txt", @"\docs\", 1, "");
+        await SeedFileForVersionAsync(2, 2, 1, "compressed.txt", @"\docs\", 2, "");
+        await SeedFileForVersionAsync(3, 3, 1, "encrypted-long.txt", @"\docs\", 6, "very-long-file-name");
+
+        var destination = CreateTempDestination();
+        var storage = new RecordingRestoreStorage();
+        var restoreJob = CreateRestoreJob(storage, destination: destination, file: @"\");
+        restoreJob.Password = "test123";
+
+        await restoreJob.RestoreAsync(CancellationToken.None);
+
+        Assert.That(restoreJob.FileErrorList, Is.Empty);
+        Assert.That(storage.CopiedPlain, Has.Count.EqualTo(1));
+        Assert.That(storage.CopiedCompressed, Has.Count.EqualTo(1));
+        Assert.That(storage.CopiedEncrypted, Has.Count.EqualTo(1));
+
+        Assert.That(storage.CopiedPlain[0].RemoteFile, Is.EqualTo(versionDate + @"\docs\" + "plain.txt"));
+        Assert.That(storage.CopiedCompressed[0].RemoteFile, Is.EqualTo(versionDate + @"\docs\" + "compressed.txt"));
+        Assert.That(storage.CopiedEncrypted[0].RemoteFile, Is.EqualTo(Path.Combine(versionDate, "_LONGFILES_", "very-long-file-name")));
+    }
+
+    [Test]
+    public async Task TestRestoreSingleFileFilter()
+    {
+        const string versionDate = "01-01-2021 00-00-00";
+        await SeedVersionAsync(1, versionDate);
+        await SeedFileForVersionAsync(1, 1, 1, "plain.txt", @"\docs\", 1, "");
+        await SeedFileForVersionAsync(2, 2, 1, "other.txt", @"\docs\", 1, "");
+
+        var destination = CreateTempDestination();
+        var storage = new RecordingRestoreStorage();
+        var restoreJob = CreateRestoreJob(storage, destination: destination, file: @"\docs\plain.txt");
+
+        await restoreJob.RestoreAsync(CancellationToken.None);
+
+        Assert.That(storage.CopiedPlain, Has.Count.EqualTo(1));
+        Assert.That(storage.CopiedPlain[0].RemoteFile, Does.Contain("plain.txt"));
+    }
+
+    [Test]
+    public async Task TestOverwriteDontCopySkipsExistingFile()
+    {
+        const string versionDate = "01-01-2021 00-00-00";
+        await SeedVersionAsync(1, versionDate);
+        await SeedFileForVersionAsync(1, 1, 1, "plain.txt", @"\docs\", 1, "");
+
+        var destination = CreateTempDestination();
+        Directory.CreateDirectory(destination);
+        var existingPath = Path.Combine(destination, "plain.txt");
+        File.WriteAllText(existingPath, "local-content");
+
+        var storage = new RecordingRestoreStorage();
+        var restoreJob = CreateRestoreJob(storage, destination: destination, file: @"\", overwrite: FileOverwrite.DontCopy);
+
+        await restoreJob.RestoreAsync(CancellationToken.None);
+
+        Assert.That(storage.CopiedPlain, Is.Empty);
+        Assert.That(File.ReadAllText(existingPath), Is.EqualTo("local-content"));
+    }
+
+    [Test]
+    public async Task TestOverwritePolicyReplacesExistingFile()
+    {
+        const string versionDate = "01-01-2021 00-00-00";
+        await SeedVersionAsync(1, versionDate);
+        await SeedFileForVersionAsync(1, 1, 1, "plain.txt", @"\docs\", 1, "");
+
+        var destination = CreateTempDestination();
+        Directory.CreateDirectory(destination);
+        var existingPath = Path.Combine(destination, "plain.txt");
+        File.WriteAllText(existingPath, "local-content");
+
+        var storage = new RecordingRestoreStorage(writeRestoredContent: "restored-content");
+        var restoreJob = CreateRestoreJob(storage, destination: destination, file: @"\", overwrite: FileOverwrite.Overwrite);
+
+        await restoreJob.RestoreAsync(CancellationToken.None);
+
+        Assert.That(storage.CopiedPlain, Has.Count.EqualTo(1));
+        Assert.That(File.ReadAllText(existingPath), Is.EqualTo("restored-content"));
+    }
+
+    [Test]
+    public async Task TestOverwriteAskRespectsNoOverwriteDecision()
+    {
+        const string versionDate = "01-01-2021 00-00-00";
+        await SeedVersionAsync(1, versionDate);
+        await SeedFileForVersionAsync(1, 1, 1, "plain.txt", @"\docs\", 1, "");
+
+        var destination = CreateTempDestination();
+        Directory.CreateDirectory(destination);
+        var existingPath = Path.Combine(destination, "plain.txt");
+        File.WriteAllText(existingPath, "local-content");
+
+        var storage = new RecordingRestoreStorage();
+        var restoreJob = CreateRestoreJob(storage, destination: destination, file: @"\", overwrite: FileOverwrite.Ask);
+        var observer = new JobReportStub { OverwriteResult = RequestOverwriteResult.NoOverwrite };
+        restoreJob.AddObserver(observer);
+
+        await restoreJob.RestoreAsync(CancellationToken.None);
+
+        Assert.That(observer.RequestOverwriteCalls, Is.EqualTo(1));
+        Assert.That(storage.CopiedPlain, Is.Empty);
+        Assert.That(File.ReadAllText(existingPath), Is.EqualTo("local-content"));
+    }
+
+    [Test]
+    public async Task TestCancellationReportsCanceledState()
+    {
+        const string versionDate = "01-01-2021 00-00-00";
+        await SeedVersionAsync(1, versionDate);
+        await SeedFileForVersionAsync(1, 1, 1, "plain.txt", @"\docs\", 1, "");
+
+        var destination = CreateTempDestination();
+        using var cts = new CancellationTokenSource();
+        var storage = new RecordingRestoreStorage(cancelOnCopy: cts);
+        var restoreJob = CreateRestoreJob(storage, destination: destination, file: @"\");
+        var observer = new JobReportStub();
+        restoreJob.AddObserver(observer);
+
+        await restoreJob.RestoreAsync(cts.Token);
+
+        Assert.That(observer.ReportedStates, Does.Contain(JobState.CANCELED));
+        Assert.That(observer.ReportedStates, Does.Not.Contain(JobState.FINISHED));
+    }
+
+    [Test]
+    public async Task TestRestoreCollectsFileErrorsAndContinues()
+    {
+        const string versionDate = "01-01-2021 00-00-00";
+        await SeedVersionAsync(1, versionDate);
+        await SeedFileForVersionAsync(1, 1, 1, "fails.txt", @"\docs\", 1, "");
+        await SeedFileForVersionAsync(2, 2, 1, "ok.txt", @"\docs\", 1, "");
+
+        var destination = CreateTempDestination();
+        var storage = new RecordingRestoreStorage(throwOnRemoteContaining: "fails.txt");
+        var restoreJob = CreateRestoreJob(storage, destination: destination, file: @"\");
+        var observer = new JobReportStub();
+        restoreJob.AddObserver(observer);
+
+        await restoreJob.RestoreAsync(CancellationToken.None);
+
+        Assert.That(restoreJob.FileErrorList.Count, Is.EqualTo(1));
+        Assert.That(storage.CopiedPlain, Has.Count.EqualTo(1));
+        Assert.That(storage.CopiedPlain[0].RemoteFile, Does.Contain("ok.txt"));
+        Assert.That(observer.ReportedStates, Does.Contain(JobState.ERROR));
+    }
+
+    [Test]
+    public async Task TestRestoreIncrementalVersionsUseLinkedFilePackages()
+    {
+        const string versionDate1 = "01-01-2021 00-00-00";
+        const string versionDate2 = "02-01-2021 00-00-00";
+
+        await SeedVersionAsync(1, versionDate1);
+        await SeedVersionAsync(2, versionDate2);
+
+        // Same logical file; version 2 links a newer fileversion package written in version 2.
+        await SeedFileForVersionAsync(1, 1, 1, "doc.txt", @"\docs\", 1, "");
+        await dbClientFactory.ExecuteNonQueryAsync(
+            "INSERT INTO fileversiontable (fileversionID, fileStatus, fileType, fileHash, fileDateModified, fileDateCreated, fileSize, filePackage, fileID, longfilename) VALUES " +
+            "(2, 1, 1, '', '2021-01-02 00:00:00', '2021-01-01 00:00:00', 456, 2, 1, '')");
+        await dbClientFactory.ExecuteNonQueryAsync(
+            "INSERT INTO filelink (fileversionID, versionID) VALUES (2, 2)");
+
+        var destination = CreateTempDestination();
+        var storage = new RecordingRestoreStorage();
+
+        var restoreV1 = CreateRestoreJob(storage, version: 1, destination: destination, file: @"\");
+        await restoreV1.RestoreAsync(CancellationToken.None);
+
+        var restoreV2 = CreateRestoreJob(storage, version: 2, destination: destination, file: @"\", overwrite: FileOverwrite.Overwrite);
+        await restoreV2.RestoreAsync(CancellationToken.None);
+
+        Assert.That(storage.CopiedPlain, Has.Count.EqualTo(2));
+        Assert.That(storage.CopiedPlain[0].RemoteFile, Is.EqualTo(versionDate1 + @"\docs\" + "doc.txt"));
+        Assert.That(storage.CopiedPlain[1].RemoteFile, Is.EqualTo(versionDate2 + @"\docs\" + "doc.txt"));
+    }
+
+    private RestoreJob CreateRestoreJob(
+        IStorageProvider storage,
+        int version = 1,
+        string destination = null,
+        string file = @"\",
+        FileOverwrite overwrite = FileOverwrite.Overwrite)
+    {
+        return new RestoreJob(
+            storage,
+            dbClientFactory,
+            queryManager,
+            configurationManager,
+            versionQueryRepository)
+        {
+            Version = version,
+            File = file,
+            Destination = destination,
+            FileOverwrite = overwrite,
+        };
+    }
+
+    private async Task SeedVersionAsync(int versionId, string versionDate)
+    {
+        await dbClientFactory.ExecuteNonQueryAsync(
+            $"INSERT INTO versiontable (versionID, versionDate, versionTitle, versionDescription, versionType, versionStatus, versionStable, versionSources) VALUES ({versionId}, '{versionDate}', 'v{versionId}', '', 2, 0, 1, 'D:\\\\Source')");
+    }
+
+    private async Task SeedFileForVersionAsync(
+        int fileId,
+        int fileVersionId,
+        int versionId,
+        string fileName,
+        string filePath,
+        int fileType,
+        string longFileName)
+    {
+        await dbClientFactory.ExecuteNonQueryAsync(
+            $"INSERT INTO filetable (fileID, fileName, filePath) VALUES ({fileId}, '{fileName}', '{filePath}')");
+        await dbClientFactory.ExecuteNonQueryAsync(
+            "INSERT INTO fileversiontable (fileversionID, fileStatus, fileType, fileHash, fileDateModified, fileDateCreated, fileSize, filePackage, fileID, longfilename) VALUES " +
+            $"({fileVersionId}, 1, {fileType}, '', '2021-01-01 00:00:00', '2021-01-01 00:00:00', 123, {versionId}, {fileId}, '{longFileName}')");
+        await dbClientFactory.ExecuteNonQueryAsync(
+            $"INSERT INTO filelink (fileversionID, versionID) VALUES ({fileVersionId}, {versionId})");
+    }
+
+    private static string CreateTempDestination()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "BSH.Test", "restore-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private sealed class JobReportStub : IJobReport
+    {
+        public RequestOverwriteResult OverwriteResult { get; set; } = RequestOverwriteResult.Overwrite;
+        public int RequestOverwriteCalls { get; private set; }
+        public List<JobState> ReportedStates { get; } = [];
+
+        public void ReportAction(ActionType action, bool silent) { }
+        public void ReportState(JobState jobState) => ReportedStates.Add(jobState);
+        public void ReportStatus(string title, string text) { }
+        public void ReportProgress(int total, int current) { }
+        public void ReportFileProgress(string file) { }
+        public void ReportExceptions(Collection<FileExceptionEntry> files, bool silent) { }
+        public Task RequestShowErrorInsufficientDiskSpaceAsync() => Task.CompletedTask;
+
+        public Task<RequestOverwriteResult> RequestOverwrite(FileTableRow localFile, FileTableRow remoteFile)
+        {
+            RequestOverwriteCalls++;
+            return Task.FromResult(OverwriteResult);
+        }
+    }
+
+    private sealed class RecordingRestoreStorage : IStorageProvider
+    {
+        private readonly bool failCheckMedium;
+        private readonly string throwOnRemoteContaining;
+        private readonly string writeRestoredContent;
+        private readonly CancellationTokenSource cancelOnCopy;
+
+        public RecordingRestoreStorage(
+            bool failCheckMedium = false,
+            string throwOnRemoteContaining = null,
+            string writeRestoredContent = null,
+            CancellationTokenSource cancelOnCopy = null)
+        {
+            this.failCheckMedium = failCheckMedium;
+            this.throwOnRemoteContaining = throwOnRemoteContaining;
+            this.writeRestoredContent = writeRestoredContent;
+            this.cancelOnCopy = cancelOnCopy;
+        }
+
+        public StorageProviderKind Kind => StorageProviderKind.LocalFileSystem;
+        public List<(string LocalFile, string RemoteFile)> CopiedPlain { get; } = [];
+        public List<(string LocalFile, string RemoteFile)> CopiedCompressed { get; } = [];
+        public List<(string LocalFile, string RemoteFile, string Password)> CopiedEncrypted { get; } = [];
+
+        public Task<bool> CheckMedium(bool quickCheck = false) => Task.FromResult(!failCheckMedium);
+        public void Open() { }
+        public bool CanWriteToStorage() => true;
+        public bool CopyFileToStorage(string localFile, string remoteFile) => true;
+        public bool CopyFileToStorageCompressed(string localFile, string remoteFile) => true;
+        public bool CopyFileToStorageEncrypted(string localFile, string remoteFile, string password) => true;
+        public bool DecryptOnStorage(string remoteFile, string password) => true;
+        public bool DeleteFileFromStorage(string remoteFile) => true;
+        public bool DeleteFileFromStorageCompressed(string remoteFile) => true;
+        public bool DeleteFileFromStorageEncrypted(string remoteFile) => true;
+        public bool DeleteDirectory(string remoteDirectory) => true;
+        public bool RenameDirectory(string remoteDirectorySource, string remoteDirectoryTarget) => true;
+        public bool UploadDatabaseFile(string databaseFile) => true;
+        public void UpdateStorageVersion(int versionId) { }
+        public bool IsPathTooLong(string path, bool compression, bool encryption) => false;
+        public long GetFreeSpace() => 0;
+        public void Dispose() { }
+
+        public bool CopyFileFromStorage(string localFile, string remoteFile)
+        {
+            return CopyFromStorage(CopiedPlain, localFile, remoteFile);
+        }
+
+        public bool CopyFileFromStorageCompressed(string localFile, string remoteFile)
+        {
+            return CopyFromStorage(CopiedCompressed, localFile, remoteFile);
+        }
+
+        public bool CopyFileFromStorageEncrypted(string localFile, string remoteFile, string password)
+        {
+            if (!string.IsNullOrEmpty(throwOnRemoteContaining) && remoteFile.Contains(throwOnRemoteContaining, StringComparison.Ordinal))
+            {
+                throw new IOException("Simulated restore failure");
+            }
+
+            cancelOnCopy?.Cancel();
+            WriteRestoredContentIfRequested(localFile);
+            CopiedEncrypted.Add((localFile, remoteFile, password));
+            return true;
+        }
+
+        private bool CopyFromStorage(
+            List<(string LocalFile, string RemoteFile)> target,
+            string localFile,
+            string remoteFile)
+        {
+            if (!string.IsNullOrEmpty(throwOnRemoteContaining) && remoteFile.Contains(throwOnRemoteContaining, StringComparison.Ordinal))
+            {
+                throw new IOException("Simulated restore failure");
+            }
+
+            cancelOnCopy?.Cancel();
+            WriteRestoredContentIfRequested(localFile);
+            target.Add((localFile, remoteFile));
+            return true;
+        }
+
+        private void WriteRestoredContentIfRequested(string localFile)
+        {
+            if (writeRestoredContent == null)
+            {
+                return;
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(localFile)!);
+            File.WriteAllText(localFile, writeRestoredContent);
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the highest-priority follow-ups from the beta testing plan: dedicated `RestoreJob` tests, real filesystem backup↔restore integration coverage, and a release-workflow test gate so beta/stable tags cannot ship a red suite.

## Changes

### `src/BSH.Test/Mocks/StorageMock.cs`
- Extended with restore-side call counts/lists, selective remote-path failures, and cancel-on-copy for restore unit tests (same mock used by backup unit tests).

### `src/BSH.Test/RestoreTests.cs` (unit, mocked storage)
- Medium not ready → `DeviceNotReadyException`
- Routes plain / compressed / encrypted (+ long-path) via the correct storage APIs
- Single-file filter
- Overwrite: `DontCopy`, `Overwrite`, `Ask` + `NoOverwrite` (asserts mock call counts; only creates a local placeholder where `File.Exists` gates overwrite)
- Cancel mid-restore → `JobState.CANCELED`
- Per-file errors collected while remaining files continue
- Incremental version links restore the correct `filePackage` remote paths

### `src/BSH.Test/Integration/FileSystemRestoreIntegrationTests.cs`
- `[Category("Integration")]` round-trips through real `FileSystemStorage`
- Plain, compressed, and encrypted content equality
- Incremental: restore older and newer version contents independently

### `.github/workflows/dotnet-desktop-release.yml`
- Install Windows App Runtime (same approach as PR CI)
- `dotnet build` + `dotnet test` **before** publish / Inno Setup

## Test plan
- [x] CI on this PR: `dotnet test` green on `windows-latest`
- [ ] Re-verify after StorageMock refactor:
  ```powershell
  cd src
  dotnet test BSH.Test\BSH.Test.csproj -c Release -p:Platform=x64 --filter "FullyQualifiedName~Restore"
  ```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f78db-fe0e-7fd7-a0bf-178ca9b650ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f78db-fe0e-7fd7-a0bf-178ca9b650ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

