### PR TITLE
WinUI: Add backup browser file preview (#524)

### DIFF
--- a/src/BSH.MainApp/App.xaml.cs
+++ b/src/BSH.MainApp/App.xaml.cs
@@ -94,6 +94,8 @@ public partial class App : Application
             services.AddSingleton<IBrowserFavoritesService, BrowserFavoritesService>();
             services.AddSingleton<IBrowserContentService, BrowserContentService>();
             services.AddSingleton<IBrowserDialogService, BrowserDialogService>();
+            services.AddSingleton<IBrowserPreviewService, BrowserPreviewService>();
+            services.AddSingleton<ISmartPreviewHost, SmartPreviewHost>();
             services.AddSingleton<IBackupTargetService, BackupTargetService>();
             services.AddSingleton<IPowerStatusService, PowerStatusService>();
             services.AddTransient<IWaitForMediaService, WaitForMediaService>();

--- a/src/BSH.MainApp/Contracts/Services/IBrowserPreviewService.cs
+++ b/src/BSH.MainApp/Contracts/Services/IBrowserPreviewService.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace BSH.MainApp.Contracts.Services;
+
+public interface IBrowserPreviewService
+{
+    Task PreviewFileAsync(string versionId, string fileName, string filePath);
+}

--- a/src/BSH.MainApp/Contracts/Services/ISmartPreviewHost.cs
+++ b/src/BSH.MainApp/Contracts/Services/ISmartPreviewHost.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace BSH.MainApp.Contracts.Services;
+
+public interface ISmartPreviewHost
+{
+    Task ShowAsync(string filePath, bool isTemporary);
+}

--- a/src/BSH.MainApp/Services/BrowserPreviewService.cs
+++ b/src/BSH.MainApp/Services/BrowserPreviewService.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Brightbits.BSH.Engine;
+using Brightbits.BSH.Engine.Contracts;
+using Brightbits.BSH.Engine.Contracts.Services;
+using BSH.MainApp.Contracts.Services;
+using Windows.UI.Popups;
+
+namespace BSH.MainApp.Services;
+
+public class BrowserPreviewService : IBrowserPreviewService
+{
+    private readonly IJobService jobService;
+    private readonly IBackupService backupService;
+    private readonly IQueryManager queryManager;
+    private readonly IPresentationService presentationService;
+    private readonly ISmartPreviewHost smartPreviewHost;
+
+    public BrowserPreviewService(
+        IJobService jobService,
+        IBackupService backupService,
+        IQueryManager queryManager,
+        IPresentationService presentationService,
+        ISmartPreviewHost smartPreviewHost)
+    {
+        this.jobService = jobService;
+        this.backupService = backupService;
+        this.queryManager = queryManager;
+        this.presentationService = presentationService;
+        this.smartPreviewHost = smartPreviewHost;
+    }
+
+    public async Task PreviewFileAsync(string versionId, string fileName, string filePath)
+    {
+        if (!await jobService.CheckMediaAsync(ActionType.Restore))
+        {
+            return;
+        }
+
+        if (!await jobService.RequestPassword())
+        {
+            return;
+        }
+
+        string? localFilePath = null;
+        var isTemporary = false;
+
+        try
+        {
+            var password = backupService.GetPassword();
+            (localFilePath, isTemporary) = await queryManager.GetFileNameFromDriveAsync(
+                int.Parse(versionId),
+                fileName,
+                filePath,
+                password);
+
+            if (string.IsNullOrEmpty(localFilePath))
+            {
+                return;
+            }
+
+            await smartPreviewHost.ShowAsync(localFilePath, isTemporary);
+        }
+        catch
+        {
+            await presentationService.ShowMessageBoxAsync(
+                "Feature not available",
+                "Feature is currently not available.\n\nThis feature is currently not available because the quick preview could not be found. Reinstall Backup Service Home to resolve the problem.",
+                [new UICommand("OK")]);
+        }
+        finally
+        {
+            if (isTemporary && !string.IsNullOrEmpty(localFilePath))
+            {
+                TryDeleteTemporaryFile(localFilePath);
+            }
+        }
+    }
+
+    private static void TryDeleteTemporaryFile(string filePath)
+    {
+        for (var i = 0; i < 5; i++)
+        {
+            try
+            {
+                File.Delete(filePath);
+                break;
+            }
+            catch
+            {
+                // Preview process may still be releasing the file; retry.
+            }
+        }
+    }
+}

--- a/src/BSH.MainApp/Services/SmartPreviewHost.cs
+++ b/src/BSH.MainApp/Services/SmartPreviewHost.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Diagnostics;
+using BSH.MainApp.Contracts.Services;
+
+namespace BSH.MainApp.Services;
+
+public class SmartPreviewHost : ISmartPreviewHost
+{
+    public async Task ShowAsync(string filePath, bool isTemporary)
+    {
+        var executablePath = Path.Combine(AppContext.BaseDirectory, "SmartPreview.exe");
+        if (!File.Exists(executablePath))
+        {
+            throw new FileNotFoundException("SmartPreview.exe was not found.", executablePath);
+        }
+
+        var arguments = " -file:\"" + filePath + "\"" + (isTemporary ? " -c" : "");
+        var process = Process.Start(new ProcessStartInfo(executablePath, arguments)
+        {
+            WindowStyle = ProcessWindowStyle.Normal
+        });
+
+        if (process == null)
+        {
+            throw new InvalidOperationException("Failed to start SmartPreview.exe.");
+        }
+
+        await process.WaitForExitAsync();
+    }
+}

--- a/src/BSH.MainApp/ViewModels/BrowserViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/BrowserViewModel.cs
@@ -22,6 +22,7 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
     private readonly IPresentationService presentationService;
     private readonly IBrowserContentService browserContentService;
     private readonly IBrowserDialogService browserDialogService;
+    private readonly IBrowserPreviewService browserPreviewService;
     private BrowserContentMode contentMode = BrowserContentMode.Folder;
     private long contentRequestId;
     private bool suppressSearchTermsChanged;
@@ -71,7 +72,8 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
         IBackupService backupService,
         IPresentationService presentationService,
         IBrowserContentService browserContentService,
-        IBrowserDialogService browserDialogService)
+        IBrowserDialogService browserDialogService,
+        IBrowserPreviewService browserPreviewService)
     {
         this.queryManager = queryManager;
         this.jobService = jobService;
@@ -79,6 +81,7 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
         this.presentationService = presentationService;
         this.browserContentService = browserContentService;
         this.browserDialogService = browserDialogService;
+        this.browserPreviewService = browserPreviewService;
     }
 
     private bool CanUpFolder() => contentMode == BrowserContentMode.Folder && CurrentFolderPath.Count > 1;
@@ -268,7 +271,12 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
     [RelayCommand(CanExecute = nameof(HasFileSelected))]
     private async Task ShowFilePreview()
     {
-        throw new NotImplementedException();
+        if (CurrentItem == null || CurrentVersion == null)
+        {
+            return;
+        }
+
+        await browserPreviewService.PreviewFileAsync(CurrentVersion.Id, CurrentItem.Name, CurrentItem.FullPath);
     }
 
     [RelayCommand(CanExecute = nameof(CanAddFolderToFavorites))]

--- a/src/BSH.MainApp/Views/BrowserPage.xaml
+++ b/src/BSH.MainApp/Views/BrowserPage.xaml
@@ -232,7 +232,7 @@
                             LabelPosition="Collapsed"
                             Width="Auto"
                             MinWidth="40"
-                            Visibility="Collapsed" />
+                            ToolTipService.ToolTip="Quick preview" />
                             <AppBarButton 
                             Command="{x:Bind ViewModel.ShowFilePropertiesCommand}" 
                             Label="Properties"

--- a/src/BSH.Test/BrowserPreviewServiceTests.cs
+++ b/src/BSH.Test/BrowserPreviewServiceTests.cs
@@ -1,0 +1,307 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Brightbits.BSH.Engine;
+using Brightbits.BSH.Engine.Contracts;
+using Brightbits.BSH.Engine.Contracts.Services;
+using Brightbits.BSH.Engine.Jobs;
+using Brightbits.BSH.Engine.Models;
+using BSH.MainApp.Contracts.Services;
+using BSH.MainApp.Models;
+using BSH.MainApp.Services;
+using BSH.MainApp.ViewModels.Windows;
+using Microsoft.UI.Xaml.Controls;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Windows.UI.Popups;
+
+namespace BSH.Test;
+
+public class BrowserPreviewServiceTests
+{
+    [Test]
+    public async Task PreviewFileAsync_WhenMediaUnavailable_DoesNotRetrieveOrLaunch()
+    {
+        var jobService = new PreviewJobService { CheckMediaResult = false };
+        var queryManager = new PreviewQueryManager();
+        var host = new RecordingPreviewHost();
+        var service = CreateService(jobService, queryManager: queryManager, previewHost: host);
+
+        await service.PreviewFileAsync("2", "report.txt", @"\source\docs\");
+
+        Assert.That(jobService.CheckMediaCalls, Is.EqualTo(new[] { ActionType.Restore }));
+        Assert.That(jobService.RequestPasswordCallCount, Is.EqualTo(0));
+        Assert.That(queryManager.GetFileNameCalls, Is.Empty);
+        Assert.That(host.ShownFiles, Is.Empty);
+    }
+
+    [Test]
+    public async Task PreviewFileAsync_WhenPasswordRejected_DoesNotRetrieveOrLaunch()
+    {
+        var jobService = new PreviewJobService { RequestPasswordResult = false };
+        var queryManager = new PreviewQueryManager();
+        var host = new RecordingPreviewHost();
+        var service = CreateService(jobService, queryManager: queryManager, previewHost: host);
+
+        await service.PreviewFileAsync("2", "report.txt", @"\source\docs\");
+
+        Assert.That(jobService.RequestPasswordCallCount, Is.EqualTo(1));
+        Assert.That(queryManager.GetFileNameCalls, Is.Empty);
+        Assert.That(host.ShownFiles, Is.Empty);
+    }
+
+    [Test]
+    public async Task PreviewFileAsync_RetrievesFileLaunchesPreviewAndCleansTemporaryFile()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), "bsh-preview-" + Guid.NewGuid().ToString("N") + ".txt");
+        await File.WriteAllTextAsync(tempFile, "preview-content");
+
+        var queryManager = new PreviewQueryManager
+        {
+            FileResult = (tempFile, true)
+        };
+        var host = new RecordingPreviewHost();
+        var presentation = new PreviewPresentationService();
+        var service = CreateService(queryManager: queryManager, previewHost: host, presentationService: presentation);
+
+        await service.PreviewFileAsync("2", "report.txt", @"\source\docs\");
+
+        Assert.That(queryManager.GetFileNameCalls.Single(), Is.EqualTo((2, "report.txt", @"\source\docs\", "secret")));
+        Assert.That(host.ShownFiles.Single(), Is.EqualTo((tempFile, true)));
+        Assert.That(File.Exists(tempFile), Is.False);
+        Assert.That(presentation.MessageBoxes, Is.Empty);
+    }
+
+    [Test]
+    public async Task PreviewFileAsync_WhenLaunchFails_SurfacesErrorThroughPresentationService()
+    {
+        var queryManager = new PreviewQueryManager
+        {
+            FileResult = (@"C:\backed-up\report.txt", false)
+        };
+        var host = new RecordingPreviewHost { ThrowOnShow = true };
+        var presentation = new PreviewPresentationService();
+        var service = CreateService(queryManager: queryManager, previewHost: host, presentationService: presentation);
+
+        await service.PreviewFileAsync("2", "report.txt", @"\source\docs\");
+
+        Assert.That(presentation.MessageBoxes, Has.Count.EqualTo(1));
+        Assert.That(presentation.MessageBoxes[0].Title, Is.EqualTo("Feature not available"));
+        Assert.That(presentation.MessageBoxes[0].Content, Does.Contain("not available"));
+    }
+
+    [Test]
+    public async Task PreviewFileAsync_WhenFileIsNotTemporary_LaunchesWithoutDeletingSource()
+    {
+        var sourcePath = Path.Combine(Path.GetTempPath(), "bsh-preview-source-" + Guid.NewGuid().ToString("N") + ".txt");
+        await File.WriteAllTextAsync(sourcePath, "source-content");
+
+        try
+        {
+            var queryManager = new PreviewQueryManager
+            {
+                FileResult = (sourcePath, false)
+            };
+            var host = new RecordingPreviewHost();
+            var service = CreateService(queryManager: queryManager, previewHost: host);
+
+            await service.PreviewFileAsync("2", "report.txt", @"\source\docs\");
+
+            Assert.That(host.ShownFiles.Single(), Is.EqualTo((sourcePath, false)));
+            Assert.That(File.Exists(sourcePath), Is.True);
+        }
+        finally
+        {
+            if (File.Exists(sourcePath))
+            {
+                File.Delete(sourcePath);
+            }
+        }
+    }
+
+    [Test]
+    public async Task PreviewFileAsync_WhenRetrievedPathIsEmpty_DoesNotLaunch()
+    {
+        var queryManager = new PreviewQueryManager
+        {
+            FileResult = (null, false)
+        };
+        var host = new RecordingPreviewHost();
+        var presentation = new PreviewPresentationService();
+        var service = CreateService(queryManager: queryManager, previewHost: host, presentationService: presentation);
+
+        await service.PreviewFileAsync("2", "report.txt", @"\source\docs\");
+
+        Assert.That(host.ShownFiles, Is.Empty);
+        Assert.That(presentation.MessageBoxes, Is.Empty);
+    }
+
+    [Test]
+    public async Task PreviewFileAsync_WhenLaunchFailsForTemporaryFile_StillCleansUp()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), "bsh-preview-fail-" + Guid.NewGuid().ToString("N") + ".txt");
+        await File.WriteAllTextAsync(tempFile, "preview-content");
+
+        var queryManager = new PreviewQueryManager
+        {
+            FileResult = (tempFile, true)
+        };
+        var host = new RecordingPreviewHost { ThrowOnShow = true };
+        var presentation = new PreviewPresentationService();
+        var service = CreateService(queryManager: queryManager, previewHost: host, presentationService: presentation);
+
+        await service.PreviewFileAsync("2", "report.txt", @"\source\docs\");
+
+        Assert.That(presentation.MessageBoxes, Has.Count.EqualTo(1));
+        Assert.That(File.Exists(tempFile), Is.False);
+    }
+
+    private static BrowserPreviewService CreateService(
+        PreviewJobService? jobService = null,
+        PreviewBackupService? backupService = null,
+        PreviewQueryManager? queryManager = null,
+        PreviewPresentationService? presentationService = null,
+        RecordingPreviewHost? previewHost = null)
+    {
+        return new BrowserPreviewService(
+            jobService ?? new PreviewJobService(),
+            backupService ?? new PreviewBackupService(),
+            queryManager ?? new PreviewQueryManager(),
+            presentationService ?? new PreviewPresentationService(),
+            previewHost ?? new RecordingPreviewHost());
+    }
+
+    private sealed class RecordingPreviewHost : ISmartPreviewHost
+    {
+        public List<(string FilePath, bool IsTemporary)> ShownFiles { get; } = [];
+        public bool ThrowOnShow { get; set; }
+
+        public Task ShowAsync(string filePath, bool isTemporary)
+        {
+            if (ThrowOnShow)
+            {
+                throw new InvalidOperationException("SmartPreview failed to start.");
+            }
+
+            ShownFiles.Add((filePath, isTemporary));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class PreviewJobService : IJobService
+    {
+        public bool CheckMediaResult { get; set; } = true;
+        public bool RequestPasswordResult { get; set; } = true;
+        public List<ActionType> CheckMediaCalls { get; } = [];
+        public int RequestPasswordCallCount { get; private set; }
+
+        public bool IsCancellationRequested => false;
+        public void Cancel() { }
+        public Task<bool> CheckMediaAsync(ActionType action, bool silent = false)
+        {
+            CheckMediaCalls.Add(action);
+            return Task.FromResult(CheckMediaResult);
+        }
+
+        public Task<bool> CreateBackupAsync(string title, string description, bool statusDialog = true, bool fullBackup = false, bool shutdownPC = false, bool shutdownApp = false, string sourceFolders = "") => Task.FromResult(true);
+        public Task DeleteBackupAsync(string version, bool statusDialog = true) => Task.CompletedTask;
+        public Task DeleteBackupsAsync(List<string> versions, bool statusDialog = true) => Task.CompletedTask;
+        public Task DeleteSingleFileAsync(string fileFilter, string folderFilter, bool statusDialog = true) => Task.CompletedTask;
+        public CancellationToken GetNewCancellationToken() => CancellationToken.None;
+        public Task<bool> RequestPassword()
+        {
+            RequestPasswordCallCount++;
+            return Task.FromResult(RequestPasswordResult);
+        }
+
+        public Task RestoreBackupAsync(string version, List<string> files, string destination, bool statusDialog = true) => Task.CompletedTask;
+        public Task RestoreBackupAsync(string version, string file, string destination, bool statusDialog = true) => Task.CompletedTask;
+        public Task ModifyBackupAsync(bool statusDialog = true) => Task.CompletedTask;
+    }
+
+    private sealed class PreviewBackupService : IBackupService
+    {
+        public Task<bool> CheckMedia(bool quickCheck = false) => Task.FromResult(true);
+        public string GetPassword() => "secret";
+        public bool HasPassword() => true;
+        public void SetPassword(string password) { }
+        public Task SetStableAsync(string version, bool stable) => Task.CompletedTask;
+        public Task UpdateVersionAsync(string version, VersionDetails versionDetails) => Task.CompletedTask;
+        public Task StartBackup(string title, string description, IJobReport jobReport, CancellationToken cancellationToken, bool fullBackup = false, string sources = "", bool silent = false) => Task.CompletedTask;
+        public Task StartDelete(string version, IJobReport jobReport, CancellationToken cancellationToken, bool silent = false) => Task.CompletedTask;
+        public Task StartDeleteSingle(string fileFilter, string pathFilter, IJobReport jobReport, CancellationToken cancellationToken, bool silent = false) => Task.CompletedTask;
+        public Task StartEdit(IJobReport jobReport, CancellationToken cancellationToken, bool silent = false) => Task.CompletedTask;
+        public Task StartRestore(string version, string file, string destination, IJobReport jobReport, CancellationToken cancellationToken, FileOverwrite overwrite = FileOverwrite.Ask, bool silent = false) => Task.CompletedTask;
+        public void UpdateDatabaseFile(string databaseFile) { }
+    }
+
+    private sealed class PreviewQueryManager : IQueryManager
+    {
+        public (string Path, bool IsTemporary)? FileResult { get; set; } = (@"C:\backed-up\report.txt", false);
+        public List<(int VersionId, string FileName, string FilePath, string Password)> GetFileNameCalls { get; } = [];
+
+        public Task<(string, bool)> GetFileNameFromDriveAsync(int versionId, string fileName, string filePath, string password)
+        {
+            GetFileNameCalls.Add((versionId, fileName, filePath, password));
+            return Task.FromResult(FileResult ?? ((string)null, false));
+        }
+
+        public Task<string> GetBackVersionWhereFileAsync(string startVersion, string searchString) => Task.FromResult<string>(null);
+        public Task<string> GetBackVersionWhereFilesInFolderAsync(string startVersion, string path) => Task.FromResult<string>(null);
+        public string GetFileNameFromDrive(FileTableRow file) => file.FileName;
+        public Task<FileDetails> GetFileDetailsAsync(string version, string fileName, string filePath) => Task.FromResult<FileDetails>(null);
+        public Task<List<FileTableRow>> GetFilesByVersionAsync(string version, string path) => Task.FromResult(new List<FileTableRow>());
+        public Task<List<string>> GetFolderListAsync(string version, string path) => Task.FromResult(new List<string>());
+        public Task<string> GetFullRestoreFolderAsync(string folder, string version) => Task.FromResult(folder);
+        public Task<VersionDetails> GetLastBackupAsync() => Task.FromResult(new VersionDetails { Id = "1" });
+        public Task<VersionDetails> GetLastFullBackupAsync() => Task.FromResult(new VersionDetails { Id = "1" });
+        public Task<string> GetLocalizedPathAsync(string path) => Task.FromResult(path);
+        public Task<string> GetNextVersionWhereFileAsync(string startVersion, string searchString) => Task.FromResult<string>(null);
+        public Task<string> GetNextVersionWhereFilesInFolderAsync(string startVersion, string path) => Task.FromResult<string>(null);
+        public Task<int> GetNumberOfVersionsAsync() => Task.FromResult(1);
+        public Task<int> GetNumberOfFilesAsync() => Task.FromResult(0);
+        public Task<double> GetTotalFileSizeAsync() => Task.FromResult(0d);
+        public Task<VersionDetails> GetOldestBackupAsync() => Task.FromResult(new VersionDetails { Id = "1" });
+        public Task<VersionDetails> GetVersionByIdAsync(string id) => Task.FromResult(new VersionDetails { Id = id });
+        public List<VersionDetails> GetVersions(bool desc = true) => [new VersionDetails { Id = "1" }];
+        public Task<List<FileTableRow>> GetVersionsByFileAsync(string fileName, string filePath) => Task.FromResult(new List<FileTableRow>());
+        public Task<List<FileTableRow>> SearchFilesByVersionAsync(string version, string searchTerm, int limit = 500) => Task.FromResult(new List<FileTableRow>());
+        public Task<bool> HasChangesOrNewAsync(string path, string versionId) => Task.FromResult(false);
+    }
+
+    private sealed class PreviewPresentationService : IPresentationService
+    {
+        public List<(string Title, string Content)> MessageBoxes { get; } = [];
+
+        public Task CloseBackupBrowserWindowAsync() => Task.CompletedTask;
+        public Task CloseMainWindowAsync() => Task.CompletedTask;
+        public Task<TaskCompleteAction> CloseStatusWindowAsync() => Task.FromResult(TaskCompleteAction.NoAction);
+        public Task OpenCurrentEventLogAsync() => Task.CompletedTask;
+        public Task OpenHelpSupportAsync() => Task.CompletedTask;
+        public Task<(string? password, bool persist)> RequestPasswordAsync() => Task.FromResult<(string?, bool)>((null, false));
+        public Task<RequestOverwriteResult> RequestOverwriteAsync(FileTableRow localFile, FileTableRow remoteFile) => Task.FromResult(RequestOverwriteResult.None);
+        public Task ResetConfigurationAsync() => Task.CompletedTask;
+        public Task ShowAboutWindowAsync() => Task.CompletedTask;
+        public Task ShowBackupBrowserWindowAsync() => Task.CompletedTask;
+        public Task<(bool, NewBackupViewModel)> ShowCreateBackupWindowAsync() => Task.FromResult((false, new NewBackupViewModel()));
+        public Task<(bool, EditBackupViewModel)> ShowEditBackupWindowAsync(EditBackupViewModel backupViewModel) => Task.FromResult((false, backupViewModel));
+        public Task<bool> ShowDeleteBackupWindowAsync() => Task.FromResult(false);
+        public Task ShowErrorInsufficientDiskSpaceAsync() => Task.CompletedTask;
+        public Task ShowFileExceptionsAsync(IReadOnlyCollection<FileExceptionEntry> files) => Task.CompletedTask;
+        public Task ShowMainWindowAsync() => Task.CompletedTask;
+        public Task ShowStatusWindowAsync() => Task.CompletedTask;
+        public Task<ContentDialogResult> ShowMessageBoxAsync(string title, string content, IList<IUICommand>? commands, uint defaultCommandIndex = 0, uint cancelCommandIndex = 1)
+        {
+            MessageBoxes.Add((title, content));
+            return Task.FromResult(ContentDialogResult.None);
+        }
+
+        public Task ShowExcludeFileFolderWindowAsync() => Task.CompletedTask;
+        public Task ShowScheduleEditorWindowAsync() => Task.CompletedTask;
+    }
+}

--- a/src/BSH.Test/BrowserViewModelTests.cs
+++ b/src/BSH.Test/BrowserViewModelTests.cs
@@ -104,11 +104,38 @@ public class BrowserViewModelTests
         Assert.That(queryManager.GetVersionsCallCount, Is.GreaterThanOrEqualTo(1));
     }
 
+    [Test]
+    public void ShowFilePreviewCommand_IsEnabledOnlyForFileSelections()
+    {
+        var viewModel = CreateViewModel();
+        viewModel.CurrentVersion = Version("2");
+
+        viewModel.CurrentItem = new FileOrFolderItem { Name = "docs", FullPath = @"\source\docs\", IsFile = false };
+        Assert.That(viewModel.ShowFilePreviewCommand.CanExecute(null), Is.False);
+
+        viewModel.CurrentItem = new FileOrFolderItem { Name = "report.txt", FullPath = @"\source\docs\", IsFile = true };
+        Assert.That(viewModel.ShowFilePreviewCommand.CanExecute(null), Is.True);
+    }
+
+    [Test]
+    public async Task ShowFilePreviewCommand_DelegatesToPreviewServiceForSelectedFile()
+    {
+        var previewService = new BrowserPreviewServiceFake();
+        var viewModel = CreateViewModel(previewService: previewService);
+        viewModel.CurrentVersion = Version("2");
+        viewModel.CurrentItem = new FileOrFolderItem { Name = "report.txt", FullPath = @"\source\docs\", IsFile = true };
+
+        await viewModel.ShowFilePreviewCommand.ExecuteAsync(null);
+
+        Assert.That(previewService.PreviewCalls.Single(), Is.EqualTo(("2", "report.txt", @"\source\docs\")));
+    }
+
     private static BrowserViewModel CreateViewModel(
         BrowserQueryManager? queryManager = null,
         BrowserJobService? jobService = null,
         BrowserDialogService? browserDialogService = null,
-        BrowserFavoritesService? favoritesService = null)
+        BrowserFavoritesService? favoritesService = null,
+        BrowserPreviewServiceFake? previewService = null)
     {
         queryManager ??= new BrowserQueryManager();
         favoritesService ??= new BrowserFavoritesService(new MemoryLocalSettingsService());
@@ -119,7 +146,8 @@ public class BrowserViewModelTests
             new BrowserBackupService(),
             new BrowserPresentationService(),
             new BrowserContentService(queryManager, favoritesService),
-            browserDialogService ?? new BrowserDialogService());
+            browserDialogService ?? new BrowserDialogService(),
+            previewService ?? new BrowserPreviewServiceFake());
     }
 
     private static VersionDetails Version(string id) => new()
@@ -218,6 +246,17 @@ public class BrowserViewModelTests
         public Task<IReadOnlyList<string>> ShowDeleteBackupsWindowAsync(IReadOnlyList<VersionDetails> versions) { MultiDeletePromptedVersions = versions.Select(x => x.Id).ToList(); return Task.FromResult(VersionsSelectedForDelete ?? []); }
         public Task<string?> ShowRenameFavoriteWindowAsync(BrowserFavoriteItem favorite) => Task.FromResult<string?>(favorite.Name);
         public Task ShowFileDetailsAsync(FileDetails fileDetails) => Task.CompletedTask;
+    }
+
+    private sealed class BrowserPreviewServiceFake : IBrowserPreviewService
+    {
+        public List<(string VersionId, string FileName, string FilePath)> PreviewCalls { get; } = [];
+
+        public Task PreviewFileAsync(string versionId, string fileName, string filePath)
+        {
+            PreviewCalls.Add((versionId, fileName, filePath));
+            return Task.CompletedTask;
+        }
     }
 
     private sealed class BrowserPresentationService : IPresentationService


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #524

## Summary
Adds the backup browser quick-preview vertical slice to WinUI by wiring the existing Quick preview command through the same media/password/materialize/launch/cleanup flow used by WinForms.

- `BrowserPreviewService` checks media (`ActionType.Restore`) and password, retrieves the file via `GetFileNameFromDriveAsync`, launches `SmartPreview.exe`, and cleans temporary files in `finally`
- `SmartPreviewHost` isolates process launch for testability and fails clearly when the exe is missing
- Quick preview AppBarButton is visible again with a tooltip
- Unit tests cover command eligibility and preview orchestration without starting the preview process

## Test plan
- [x] `dotnet test src/BSH.Test/BSH.Test.csproj -p:Platform=x64 --filter "FullyQualifiedName~BrowserPreview|FullyQualifiedName~ShowFilePreview"`
- [x] In WinUI backup browser, select a file and confirm Quick preview is enabled; select a folder and confirm it is disabled
- [x] Preview a local/direct backed-up file and confirm SmartPreview opens
- [x] Preview a compressed/encrypted/FTP-backed file and confirm temp materialization + cleanup after close
- [x] Confirm media-unavailable and password-cancel paths abort without launching preview
- [x] Confirm a missing `SmartPreview.exe` surfaces the Feature not available message
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f78e8-35f0-7d7b-8c3d-60bc5bdd9963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f78e8-35f0-7d7b-8c3d-60bc5bdd9963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

