### PR TITLE
WinUI: Persist browser view preferences (#577)

### DIFF
--- a/src/BSH.MainApp/App.xaml.cs
+++ b/src/BSH.MainApp/App.xaml.cs
@@ -92,6 +92,7 @@ public partial class App : Application
             services.AddSingleton<IFileService, FileService>();
             services.AddSingleton<IStatusService, StatusService>();
             services.AddSingleton<IBrowserFavoritesService, BrowserFavoritesService>();
+            services.AddSingleton<IBrowserViewPreferencesService, BrowserViewPreferencesService>();
             services.AddSingleton<IBrowserContentService, BrowserContentService>();
             services.AddSingleton<IBrowserDialogService, BrowserDialogService>();
             services.AddSingleton<IBrowserPreviewService, BrowserPreviewService>();

--- a/src/BSH.MainApp/Contracts/Services/IBrowserViewPreferencesService.cs
+++ b/src/BSH.MainApp/Contracts/Services/IBrowserViewPreferencesService.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace BSH.MainApp.Contracts.Services;
+
+public interface IBrowserViewPreferencesService
+{
+    Task<bool> GetInfoPaneVisibleAsync();
+
+    Task SetInfoPaneVisibleAsync(bool visible);
+}

--- a/src/BSH.MainApp/Services/BrowserViewPreferencesService.cs
+++ b/src/BSH.MainApp/Services/BrowserViewPreferencesService.cs
@@ -10,6 +10,7 @@ public class BrowserViewPreferencesService : IBrowserViewPreferencesService
     public const string InfoPaneVisibleSettingsKey = "BrowserInfoPaneVisible";
 
     private readonly ILocalSettingsService localSettingsService;
+    private readonly SemaphoreSlim writeGate = new(1, 1);
 
     public BrowserViewPreferencesService(ILocalSettingsService localSettingsService)
     {
@@ -21,8 +22,16 @@ public class BrowserViewPreferencesService : IBrowserViewPreferencesService
         return await localSettingsService.ReadSettingAsync<bool?>(InfoPaneVisibleSettingsKey) ?? false;
     }
 
-    public Task SetInfoPaneVisibleAsync(bool visible)
+    public async Task SetInfoPaneVisibleAsync(bool visible)
     {
-        return localSettingsService.SaveSettingAsync(InfoPaneVisibleSettingsKey, visible);
+        await writeGate.WaitAsync();
+        try
+        {
+            await localSettingsService.SaveSettingAsync(InfoPaneVisibleSettingsKey, visible);
+        }
+        finally
+        {
+            writeGate.Release();
+        }
     }
 }

--- a/src/BSH.MainApp/Services/BrowserViewPreferencesService.cs
+++ b/src/BSH.MainApp/Services/BrowserViewPreferencesService.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using BSH.MainApp.Contracts.Services;
+
+namespace BSH.MainApp.Services;
+
+public class BrowserViewPreferencesService : IBrowserViewPreferencesService
+{
+    public const string InfoPaneVisibleSettingsKey = "BrowserInfoPaneVisible";
+
+    private readonly ILocalSettingsService localSettingsService;
+
+    public BrowserViewPreferencesService(ILocalSettingsService localSettingsService)
+    {
+        this.localSettingsService = localSettingsService;
+    }
+
+    public async Task<bool> GetInfoPaneVisibleAsync()
+    {
+        return await localSettingsService.ReadSettingAsync<bool?>(InfoPaneVisibleSettingsKey) ?? false;
+    }
+
+    public Task SetInfoPaneVisibleAsync(bool visible)
+    {
+        return localSettingsService.SaveSettingAsync(InfoPaneVisibleSettingsKey, visible);
+    }
+}

--- a/src/BSH.MainApp/ViewModels/BrowserViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/BrowserViewModel.cs
@@ -95,7 +95,7 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
             return;
         }
 
-        _ = viewPreferencesService.SetInfoPaneVisibleAsync(value);
+        _ = PersistInfoPaneVisibleAsync(value);
     }
 
     public async Task LoadViewPreferencesAsync()
@@ -105,9 +105,25 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
         {
             ToggleInfoPane = await viewPreferencesService.GetInfoPaneVisibleAsync();
         }
+        catch
+        {
+            // Preference restore must not disrupt browsing; keep the default pane state.
+        }
         finally
         {
             suppressInfoPaneChanged = false;
+        }
+    }
+
+    private async Task PersistInfoPaneVisibleAsync(bool value)
+    {
+        try
+        {
+            await viewPreferencesService.SetInfoPaneVisibleAsync(value);
+        }
+        catch
+        {
+            // Preference persistence must not disrupt browsing.
         }
     }
 
@@ -607,7 +623,8 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
 
     public async void OnNavigatedTo(object parameter)
     {
-        await LoadViewPreferencesAsync();
+        // Restore layout prefs in parallel so a slow/failed settings read cannot block browsing.
+        var preferencesTask = LoadViewPreferencesAsync();
 
         LoadVersions();
 
@@ -616,6 +633,8 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
             CurrentVersion = Versions[0];
             await LoadVersion();
         }
+
+        await preferencesTask;
     }
 
     public void OnNavigatedFrom()

--- a/src/BSH.MainApp/ViewModels/BrowserViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/BrowserViewModel.cs
@@ -23,9 +23,11 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
     private readonly IBrowserContentService browserContentService;
     private readonly IBrowserDialogService browserDialogService;
     private readonly IBrowserPreviewService browserPreviewService;
+    private readonly IBrowserViewPreferencesService viewPreferencesService;
     private BrowserContentMode contentMode = BrowserContentMode.Folder;
     private long contentRequestId;
     private bool suppressSearchTermsChanged;
+    private bool suppressInfoPaneChanged;
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(RestoreFileCommand))]
@@ -73,7 +75,8 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
         IPresentationService presentationService,
         IBrowserContentService browserContentService,
         IBrowserDialogService browserDialogService,
-        IBrowserPreviewService browserPreviewService)
+        IBrowserPreviewService browserPreviewService,
+        IBrowserViewPreferencesService viewPreferencesService)
     {
         this.queryManager = queryManager;
         this.jobService = jobService;
@@ -82,6 +85,30 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
         this.browserContentService = browserContentService;
         this.browserDialogService = browserDialogService;
         this.browserPreviewService = browserPreviewService;
+        this.viewPreferencesService = viewPreferencesService;
+    }
+
+    partial void OnToggleInfoPaneChanged(bool value)
+    {
+        if (suppressInfoPaneChanged)
+        {
+            return;
+        }
+
+        _ = viewPreferencesService.SetInfoPaneVisibleAsync(value);
+    }
+
+    public async Task LoadViewPreferencesAsync()
+    {
+        suppressInfoPaneChanged = true;
+        try
+        {
+            ToggleInfoPane = await viewPreferencesService.GetInfoPaneVisibleAsync();
+        }
+        finally
+        {
+            suppressInfoPaneChanged = false;
+        }
     }
 
     private bool CanUpFolder() => contentMode == BrowserContentMode.Folder && CurrentFolderPath.Count > 1;
@@ -580,6 +607,8 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
 
     public async void OnNavigatedTo(object parameter)
     {
+        await LoadViewPreferencesAsync();
+
         LoadVersions();
 
         if (Versions.Count > 0)

--- a/src/BSH.Test/BrowserViewModelTests.cs
+++ b/src/BSH.Test/BrowserViewModelTests.cs
@@ -166,13 +166,34 @@ public class BrowserViewModelTests
         Assert.That(viewModel.ToggleInfoPane, Is.True);
     }
 
+    [Test]
+    public async Task LoadViewPreferencesLeavesDefaultWhenSettingsReadFails()
+    {
+        var viewModel = CreateViewModel(viewPreferencesService: new FailingBrowserViewPreferencesService());
+
+        await viewModel.LoadViewPreferencesAsync();
+
+        Assert.That(viewModel.ToggleInfoPane, Is.False);
+    }
+
+    [Test]
+    public async Task ToggleInfoPaneChangeIgnoresPersistenceFailures()
+    {
+        var viewModel = CreateViewModel(viewPreferencesService: new FailingBrowserViewPreferencesService());
+
+        Assert.DoesNotThrow(() => viewModel.ToggleInfoPane = true);
+        await Task.Yield();
+
+        Assert.That(viewModel.ToggleInfoPane, Is.True);
+    }
+
     private static BrowserViewModel CreateViewModel(
         BrowserQueryManager? queryManager = null,
         BrowserJobService? jobService = null,
         BrowserDialogService? browserDialogService = null,
         BrowserFavoritesService? favoritesService = null,
         BrowserPreviewServiceFake? previewService = null,
-        BrowserViewPreferencesService? viewPreferencesService = null)
+        IBrowserViewPreferencesService? viewPreferencesService = null)
     {
         queryManager ??= new BrowserQueryManager();
         favoritesService ??= new BrowserFavoritesService(new MemoryLocalSettingsService());
@@ -341,5 +362,12 @@ public class BrowserViewModelTests
             settings[key] = value;
             return Task.CompletedTask;
         }
+    }
+
+    private sealed class FailingBrowserViewPreferencesService : IBrowserViewPreferencesService
+    {
+        public Task<bool> GetInfoPaneVisibleAsync() => throw new InvalidOperationException("settings unavailable");
+
+        public Task SetInfoPaneVisibleAsync(bool visible) => throw new InvalidOperationException("settings unavailable");
     }
 }

--- a/src/BSH.Test/BrowserViewModelTests.cs
+++ b/src/BSH.Test/BrowserViewModelTests.cs
@@ -130,15 +130,53 @@ public class BrowserViewModelTests
         Assert.That(previewService.PreviewCalls.Single(), Is.EqualTo(("2", "report.txt", @"\source\docs\")));
     }
 
+    [Test]
+    public void ToggleInfoPaneDefaultsToHiddenWhenNoPreferenceSaved()
+    {
+        var viewModel = CreateViewModel();
+
+        Assert.That(viewModel.ToggleInfoPane, Is.False);
+    }
+
+    [Test]
+    public async Task ToggleInfoPaneChangePersistsPreference()
+    {
+        var preferences = new BrowserViewPreferencesService(new MemoryLocalSettingsService());
+        var viewModel = CreateViewModel(viewPreferencesService: preferences);
+
+        viewModel.ToggleInfoPane = true;
+
+        Assert.That(await preferences.GetInfoPaneVisibleAsync(), Is.True);
+
+        viewModel.ToggleInfoPane = false;
+
+        Assert.That(await preferences.GetInfoPaneVisibleAsync(), Is.False);
+    }
+
+    [Test]
+    public async Task LoadViewPreferencesRestoresPersistedInfoPanePreference()
+    {
+        var settings = new MemoryLocalSettingsService();
+        await settings.SaveSettingAsync(BrowserViewPreferencesService.InfoPaneVisibleSettingsKey, true);
+        var preferences = new BrowserViewPreferencesService(settings);
+        var viewModel = CreateViewModel(viewPreferencesService: preferences);
+
+        await viewModel.LoadViewPreferencesAsync();
+
+        Assert.That(viewModel.ToggleInfoPane, Is.True);
+    }
+
     private static BrowserViewModel CreateViewModel(
         BrowserQueryManager? queryManager = null,
         BrowserJobService? jobService = null,
         BrowserDialogService? browserDialogService = null,
         BrowserFavoritesService? favoritesService = null,
-        BrowserPreviewServiceFake? previewService = null)
+        BrowserPreviewServiceFake? previewService = null,
+        BrowserViewPreferencesService? viewPreferencesService = null)
     {
         queryManager ??= new BrowserQueryManager();
         favoritesService ??= new BrowserFavoritesService(new MemoryLocalSettingsService());
+        viewPreferencesService ??= new BrowserViewPreferencesService(new MemoryLocalSettingsService());
 
         return new BrowserViewModel(
             queryManager,
@@ -147,7 +185,8 @@ public class BrowserViewModelTests
             new BrowserPresentationService(),
             new BrowserContentService(queryManager, favoritesService),
             browserDialogService ?? new BrowserDialogService(),
-            previewService ?? new BrowserPreviewServiceFake());
+            previewService ?? new BrowserPreviewServiceFake(),
+            viewPreferencesService);
     }
 
     private static VersionDetails Version(string id) => new()

--- a/src/BSH.Test/BrowserViewPreferencesServiceTests.cs
+++ b/src/BSH.Test/BrowserViewPreferencesServiceTests.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using BSH.MainApp.Contracts.Services;
+using BSH.MainApp.Services;
+using NUnit.Framework;
+
+namespace BSH.Test;
+
+public class BrowserViewPreferencesServiceTests
+{
+    [Test]
+    public async Task InfoPaneVisibleDefaultsToFalseWhenUnset()
+    {
+        var service = new BrowserViewPreferencesService(new MemoryLocalSettingsService());
+
+        Assert.That(await service.GetInfoPaneVisibleAsync(), Is.False);
+    }
+
+    [Test]
+    public async Task InfoPaneVisibleIsPersistedWhenChanged()
+    {
+        var settings = new MemoryLocalSettingsService();
+        var service = new BrowserViewPreferencesService(settings);
+
+        await service.SetInfoPaneVisibleAsync(true);
+
+        Assert.That(await service.GetInfoPaneVisibleAsync(), Is.True);
+        Assert.That(await settings.ReadSettingAsync<bool>(BrowserViewPreferencesService.InfoPaneVisibleSettingsKey), Is.True);
+
+        await service.SetInfoPaneVisibleAsync(false);
+
+        Assert.That(await service.GetInfoPaneVisibleAsync(), Is.False);
+        Assert.That(await settings.ReadSettingAsync<bool>(BrowserViewPreferencesService.InfoPaneVisibleSettingsKey), Is.False);
+    }
+
+    [Test]
+    public async Task InfoPaneVisibleIsRestoredFromExistingSettings()
+    {
+        var settings = new MemoryLocalSettingsService();
+        await settings.SaveSettingAsync(BrowserViewPreferencesService.InfoPaneVisibleSettingsKey, true);
+
+        var service = new BrowserViewPreferencesService(settings);
+
+        Assert.That(await service.GetInfoPaneVisibleAsync(), Is.True);
+    }
+
+    private sealed class MemoryLocalSettingsService : ILocalSettingsService
+    {
+        private readonly Dictionary<string, object?> settings = [];
+
+        public Task<T?> ReadSettingAsync<T>(string key)
+        {
+            if (!settings.TryGetValue(key, out var value))
+            {
+                return Task.FromResult(default(T));
+            }
+
+            return Task.FromResult((T?)value);
+        }
+
+        public Task SaveSettingAsync<T>(string key, T value)
+        {
+            settings[key] = value;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/BSH.Test/BrowserViewPreferencesServiceTests.cs
+++ b/src/BSH.Test/BrowserViewPreferencesServiceTests.cs
@@ -47,6 +47,20 @@ public class BrowserViewPreferencesServiceTests
         Assert.That(await service.GetInfoPaneVisibleAsync(), Is.True);
     }
 
+    [Test]
+    public async Task RapidInfoPaneWritesPreserveLastValue()
+    {
+        var settings = new DelayedLocalSettingsService(TimeSpan.FromMilliseconds(40));
+        var service = new BrowserViewPreferencesService(settings);
+
+        var first = service.SetInfoPaneVisibleAsync(true);
+        var second = service.SetInfoPaneVisibleAsync(false);
+        await Task.WhenAll(first, second);
+
+        Assert.That(await service.GetInfoPaneVisibleAsync(), Is.False);
+        Assert.That(settings.WriteValues, Is.EqualTo(new[] { true, false }));
+    }
+
     private sealed class MemoryLocalSettingsService : ILocalSettingsService
     {
         private readonly Dictionary<string, object?> settings = [];
@@ -65,6 +79,36 @@ public class BrowserViewPreferencesServiceTests
         {
             settings[key] = value;
             return Task.CompletedTask;
+        }
+    }
+
+    private sealed class DelayedLocalSettingsService : ILocalSettingsService
+    {
+        private readonly TimeSpan delay;
+        private readonly Dictionary<string, object?> settings = [];
+
+        public DelayedLocalSettingsService(TimeSpan delay)
+        {
+            this.delay = delay;
+        }
+
+        public List<object?> WriteValues { get; } = [];
+
+        public Task<T?> ReadSettingAsync<T>(string key)
+        {
+            if (!settings.TryGetValue(key, out var value))
+            {
+                return Task.FromResult(default(T));
+            }
+
+            return Task.FromResult((T?)value);
+        }
+
+        public async Task SaveSettingAsync<T>(string key, T value)
+        {
+            await Task.Delay(delay);
+            settings[key] = value;
+            WriteValues.Add(value);
         }
     }
 }

--- a/src/BSH.Test/BrowserViewPreferencesServiceTests.cs
+++ b/src/BSH.Test/BrowserViewPreferencesServiceTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexander Seeliger. All Rights Reserved.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using BSH.MainApp.Contracts.Services;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #577 by persisting the WinUI backup browser’s preview/info pane visibility through `ILocalSettingsService`, so the preference survives app restarts.

- Adds `IBrowserViewPreferencesService` / `BrowserViewPreferencesService` (same pattern as folder favorites)
- Restores the preference when navigating to the backup browser (`LoadViewPreferencesAsync`, in parallel with content load)
- Saves on `ToggleInfoPane` changes with serialized writes (last write wins under rapid toggles)
- Settings read/write failures do not break browsing; default remains hidden when unset
- Unit tests cover service defaults/persistence, rapid-write ordering, view-model load/save, and failure resilience
- Merged with latest `main` (restore-to-destination + switch storage)

**Density / list-detail view mode:** Not implemented. The WinUI browser still exposes a single list presentation with no view-mode toggle (same practical decision as #525). Only the existing mutable layout preference (info pane) is persisted.

## Test plan

- [x] Run `dotnet test` on Windows (`BSH.Test`) and confirm new preference tests pass
- [x] Open Backup browser, enable Preview pane, restart app, confirm pane is open
- [x] Disable Preview pane, restart, confirm pane stays closed
- [x] Confirm folder navigation / restore still work with pane toggled
- [x] Rapidly toggle the preview pane and confirm the final state sticks after restart
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-861b4b92-a810-4574-9848-73ae20efcc81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-861b4b92-a810-4574-9848-73ae20efcc81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

