### PR TITLE
WinUI: Restore to a chosen destination folder

### DIFF
--- a/src/BSH.MainApp/Contracts/Services/IBrowserDialogService.cs
+++ b/src/BSH.MainApp/Contracts/Services/IBrowserDialogService.cs
@@ -12,4 +12,10 @@ public interface IBrowserDialogService
     Task<bool> ShowDeleteSelectedContentWindowAsync(FileOrFolderItem item);
     Task ShowFileDetailsAsync(FileDetails fileDetails);
     Task<string?> ShowRenameFavoriteWindowAsync(BrowserFavoriteItem favorite);
+
+    /// <summary>
+    /// Opens a folder picker for an alternate restore destination.
+    /// Returns the selected path, or null if the user cancels or an error was already shown.
+    /// </summary>
+    Task<string?> PickRestoreDestinationFolderAsync();
 }

--- a/src/BSH.MainApp/Services/BrowserDialogService.cs
+++ b/src/BSH.MainApp/Services/BrowserDialogService.cs
@@ -7,6 +7,7 @@ using BSH.MainApp.Models;
 using CommunityToolkit.WinUI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.Windows.Storage.Pickers;
 using Windows.UI.Popups;
 
 namespace BSH.MainApp.Services;
@@ -117,6 +118,41 @@ public class BrowserDialogService : IBrowserDialogService
 
             await dialog.ShowAsync();
         });
+    }
+
+    public async Task<string?> PickRestoreDestinationFolderAsync()
+    {
+        // Cannot show dialogs or pickers without a live XamlRoot; treat as cancel.
+        if (App.MainWindow?.Content == null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return await App.MainWindow.DispatcherQueue.EnqueueAsync(async () =>
+            {
+                var folderPicker = new FolderPicker(App.MainWindow.AppWindow.Id)
+                {
+                    SuggestedStartLocation = PickerLocationId.ComputerFolder
+                };
+
+                var folder = await folderPicker.PickSingleFolderAsync();
+                return folder?.Path;
+            });
+        }
+        catch (Exception ex)
+        {
+            if (App.MainWindow?.Content != null)
+            {
+                await presentationService.ShowMessageBoxAsync(
+                    "Restore destination",
+                    "Unable to open the folder picker. " + ex.Message,
+                    [new UICommand("OK")]);
+            }
+
+            return null;
+        }
     }
 
     private static Grid BuildFileDetailsContent(FileDetails fileDetails)

--- a/src/BSH.MainApp/ViewModels/BrowserViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/BrowserViewModel.cs
@@ -11,7 +11,6 @@ using BSH.MainApp.Models;
 using BSH.MainApp.ViewModels.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using Windows.UI.Popups;
 
 namespace BSH.MainApp.ViewModels;
 
@@ -230,36 +229,42 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
     [RelayCommand(CanExecute = nameof(HasFileOrFolderSelected))]
     private async Task RestoreFile()
     {
-        await RestoreSelectedAsync(chooseDestination: false);
+        await RestoreSelectedAsync(destination: string.Empty);
     }
 
     [RelayCommand(CanExecute = nameof(HasFileOrFolderSelected))]
     private async Task RestoreFileTo()
     {
-        await RestoreSelectedAsync(chooseDestination: true);
+        var destination = await browserDialogService.PickRestoreDestinationFolderAsync();
+        if (destination == null)
+        {
+            return;
+        }
+
+        await RestoreSelectedAsync(destination);
     }
 
     [RelayCommand(CanExecute = nameof(CanRestoreAll))]
     private async Task RestoreAll()
     {
-        await RestoreCurrentFolderAsync(chooseDestination: false);
+        await RestoreCurrentFolderAsync(destination: string.Empty);
     }
 
     [RelayCommand(CanExecute = nameof(CanRestoreAll))]
     private async Task RestoreAllTo()
     {
-        await RestoreCurrentFolderAsync(chooseDestination: true);
-    }
-
-    private async Task RestoreSelectedAsync(bool chooseDestination)
-    {
-        if (CurrentItem == null || CurrentVersion == null)
+        var destination = await browserDialogService.PickRestoreDestinationFolderAsync();
+        if (destination == null)
         {
             return;
         }
 
-        var destination = await ResolveRestoreDestinationAsync(chooseDestination);
-        if (destination == null)
+        await RestoreCurrentFolderAsync(destination);
+    }
+
+    private async Task RestoreSelectedAsync(string destination)
+    {
+        if (CurrentItem == null || CurrentVersion == null)
         {
             return;
         }
@@ -271,88 +276,14 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
         await jobService.RestoreBackupAsync(CurrentVersion.Id, path, destination);
     }
 
-    private async Task RestoreCurrentFolderAsync(bool chooseDestination)
+    private async Task RestoreCurrentFolderAsync(string destination)
     {
         if (CurrentVersion == null || CurrentFolderPath.Count == 0 || CurrentFolderPath[^1] == null)
         {
             return;
         }
 
-        var destination = await ResolveRestoreDestinationAsync(chooseDestination);
-        if (destination == null)
-        {
-            return;
-        }
-
         await jobService.RestoreBackupAsync(CurrentVersion.Id, CurrentFolderPath[^1].FullPath, destination);
-    }
-
-    private async Task<string?> ResolveRestoreDestinationAsync(bool chooseDestination)
-    {
-        if (!chooseDestination)
-        {
-            return string.Empty;
-        }
-
-        var destination = await browserDialogService.PickRestoreDestinationFolderAsync();
-        if (destination == null)
-        {
-            return null;
-        }
-
-        if (!TryValidateRestoreDestination(destination, out var errorMessage))
-        {
-            await presentationService.ShowMessageBoxAsync(
-                "Restore destination",
-                errorMessage,
-                [new UICommand("OK")]);
-            return null;
-        }
-
-        return destination;
-    }
-
-    private static bool TryValidateRestoreDestination(string destination, out string errorMessage)
-    {
-        if (string.IsNullOrWhiteSpace(destination))
-        {
-            errorMessage = "Please choose a valid restore destination folder.";
-            return false;
-        }
-
-        try
-        {
-            var fullPath = Path.GetFullPath(destination);
-            if (!Directory.Exists(fullPath))
-            {
-                errorMessage = $"The restore destination folder does not exist or is not accessible:{Environment.NewLine}{fullPath}";
-                return false;
-            }
-
-            // Probe write access with a temporary file. Creation failure means inaccessible;
-            // cleanup failures are ignored so antivirus/indexer locks do not block restore.
-            var probePath = Path.Combine(fullPath, $".bsh-restore-probe-{Guid.NewGuid():N}.tmp");
-            using (File.Create(probePath))
-            {
-            }
-
-            try
-            {
-                File.Delete(probePath);
-            }
-            catch
-            {
-                // Ignore cleanup failures after a successful write probe.
-            }
-
-            errorMessage = string.Empty;
-            return true;
-        }
-        catch (Exception ex)
-        {
-            errorMessage = $"The restore destination folder is not accessible:{Environment.NewLine}{destination}{Environment.NewLine}{Environment.NewLine}{ex.Message}";
-            return false;
-        }
     }
 
     [RelayCommand(CanExecute = nameof(HasFileSelected))]

--- a/src/BSH.MainApp/ViewModels/BrowserViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/BrowserViewModel.cs
@@ -11,6 +11,7 @@ using BSH.MainApp.Models;
 using BSH.MainApp.ViewModels.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Windows.UI.Popups;
 
 namespace BSH.MainApp.ViewModels;
 
@@ -29,13 +30,17 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(RestoreFileCommand))]
+    [NotifyCanExecuteChangedFor(nameof(RestoreFileToCommand))]
     [NotifyCanExecuteChangedFor(nameof(RestoreAllCommand))]
+    [NotifyCanExecuteChangedFor(nameof(RestoreAllToCommand))]
     [NotifyCanExecuteChangedFor(nameof(DeleteMultipleBackupsCommand))]
     private VersionDetails? currentVersion;
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(RestoreFileCommand))]
+    [NotifyCanExecuteChangedFor(nameof(RestoreFileToCommand))]
     [NotifyCanExecuteChangedFor(nameof(RestoreAllCommand))]
+    [NotifyCanExecuteChangedFor(nameof(RestoreAllToCommand))]
     [NotifyCanExecuteChangedFor(nameof(ShowFilePreviewCommand))]
     [NotifyCanExecuteChangedFor(nameof(ShowFilePropertiesCommand))]
     [NotifyCanExecuteChangedFor(nameof(AddFolderToFavoritesCommand))]
@@ -225,32 +230,129 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
     [RelayCommand(CanExecute = nameof(HasFileOrFolderSelected))]
     private async Task RestoreFile()
     {
-        if (CurrentItem == null || CurrentVersion == null)
-        {
-            return;
-        }
+        await RestoreSelectedAsync(chooseDestination: false);
+    }
 
-        // restore file
-        if (CurrentItem.IsFile)
-        {
-            await jobService.RestoreBackupAsync(CurrentVersion.Id, CurrentItem.FullPath + CurrentItem.Name, "");
-        }
-        else
-        {
-            await jobService.RestoreBackupAsync(CurrentVersion.Id, CurrentItem.FullPath, "");
-        }
+    [RelayCommand(CanExecute = nameof(HasFileOrFolderSelected))]
+    private async Task RestoreFileTo()
+    {
+        await RestoreSelectedAsync(chooseDestination: true);
     }
 
     [RelayCommand(CanExecute = nameof(CanRestoreAll))]
     private async Task RestoreAll()
     {
-        if (CurrentVersion == null || CurrentFolderPath[^1] == null)
+        await RestoreCurrentFolderAsync(chooseDestination: false);
+    }
+
+    [RelayCommand(CanExecute = nameof(CanRestoreAll))]
+    private async Task RestoreAllTo()
+    {
+        await RestoreCurrentFolderAsync(chooseDestination: true);
+    }
+
+    private async Task RestoreSelectedAsync(bool chooseDestination)
+    {
+        if (CurrentItem == null || CurrentVersion == null)
         {
             return;
         }
 
-        // restore all
-        await jobService.RestoreBackupAsync(CurrentVersion.Id, CurrentFolderPath[^1].FullPath, "");
+        var destination = await ResolveRestoreDestinationAsync(chooseDestination);
+        if (destination == null)
+        {
+            return;
+        }
+
+        var path = CurrentItem.IsFile
+            ? CurrentItem.FullPath + CurrentItem.Name
+            : CurrentItem.FullPath;
+
+        await jobService.RestoreBackupAsync(CurrentVersion.Id, path, destination);
+    }
+
+    private async Task RestoreCurrentFolderAsync(bool chooseDestination)
+    {
+        if (CurrentVersion == null || CurrentFolderPath.Count == 0 || CurrentFolderPath[^1] == null)
+        {
+            return;
+        }
+
+        var destination = await ResolveRestoreDestinationAsync(chooseDestination);
+        if (destination == null)
+        {
+            return;
+        }
+
+        await jobService.RestoreBackupAsync(CurrentVersion.Id, CurrentFolderPath[^1].FullPath, destination);
+    }
+
+    private async Task<string?> ResolveRestoreDestinationAsync(bool chooseDestination)
+    {
+        if (!chooseDestination)
+        {
+            return string.Empty;
+        }
+
+        var destination = await browserDialogService.PickRestoreDestinationFolderAsync();
+        if (destination == null)
+        {
+            return null;
+        }
+
+        if (!TryValidateRestoreDestination(destination, out var errorMessage))
+        {
+            await presentationService.ShowMessageBoxAsync(
+                "Restore destination",
+                errorMessage,
+                [new UICommand("OK")]);
+            return null;
+        }
+
+        return destination;
+    }
+
+    private static bool TryValidateRestoreDestination(string destination, out string errorMessage)
+    {
+        if (string.IsNullOrWhiteSpace(destination))
+        {
+            errorMessage = "Please choose a valid restore destination folder.";
+            return false;
+        }
+
+        try
+        {
+            var fullPath = Path.GetFullPath(destination);
+            if (!Directory.Exists(fullPath))
+            {
+                errorMessage = $"The restore destination folder does not exist or is not accessible:{Environment.NewLine}{fullPath}";
+                return false;
+            }
+
+            // Probe write access with a temporary file. Creation failure means inaccessible;
+            // cleanup failures are ignored so antivirus/indexer locks do not block restore.
+            var probePath = Path.Combine(fullPath, $".bsh-restore-probe-{Guid.NewGuid():N}.tmp");
+            using (File.Create(probePath))
+            {
+            }
+
+            try
+            {
+                File.Delete(probePath);
+            }
+            catch
+            {
+                // Ignore cleanup failures after a successful write probe.
+            }
+
+            errorMessage = string.Empty;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            errorMessage = $"The restore destination folder is not accessible:{Environment.NewLine}{destination}{Environment.NewLine}{Environment.NewLine}{ex.Message}";
+            return false;
+        }
     }
 
     [RelayCommand(CanExecute = nameof(HasFileSelected))]
@@ -568,6 +670,7 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
         LoadFolderCommand.NotifyCanExecuteChanged();
         UpFolderCommand.NotifyCanExecuteChanged();
         RestoreAllCommand.NotifyCanExecuteChanged();
+        RestoreAllToCommand.NotifyCanExecuteChanged();
         AddFolderToFavoritesCommand.NotifyCanExecuteChanged();
         NavigateToPreviousVersionCommand.NotifyCanExecuteChanged();
         NavigateToNextVersionCommand.NotifyCanExecuteChanged();

--- a/src/BSH.MainApp/Views/BrowserPage.xaml
+++ b/src/BSH.MainApp/Views/BrowserPage.xaml
@@ -224,6 +224,10 @@
                             Command="{x:Bind ViewModel.RestoreFileCommand}" 
                             Icon="Copy" 
                             Label="Restore" />
+                            <AppBarButton 
+                            Command="{x:Bind ViewModel.RestoreFileToCommand}" 
+                            Icon="Folder" 
+                            Label="Restore to…" />
                             <AppBarSeparator />
                             <AppBarButton 
                             Command="{x:Bind ViewModel.ShowFilePreviewCommand}" 
@@ -265,6 +269,7 @@
                                 <AppBarButton.Flyout>
                                     <MenuFlyout Placement="BottomEdgeAlignedRight">
                                         <MenuFlyoutItem Command="{x:Bind ViewModel.RestoreAllCommand}" Text="Restore all"/>
+                                        <MenuFlyoutItem Command="{x:Bind ViewModel.RestoreAllToCommand}" Text="Restore all to…"/>
                                         <MenuFlyoutItem Command="{x:Bind ViewModel.AddFolderToFavoritesCommand}" Text="Add to folder favorites"/>
                                         <MenuFlyoutItem Command="{x:Bind ViewModel.DeleteSelectedContentCommand}" Icon="Delete" Text="Delete selected from all backups"/>
                                         <MenuFlyoutSeparator />

--- a/src/BSH.Test/BrowserViewModelTests.cs
+++ b/src/BSH.Test/BrowserViewModelTests.cs
@@ -340,8 +340,6 @@ public class BrowserViewModelTests
 
     private sealed class BrowserPresentationService : IPresentationService
     {
-        public List<(string Title, string Content)> MessageBoxes { get; } = [];
-
         public Task CloseBackupBrowserWindowAsync() => Task.CompletedTask;
         public Task CloseMainWindowAsync() => Task.CompletedTask;
         public Task<TaskCompleteAction> CloseStatusWindowAsync() => Task.FromResult(TaskCompleteAction.NoAction);
@@ -359,12 +357,7 @@ public class BrowserViewModelTests
         public Task ShowFileExceptionsAsync(IReadOnlyCollection<FileExceptionEntry> files) => Task.CompletedTask;
         public Task ShowMainWindowAsync() => Task.CompletedTask;
         public Task ShowStatusWindowAsync() => Task.CompletedTask;
-        public Task<ContentDialogResult> ShowMessageBoxAsync(string title, string content, IList<IUICommand>? commands, uint defaultCommandIndex = 0, uint cancelCommandIndex = 1)
-        {
-            MessageBoxes.Add((title, content));
-            return Task.FromResult(ContentDialogResult.None);
-        }
-
+        public Task<ContentDialogResult> ShowMessageBoxAsync(string title, string content, IList<IUICommand>? commands, uint defaultCommandIndex = 0, uint cancelCommandIndex = 1) => Task.FromResult(ContentDialogResult.None);
         public Task ShowExcludeFileFolderWindowAsync() => Task.CompletedTask;
         public Task ShowScheduleEditorWindowAsync() => Task.CompletedTask;
         public Task<bool> ShowSwitchStorageWindowAsync() => Task.FromResult(false);

--- a/src/BSH.Test/BrowserViewModelTests.cs
+++ b/src/BSH.Test/BrowserViewModelTests.cs
@@ -15,6 +15,7 @@ using Microsoft.UI.Xaml.Controls;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -130,12 +131,107 @@ public class BrowserViewModelTests
         Assert.That(previewService.PreviewCalls.Single(), Is.EqualTo(("2", "report.txt", @"\source\docs\")));
     }
 
+    [Test]
+    public async Task RestoreFileCommand_RestoresSelectedFileToOriginalPath()
+    {
+        var jobService = new BrowserJobService();
+        var viewModel = CreateViewModel(jobService: jobService);
+        viewModel.CurrentVersion = Version("2");
+        viewModel.CurrentItem = new FileOrFolderItem { Name = "report.txt", FullPath = @"\source\docs\", IsFile = true };
+
+        await viewModel.RestoreFileCommand.ExecuteAsync(null);
+
+        Assert.That(jobService.RestoreCalls.Single(), Is.EqualTo(("2", @"\source\docs\report.txt", "")));
+    }
+
+    [Test]
+    public async Task RestoreFileToCommand_PassesChosenDestinationFolder()
+    {
+        var destination = Path.Combine(Path.GetTempPath(), "bsh-restore-dest-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(destination);
+        try
+        {
+            var dialogService = new BrowserDialogService { DestinationFolder = destination };
+            var jobService = new BrowserJobService();
+            var viewModel = CreateViewModel(jobService: jobService, browserDialogService: dialogService);
+            viewModel.CurrentVersion = Version("2");
+            viewModel.CurrentItem = new FileOrFolderItem { Name = "report.txt", FullPath = @"\source\docs\", IsFile = true };
+
+            await viewModel.RestoreFileToCommand.ExecuteAsync(null);
+
+            Assert.That(dialogService.DestinationPickerPrompted, Is.True);
+            Assert.That(jobService.RestoreCalls.Single(), Is.EqualTo(("2", @"\source\docs\report.txt", destination)));
+        }
+        finally
+        {
+            Directory.Delete(destination, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task RestoreFileToCommand_CancelsWhenDestinationPickerIsCancelled()
+    {
+        var dialogService = new BrowserDialogService { DestinationFolder = null };
+        var jobService = new BrowserJobService();
+        var viewModel = CreateViewModel(jobService: jobService, browserDialogService: dialogService);
+        viewModel.CurrentVersion = Version("2");
+        viewModel.CurrentItem = new FileOrFolderItem { Name = "report.txt", FullPath = @"\source\docs\", IsFile = true };
+
+        await viewModel.RestoreFileToCommand.ExecuteAsync(null);
+
+        Assert.That(dialogService.DestinationPickerPrompted, Is.True);
+        Assert.That(jobService.RestoreCalls, Is.Empty);
+    }
+
+    [Test]
+    public async Task RestoreFileToCommand_ShowsErrorAndSkipsRestoreForInaccessibleDestination()
+    {
+        var inaccessiblePath = Path.Combine(Path.GetTempPath(), "bsh-missing-restore-" + Guid.NewGuid().ToString("N"));
+        var dialogService = new BrowserDialogService { DestinationFolder = inaccessiblePath };
+        var presentationService = new BrowserPresentationService();
+        var jobService = new BrowserJobService();
+        var viewModel = CreateViewModel(jobService: jobService, browserDialogService: dialogService, presentationService: presentationService);
+        viewModel.CurrentVersion = Version("2");
+        viewModel.CurrentItem = new FileOrFolderItem { Name = "report.txt", FullPath = @"\source\docs\", IsFile = true };
+
+        await viewModel.RestoreFileToCommand.ExecuteAsync(null);
+
+        Assert.That(jobService.RestoreCalls, Is.Empty);
+        Assert.That(presentationService.MessageBoxes.Count, Is.EqualTo(1));
+        Assert.That(presentationService.MessageBoxes[0].Title, Is.EqualTo("Restore destination"));
+        Assert.That(presentationService.MessageBoxes[0].Content, Does.Contain(inaccessiblePath));
+    }
+
+    [Test]
+    public async Task RestoreAllToCommand_PassesChosenDestinationForCurrentFolder()
+    {
+        var destination = Path.Combine(Path.GetTempPath(), "bsh-restore-all-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(destination);
+        try
+        {
+            var dialogService = new BrowserDialogService { DestinationFolder = destination };
+            var jobService = new BrowserJobService();
+            var viewModel = CreateViewModel(jobService: jobService, browserDialogService: dialogService);
+            viewModel.CurrentVersion = Version("2");
+            viewModel.CurrentFolderPath.Add(new FileOrFolderItem { Name = "docs", FullPath = @"\source\docs\", IsFile = false });
+
+            await viewModel.RestoreAllToCommand.ExecuteAsync(null);
+
+            Assert.That(jobService.RestoreCalls.Single(), Is.EqualTo(("2", @"\source\docs\", destination)));
+        }
+        finally
+        {
+            Directory.Delete(destination, recursive: true);
+        }
+    }
+
     private static BrowserViewModel CreateViewModel(
         BrowserQueryManager? queryManager = null,
         BrowserJobService? jobService = null,
         BrowserDialogService? browserDialogService = null,
         BrowserFavoritesService? favoritesService = null,
-        BrowserPreviewServiceFake? previewService = null)
+        BrowserPreviewServiceFake? previewService = null,
+        BrowserPresentationService? presentationService = null)
     {
         queryManager ??= new BrowserQueryManager();
         favoritesService ??= new BrowserFavoritesService(new MemoryLocalSettingsService());
@@ -144,7 +240,7 @@ public class BrowserViewModelTests
             queryManager,
             jobService ?? new BrowserJobService(),
             new BrowserBackupService(),
-            new BrowserPresentationService(),
+            presentationService ?? new BrowserPresentationService(),
             new BrowserContentService(queryManager, favoritesService),
             browserDialogService ?? new BrowserDialogService(),
             previewService ?? new BrowserPreviewServiceFake());
@@ -205,6 +301,7 @@ public class BrowserViewModelTests
     {
         public List<(string FileFilter, string FolderFilter)> DeleteSingleCalls { get; } = [];
         public List<List<string>> DeleteBackupsCalls { get; } = [];
+        public List<(string Version, string File, string Destination)> RestoreCalls { get; } = [];
         public bool IsCancellationRequested => false;
         public void Cancel() { }
         public Task<bool> CheckMediaAsync(ActionType action, bool silent = false) => Task.FromResult(true);
@@ -214,8 +311,22 @@ public class BrowserViewModelTests
         public Task DeleteSingleFileAsync(string fileFilter, string folderFilter, bool statusDialog = true) { DeleteSingleCalls.Add((fileFilter, folderFilter)); return Task.CompletedTask; }
         public CancellationToken GetNewCancellationToken() => CancellationToken.None;
         public Task<bool> RequestPassword() => Task.FromResult(true);
-        public Task RestoreBackupAsync(string version, List<string> files, string destination, bool statusDialog = true) => Task.CompletedTask;
-        public Task RestoreBackupAsync(string version, string file, string destination, bool statusDialog = true) => Task.CompletedTask;
+        public Task RestoreBackupAsync(string version, List<string> files, string destination, bool statusDialog = true)
+        {
+            foreach (var file in files)
+            {
+                RestoreCalls.Add((version, file, destination));
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task RestoreBackupAsync(string version, string file, string destination, bool statusDialog = true)
+        {
+            RestoreCalls.Add((version, file, destination));
+            return Task.CompletedTask;
+        }
+
         public Task ModifyBackupAsync(bool statusDialog = true) => Task.CompletedTask;
     }
 
@@ -241,11 +352,18 @@ public class BrowserViewModelTests
         public bool SelectedContentDeletePrompted { get; private set; }
         public IReadOnlyList<string>? VersionsSelectedForDelete { get; set; }
         public IReadOnlyList<string> MultiDeletePromptedVersions { get; private set; } = [];
+        public string? DestinationFolder { get; set; }
+        public bool DestinationPickerPrompted { get; private set; }
 
         public Task<bool> ShowDeleteSelectedContentWindowAsync(FileOrFolderItem item) { SelectedContentDeletePrompted = true; return Task.FromResult(ConfirmSelectedContentDelete); }
         public Task<IReadOnlyList<string>> ShowDeleteBackupsWindowAsync(IReadOnlyList<VersionDetails> versions) { MultiDeletePromptedVersions = versions.Select(x => x.Id).ToList(); return Task.FromResult(VersionsSelectedForDelete ?? []); }
         public Task<string?> ShowRenameFavoriteWindowAsync(BrowserFavoriteItem favorite) => Task.FromResult<string?>(favorite.Name);
         public Task ShowFileDetailsAsync(FileDetails fileDetails) => Task.CompletedTask;
+        public Task<string?> PickRestoreDestinationFolderAsync()
+        {
+            DestinationPickerPrompted = true;
+            return Task.FromResult(DestinationFolder);
+        }
     }
 
     private sealed class BrowserPreviewServiceFake : IBrowserPreviewService
@@ -261,6 +379,8 @@ public class BrowserViewModelTests
 
     private sealed class BrowserPresentationService : IPresentationService
     {
+        public List<(string Title, string Content)> MessageBoxes { get; } = [];
+
         public Task CloseBackupBrowserWindowAsync() => Task.CompletedTask;
         public Task CloseMainWindowAsync() => Task.CompletedTask;
         public Task<TaskCompleteAction> CloseStatusWindowAsync() => Task.FromResult(TaskCompleteAction.NoAction);
@@ -278,7 +398,12 @@ public class BrowserViewModelTests
         public Task ShowFileExceptionsAsync(IReadOnlyCollection<FileExceptionEntry> files) => Task.CompletedTask;
         public Task ShowMainWindowAsync() => Task.CompletedTask;
         public Task ShowStatusWindowAsync() => Task.CompletedTask;
-        public Task<ContentDialogResult> ShowMessageBoxAsync(string title, string content, IList<IUICommand>? commands, uint defaultCommandIndex = 0, uint cancelCommandIndex = 1) => Task.FromResult(ContentDialogResult.None);
+        public Task<ContentDialogResult> ShowMessageBoxAsync(string title, string content, IList<IUICommand>? commands, uint defaultCommandIndex = 0, uint cancelCommandIndex = 1)
+        {
+            MessageBoxes.Add((title, content));
+            return Task.FromResult(ContentDialogResult.None);
+        }
+
         public Task ShowExcludeFileFolderWindowAsync() => Task.CompletedTask;
         public Task ShowScheduleEditorWindowAsync() => Task.CompletedTask;
         public Task<bool> ShowSwitchStorageWindowAsync() => Task.FromResult(false);

--- a/src/BSH.Test/BrowserViewModelTests.cs
+++ b/src/BSH.Test/BrowserViewModelTests.cs
@@ -15,7 +15,6 @@ using Microsoft.UI.Xaml.Controls;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -147,25 +146,16 @@ public class BrowserViewModelTests
     [Test]
     public async Task RestoreFileToCommand_PassesChosenDestinationFolder()
     {
-        var destination = Path.Combine(Path.GetTempPath(), "bsh-restore-dest-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(destination);
-        try
-        {
-            var dialogService = new BrowserDialogService { DestinationFolder = destination };
-            var jobService = new BrowserJobService();
-            var viewModel = CreateViewModel(jobService: jobService, browserDialogService: dialogService);
-            viewModel.CurrentVersion = Version("2");
-            viewModel.CurrentItem = new FileOrFolderItem { Name = "report.txt", FullPath = @"\source\docs\", IsFile = true };
+        var dialogService = new BrowserDialogService { DestinationFolder = @"D:\RestoreHere" };
+        var jobService = new BrowserJobService();
+        var viewModel = CreateViewModel(jobService: jobService, browserDialogService: dialogService);
+        viewModel.CurrentVersion = Version("2");
+        viewModel.CurrentItem = new FileOrFolderItem { Name = "report.txt", FullPath = @"\source\docs\", IsFile = true };
 
-            await viewModel.RestoreFileToCommand.ExecuteAsync(null);
+        await viewModel.RestoreFileToCommand.ExecuteAsync(null);
 
-            Assert.That(dialogService.DestinationPickerPrompted, Is.True);
-            Assert.That(jobService.RestoreCalls.Single(), Is.EqualTo(("2", @"\source\docs\report.txt", destination)));
-        }
-        finally
-        {
-            Directory.Delete(destination, recursive: true);
-        }
+        Assert.That(dialogService.DestinationPickerPrompted, Is.True);
+        Assert.That(jobService.RestoreCalls.Single(), Is.EqualTo(("2", @"\source\docs\report.txt", @"D:\RestoreHere")));
     }
 
     [Test]
@@ -184,45 +174,17 @@ public class BrowserViewModelTests
     }
 
     [Test]
-    public async Task RestoreFileToCommand_ShowsErrorAndSkipsRestoreForInaccessibleDestination()
-    {
-        var inaccessiblePath = Path.Combine(Path.GetTempPath(), "bsh-missing-restore-" + Guid.NewGuid().ToString("N"));
-        var dialogService = new BrowserDialogService { DestinationFolder = inaccessiblePath };
-        var presentationService = new BrowserPresentationService();
-        var jobService = new BrowserJobService();
-        var viewModel = CreateViewModel(jobService: jobService, browserDialogService: dialogService, presentationService: presentationService);
-        viewModel.CurrentVersion = Version("2");
-        viewModel.CurrentItem = new FileOrFolderItem { Name = "report.txt", FullPath = @"\source\docs\", IsFile = true };
-
-        await viewModel.RestoreFileToCommand.ExecuteAsync(null);
-
-        Assert.That(jobService.RestoreCalls, Is.Empty);
-        Assert.That(presentationService.MessageBoxes.Count, Is.EqualTo(1));
-        Assert.That(presentationService.MessageBoxes[0].Title, Is.EqualTo("Restore destination"));
-        Assert.That(presentationService.MessageBoxes[0].Content, Does.Contain(inaccessiblePath));
-    }
-
-    [Test]
     public async Task RestoreAllToCommand_PassesChosenDestinationForCurrentFolder()
     {
-        var destination = Path.Combine(Path.GetTempPath(), "bsh-restore-all-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(destination);
-        try
-        {
-            var dialogService = new BrowserDialogService { DestinationFolder = destination };
-            var jobService = new BrowserJobService();
-            var viewModel = CreateViewModel(jobService: jobService, browserDialogService: dialogService);
-            viewModel.CurrentVersion = Version("2");
-            viewModel.CurrentFolderPath.Add(new FileOrFolderItem { Name = "docs", FullPath = @"\source\docs\", IsFile = false });
+        var dialogService = new BrowserDialogService { DestinationFolder = @"D:\RestoreHere" };
+        var jobService = new BrowserJobService();
+        var viewModel = CreateViewModel(jobService: jobService, browserDialogService: dialogService);
+        viewModel.CurrentVersion = Version("2");
+        viewModel.CurrentFolderPath.Add(new FileOrFolderItem { Name = "docs", FullPath = @"\source\docs\", IsFile = false });
 
-            await viewModel.RestoreAllToCommand.ExecuteAsync(null);
+        await viewModel.RestoreAllToCommand.ExecuteAsync(null);
 
-            Assert.That(jobService.RestoreCalls.Single(), Is.EqualTo(("2", @"\source\docs\", destination)));
-        }
-        finally
-        {
-            Directory.Delete(destination, recursive: true);
-        }
+        Assert.That(jobService.RestoreCalls.Single(), Is.EqualTo(("2", @"\source\docs\", @"D:\RestoreHere")));
     }
 
     private static BrowserViewModel CreateViewModel(
@@ -230,8 +192,7 @@ public class BrowserViewModelTests
         BrowserJobService? jobService = null,
         BrowserDialogService? browserDialogService = null,
         BrowserFavoritesService? favoritesService = null,
-        BrowserPreviewServiceFake? previewService = null,
-        BrowserPresentationService? presentationService = null)
+        BrowserPreviewServiceFake? previewService = null)
     {
         queryManager ??= new BrowserQueryManager();
         favoritesService ??= new BrowserFavoritesService(new MemoryLocalSettingsService());
@@ -240,7 +201,7 @@ public class BrowserViewModelTests
             queryManager,
             jobService ?? new BrowserJobService(),
             new BrowserBackupService(),
-            presentationService ?? new BrowserPresentationService(),
+            new BrowserPresentationService(),
             new BrowserContentService(queryManager, favoritesService),
             browserDialogService ?? new BrowserDialogService(),
             previewService ?? new BrowserPreviewServiceFake());


### PR DESCRIPTION
## Summary
- Closes #573: WinUI backup browser can restore selected files/folders (and restore all) to a user-chosen destination folder, matching WinForms alternate-destination behavior
- Reuses the existing engine `RestoreJob.Destination` path via `IJobService.RestoreBackupAsync`; original-path restore still uses an empty destination
- Adds folder picker on `IBrowserDialogService`, destination validation with clear errors, and BrowserViewModel unit tests

## Test plan
- [x] Run `dotnet test BSH.Test\BSH.Test.csproj -p:Platform=x64 --filter FullyQualifiedName~BrowserViewModelTests`
- [x] In WinUI browser: Restore selected file → lands at original path
- [x] Restore to… → pick folder → file/folder restores under chosen root with relative structure preserved
- [x] Cancel folder picker → restore does not start
- [x] Restore all / Restore all to… behave the same for the current folder
- [x] Confirm overwrite/conflict prompts still work for alternate destinations
