### PR TITLE
fix: Incremental disk-space preflight false aborts (#556)

### DIFF
--- a/src/BSH.Engine/Jobs/BackupJob.cs
+++ b/src/BSH.Engine/Jobs/BackupJob.cs
@@ -197,7 +197,7 @@ public class BackupJob : Job
             _logger.Information("{NumFiles} files and {NumFolders} folders are collected for backup.", files.Count, emptyFolder.Count);
 
             var freeSpaceBytes = storage.GetFreeSpace();
-            var estimatedBytes = DiskSpacePreflight.EstimateRequiredBytes(files.Select(f => f.FileSize));
+            var estimatedBytes = await EstimateRequiredCopyBytesAsync(dbClient, files);
             if (DiskSpacePreflight.IsClearlyInsufficient(freeSpaceBytes, estimatedBytes))
             {
                 await AbortForInsufficientDiskSpaceAsync(dbClient, newVersionDate, estimatedBytes, freeSpaceBytes);
@@ -397,6 +397,39 @@ public class BackupJob : Job
         await RequestShowErrorInsufficientDiskSpaceAsync();
         RollbackIncompleteVersion(dbClient, versionDate);
         ReportState(JobState.ERROR);
+    }
+
+    /// <summary>
+    /// Estimates bytes that will be written for this backup. Incremental runs only
+    /// count files without a matching existing version; unchanged files are link-only.
+    /// </summary>
+    private async Task<long> EstimateRequiredCopyBytesAsync(DbClient dbClient, List<FileTableRow> files)
+    {
+        if (FullBackup)
+        {
+            return DiskSpacePreflight.EstimateRequiredBytes(files.Select(file => file.FileSize));
+        }
+
+        var copyCandidates = new List<(double FileSize, bool HasMatchingVersion)>(files.Count);
+        foreach (var file in files)
+        {
+            var filePath = "\\" + Path.Combine(Path.GetFileName(file.FileRoot), file.FilePath) + "\\";
+            var fileId = await backupMutationRepository.GetFileIdAsync(dbClient, file.FileName, filePath);
+            if (!fileId.HasValue)
+            {
+                copyCandidates.Add((file.FileSize, HasMatchingVersion: false));
+                continue;
+            }
+
+            var fileVersionId = await backupMutationRepository.GetMatchingFileVersionIdAsync(
+                dbClient,
+                fileId.Value,
+                file.FileSize,
+                file.FileDateModified);
+            copyCandidates.Add((file.FileSize, HasMatchingVersion: fileVersionId.HasValue));
+        }
+
+        return DiskSpacePreflight.EstimateRequiredCopyBytes(fullBackup: false, copyCandidates);
     }
 
     private void RollbackIncompleteVersion(DbClient dbClient, string versionDate)

--- a/src/BSH.Engine/Utils/DiskSpacePreflight.cs
+++ b/src/BSH.Engine/Utils/DiskSpacePreflight.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Brightbits.BSH.Engine.Utils;
 
@@ -32,6 +33,25 @@ public static class DiskSpacePreflight
         }
 
         return total;
+    }
+
+    /// <summary>
+    /// Estimates bytes that will actually be written to the backup device.
+    /// Full backups copy every collected file; incrementals only copy files without
+    /// a matching existing version (unchanged files are link-only and need no space).
+    /// </summary>
+    public static long EstimateRequiredCopyBytes(
+        bool fullBackup,
+        IEnumerable<(double FileSize, bool HasMatchingVersion)> files,
+        long slackBytes = DefaultSlackBytes)
+    {
+        ArgumentNullException.ThrowIfNull(files);
+
+        var sizesToCopy = fullBackup
+            ? files.Select(file => file.FileSize)
+            : files.Where(file => !file.HasMatchingVersion).Select(file => file.FileSize);
+
+        return EstimateRequiredBytes(sizesToCopy, slackBytes);
     }
 
     /// <summary>

--- a/src/BSH.Test/DiskSpacePreflightTests.cs
+++ b/src/BSH.Test/DiskSpacePreflightTests.cs
@@ -64,4 +64,57 @@ public class DiskSpacePreflightTests
         Assert.That(DiskSpacePreflight.IsClearlyInsufficient(4_999, estimatedRequiredBytes: 5_000), Is.True);
         Assert.That(DiskSpacePreflight.IsClearlyInsufficient(100, estimatedRequiredBytes: 1_000_000), Is.True);
     }
+
+    [Test]
+    public void EstimateRequiredCopyBytes_FullBackup_IncludesAllCollectedFiles()
+    {
+        var estimate = DiskSpacePreflight.EstimateRequiredCopyBytes(
+            fullBackup: true,
+            new[]
+            {
+                (FileSize: 100_000d, HasMatchingVersion: true),
+                (FileSize: 200_000d, HasMatchingVersion: false),
+            },
+            slackBytes: 50);
+
+        Assert.That(estimate, Is.EqualTo(300_050));
+    }
+
+    [Test]
+    public void EstimateRequiredCopyBytes_Incremental_IgnoresUnchangedLinkOnlyFiles()
+    {
+        // Large unchanged source tree must not inflate the estimate; only the changed
+        // 10 MB file should count (plus slack).
+        var estimate = DiskSpacePreflight.EstimateRequiredCopyBytes(
+            fullBackup: false,
+            new[]
+            {
+                (FileSize: 500_000_000_000d, HasMatchingVersion: true),
+                (FileSize: 10_000_000d, HasMatchingVersion: false),
+                (FileSize: 250_000_000_000d, HasMatchingVersion: true),
+            },
+            slackBytes: 16);
+
+        Assert.That(estimate, Is.EqualTo(10_000_016));
+        Assert.That(
+            DiskSpacePreflight.IsClearlyInsufficient(100_000_000_000, estimate),
+            Is.False,
+            "Incremental with ample free space for changed bytes must not abort.");
+    }
+
+    [Test]
+    public void EstimateRequiredCopyBytes_Incremental_CountsNewAndChangedFiles()
+    {
+        var estimate = DiskSpacePreflight.EstimateRequiredCopyBytes(
+            fullBackup: false,
+            new[]
+            {
+                (FileSize: 1_000d, HasMatchingVersion: false),
+                (FileSize: 2_000d, HasMatchingVersion: true),
+                (FileSize: 3_000d, HasMatchingVersion: false),
+            },
+            slackBytes: 100);
+
+        Assert.That(estimate, Is.EqualTo(4_100));
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Bug and impact

After #556, disk-space preflight estimated required bytes as the sum of **all collected source files** before incremental matching. Incremental backups only copy new/changed files (unchanged files are DB link-only), so any local target with free space smaller than the full source tree aborted with “insufficient disk space” even when only megabytes needed copying.

**Trigger:** Existing local backup of a large source tree; next incremental has little/no changed data; target free space &lt; total source size → backup aborts early and produces no recovery point.

## Root cause

`BackupJob.BackupAsync` called `DiskSpacePreflight.EstimateRequiredBytes(files.Select(f => f.FileSize))` immediately after file collection, before `GetMatchingFileVersionIdAsync` / link-only handling. Issue #181 triage asked to estimate **changed/new** bytes; the merge summed every candidate.

## Fix

- Full backups: still estimate from all collected file sizes.
- Incremental backups: estimate only files without a matching existing version (same rule as the copy loop).
- Added `DiskSpacePreflight.EstimateRequiredCopyBytes` plus unit tests covering the false-abort scenario.

## Validation

- `dotnet build BSH.Engine -p:EnableWindowsTargeting=true -p:Platform=x64` succeeded.
- Smoke-tested `EstimateRequiredCopyBytes` / `IsClearlyInsufficient` against the large-unchanged + small-changed case (estimate = changed bytes + slack; not insufficient vs 100 GB free).
- Full NUnit suite not run here (Linux / `net*-windows`); new cases are in `DiskSpacePreflightTests`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3afb2e06-7790-4aad-a0fc-dabe41870b12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3afb2e06-7790-4aad-a0fc-dabe41870b12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

