### PR TITLE
WinUI: Wire notification activation and click handling

### DIFF
--- a/src/BSH.MainApp/Activation/AppNotificationActivationHandler.cs
+++ b/src/BSH.MainApp/Activation/AppNotificationActivationHandler.cs
@@ -1,15 +1,20 @@
 ﻿// Copyright (c) Alexander Seeliger. All Rights Reserved.
 // Licensed under the Apache License, Version 2.0.
 
+using BSH.MainApp.Contracts.Services;
 using Microsoft.UI.Xaml;
 using Microsoft.Windows.AppLifecycle;
+using Microsoft.Windows.AppNotifications;
 
 namespace BSH.MainApp.Activation;
 
 public class AppNotificationActivationHandler : ActivationHandler<LaunchActivatedEventArgs>
 {
-    public AppNotificationActivationHandler()
+    private readonly IAppNotificationService _notificationService;
+
+    public AppNotificationActivationHandler(IAppNotificationService notificationService)
     {
+        _notificationService = notificationService;
     }
 
     protected override bool CanHandleInternal(LaunchActivatedEventArgs? args)
@@ -17,23 +22,10 @@ public class AppNotificationActivationHandler : ActivationHandler<LaunchActivate
         return AppInstance.GetCurrent().GetActivatedEventArgs()?.Kind == ExtendedActivationKind.AppNotification;
     }
 
-    protected async override Task HandleInternalAsync(LaunchActivatedEventArgs? args)
+    protected override Task HandleInternalAsync(LaunchActivatedEventArgs? args)
     {
-        // TODO: Handle notification activations.
-
-        //// // Access the AppNotificationActivatedEventArgs.
-        //// var activatedEventArgs = (AppNotificationActivatedEventArgs)AppInstance.GetCurrent().GetActivatedEventArgs().Data;
-
-        //// // Navigate to a specific page based on the notification arguments.
-        //// if (_notificationService.ParseArguments(activatedEventArgs.Argument)["action"] == "Settings")
-        //// {
-        ////     // Queue navigation with low priority to allow the UI to initialize.
-        ////     App.MainWindow.DispatcherQueue.TryEnqueue(DispatcherQueuePriority.Low, () =>
-        ////     {
-        ////         _navigationService.NavigateTo(typeof(SettingsViewModel).FullName!);
-        ////     });
-        //// }
-
-        await Task.CompletedTask;
+        var argument = (AppInstance.GetCurrent().GetActivatedEventArgs()?.Data as AppNotificationActivatedEventArgs)?.Argument;
+        _notificationService.Activate(argument);
+        return Task.CompletedTask;
     }
 }

--- a/src/BSH.MainApp/Contracts/Services/IAppNotificationService.cs
+++ b/src/BSH.MainApp/Contracts/Services/IAppNotificationService.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Alexander Seeliger. All Rights Reserved.
 // Licensed under the Apache License, Version 2.0.
 
-using System.Collections.Specialized;
-
 namespace BSH.MainApp.Contracts.Services;
 
 public interface IAppNotificationService
@@ -11,7 +9,7 @@ public interface IAppNotificationService
 
     bool Show(string payload);
 
-    NameValueCollection ParseArguments(string arguments);
+    void Activate(string? arguments);
 
     void Unregister();
 }

--- a/src/BSH.MainApp/Services/AppNotificationService.cs
+++ b/src/BSH.MainApp/Services/AppNotificationService.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) Alexander Seeliger. All Rights Reserved.
 // Licensed under the Apache License, Version 2.0.
 
-using System.Collections.Specialized;
-using System.Web;
-
 using BSH.MainApp.Contracts.Services;
+using BSH.MainApp.Services;
+using Microsoft.UI.Dispatching;
 using Microsoft.Windows.AppNotifications;
 
 namespace BSH.MainApp.Notifications;
@@ -29,38 +28,34 @@ public class AppNotificationService : IAppNotificationService
         AppNotificationManager.Default.Register();
     }
 
-
     public void OnNotificationInvoked(AppNotificationManager sender, AppNotificationActivatedEventArgs args)
     {
-        // TODO: Handle notification invocations when your app is already running.
-
-        //// // Navigate to a specific page based on the notification arguments.
-        //// if (ParseArguments(args.Argument)["action"] == "Settings")
-        //// {
-        ////    App.MainWindow.DispatcherQueue.TryEnqueue(() =>
-        ////    {
-        ////        _navigationService.NavigateTo(typeof(SettingsViewModel).FullName!);
-        ////    });
-        //// }
-
-        App.MainWindow.DispatcherQueue.TryEnqueue(() =>
-        {
-            App.MainWindow.AppWindow.MoveInZOrderAtTop();
-        });
+        Activate(args?.Argument);
     }
 
     public bool Show(string payload)
     {
         var appNotification = new AppNotification(payload);
-
         AppNotificationManager.Default.Show(appNotification);
-
         return appNotification.Id != 0;
     }
 
-    public NameValueCollection ParseArguments(string arguments)
+    public void Activate(string? arguments)
     {
-        return HttpUtility.ParseQueryString(arguments);
+        var pageKey = ToastNotificationActivation.ResolvePageKey(arguments);
+        App.MainWindow.DispatcherQueue.TryEnqueue(DispatcherQueuePriority.Low, () =>
+        {
+            try
+            {
+                _navigationService.NavigateTo(pageKey);
+                App.MainWindow.Activate();
+                App.MainWindow.AppWindow.MoveInZOrderAtTop();
+            }
+            catch
+            {
+                // Fail safe: never crash from toast activation.
+            }
+        });
     }
 
     public void Unregister()

--- a/src/BSH.MainApp/Services/OrchestrationService.cs
+++ b/src/BSH.MainApp/Services/OrchestrationService.cs
@@ -185,7 +185,8 @@ public class OrchestrationService : IOrchestrationService
         {
             appNotificationService.Show(ToastNotificationPayload.Create(
                 "Not enough disk space.",
-                "There is not enough storage space left on the backup medium. Delete backups or switch to a new medium."));
+                "There is not enough storage space left on the backup medium. Delete backups or switch to a new medium.",
+                ToastNotificationActivation.ActionSettings));
         }
     }
 
@@ -207,6 +208,7 @@ public class OrchestrationService : IOrchestrationService
         var days = DateTime.Now.Subtract(lastBackup.CreationDate).Days;
         appNotificationService.Show(ToastNotificationPayload.Create(
             "Backup outdated",
-            $"Your last data backup is already {days} days old. Perform a data backup to ensure your current files are backed up."));
+            $"Your last data backup is already {days} days old. Perform a data backup to ensure your current files are backed up.",
+            ToastNotificationActivation.ActionOverview));
     }
 }

--- a/src/BSH.MainApp/Services/StatusService.cs
+++ b/src/BSH.MainApp/Services/StatusService.cs
@@ -116,11 +116,17 @@ public class StatusService : IJobReport, IStatusService
 
         if (jobState == JobState.FINISHED)
         {
-            ShowNotification("Backup successful", "Planned backup was performed successfully.");
+            ShowNotification(
+                "Backup successful",
+                "Planned backup was performed successfully.",
+                ToastNotificationActivation.ActionOverview);
         }
         else if (jobState == JobState.ERROR)
         {
-            ShowNotification("Backup with errors finished", "The planned backup was ended with problems. Click here for more information.");
+            ShowNotification(
+                "Backup with errors finished",
+                "The planned backup was ended with problems. Click here for more information.",
+                ToastNotificationActivation.ActionBackupResult);
         }
     }
 
@@ -200,8 +206,8 @@ public class StatusService : IJobReport, IStatusService
         await this.presentationService.ShowErrorInsufficientDiskSpaceAsync();
     }
 
-    private void ShowNotification(string title, string text)
+    private void ShowNotification(string title, string text, string action)
     {
-        appNotificationService?.Show(ToastNotificationPayload.Create(title, text));
+        appNotificationService?.Show(ToastNotificationPayload.Create(title, text, action));
     }
 }

--- a/src/BSH.MainApp/Services/ToastNotificationActivation.cs
+++ b/src/BSH.MainApp/Services/ToastNotificationActivation.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Web;
+
+namespace BSH.MainApp.Services;
+
+/// <summary>
+/// Maps toast activation arguments to a navigation page key.
+/// Unknown or missing payloads resolve to overview.
+/// </summary>
+public static class ToastNotificationActivation
+{
+    public const string ActionOverview = "overview";
+    public const string ActionSettings = "settings";
+    public const string ActionBackupResult = "backupResult";
+
+    public const string PageKeyOverview = "BSH.MainApp.ViewModels.MainViewModel";
+    public const string PageKeySettings = "BSH.MainApp.ViewModels.SettingsViewModel";
+
+    public static string ResolvePageKey(string? arguments)
+    {
+        try
+        {
+            var action = HttpUtility.ParseQueryString(arguments ?? string.Empty).Get("action");
+
+            return action switch
+            {
+                ActionSettings => PageKeySettings,
+                _ => PageKeyOverview,
+            };
+        }
+        catch
+        {
+            return PageKeyOverview;
+        }
+    }
+}

--- a/src/BSH.MainApp/Services/ToastNotificationPayload.cs
+++ b/src/BSH.MainApp/Services/ToastNotificationPayload.cs
@@ -7,10 +7,12 @@ namespace BSH.MainApp.Services;
 
 internal static class ToastNotificationPayload
 {
-    public static string Create(string title, string text)
+    public static string Create(string title, string text, string action)
     {
+        var launch = SecurityElement.Escape($"action={action}");
+
         return $"""
-            <toast>
+            <toast launch="{launch}">
                 <visual>
                     <binding template="ToastGeneric">
                         <text>{SecurityElement.Escape(title)}</text>

--- a/src/BSH.Test/ToastNotificationActivationTests.cs
+++ b/src/BSH.Test/ToastNotificationActivationTests.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using BSH.MainApp.Services;
+using NUnit.Framework;
+
+namespace BSH.Test;
+
+public class ToastNotificationActivationTests
+{
+    [TestCase(null, ToastNotificationActivation.PageKeyOverview)]
+    [TestCase("", ToastNotificationActivation.PageKeyOverview)]
+    [TestCase("action=overview", ToastNotificationActivation.PageKeyOverview)]
+    [TestCase("action=settings", ToastNotificationActivation.PageKeySettings)]
+    [TestCase("action=backupResult", ToastNotificationActivation.PageKeyOverview)]
+    [TestCase("action=unknown", ToastNotificationActivation.PageKeyOverview)]
+    [TestCase("not-a-query", ToastNotificationActivation.PageKeyOverview)]
+    public void ResolvePageKeyMapsArgumentsToSafeNavigationTargets(string? arguments, string expectedPageKey)
+    {
+        Assert.That(ToastNotificationActivation.ResolvePageKey(arguments), Is.EqualTo(expectedPageKey));
+    }
+
+    [Test]
+    public void ResolvePageKeyDoesNotThrowOnMalformedArguments()
+    {
+        Assert.DoesNotThrow(() => ToastNotificationActivation.ResolvePageKey("action=%zz&%%%"));
+    }
+}

--- a/src/BSH.Test/WinUiOrchestrationParityTests.cs
+++ b/src/BSH.Test/WinUiOrchestrationParityTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Collections.Specialized;
 using System.Threading;
 using System.Threading.Tasks;
 using Brightbits.BSH.Engine;
@@ -251,6 +250,7 @@ public class WinUiOrchestrationParityTests
 
         Assert.That(notifications.Payloads, Has.Count.EqualTo(1));
         Assert.That(notifications.Payloads[0], Does.Contain("Not enough disk space"));
+        Assert.That(notifications.Payloads[0], Does.Contain("launch=\"action=settings\""));
     }
 
     [Test]
@@ -279,11 +279,12 @@ public class WinUiOrchestrationParityTests
 
         Assert.That(notifications.Payloads, Has.Count.EqualTo(1));
         Assert.That(notifications.Payloads[0], Does.Contain("Backup outdated"));
+        Assert.That(notifications.Payloads[0], Does.Contain("launch=\"action=overview\""));
     }
 
-    [TestCase(JobState.FINISHED, "Backup successful")]
-    [TestCase(JobState.ERROR, "Backup with errors finished")]
-    public void StatusServiceShowsBackupCompletionNotifications(JobState state, string expectedTitle)
+    [TestCase(JobState.FINISHED, "Backup successful", "action=overview")]
+    [TestCase(JobState.ERROR, "Backup with errors finished", "action=backupResult")]
+    public void StatusServiceShowsBackupCompletionNotifications(JobState state, string expectedTitle, string expectedLaunch)
     {
         var notifications = new TestNotificationService();
         var configurationManager = new TestConfigurationManager
@@ -300,6 +301,7 @@ public class WinUiOrchestrationParityTests
 
         Assert.That(notifications.Payloads, Has.Count.EqualTo(1));
         Assert.That(notifications.Payloads[0], Does.Contain(expectedTitle));
+        Assert.That(notifications.Payloads[0], Does.Contain($"launch=\"{expectedLaunch}\""));
     }
 
     [Test]
@@ -470,7 +472,7 @@ public class WinUiOrchestrationParityTests
         public List<string> Payloads { get; } = new();
 
         public void Initialize() { }
-        public NameValueCollection ParseArguments(string arguments) => new();
+        public void Activate(string? arguments) { }
         public bool Show(string payload)
         {
             Payloads.Add(payload);


### PR DESCRIPTION
## Summary
- Replace TemplateStudio notification stubs with real cold-start and already-running toast activation (`#574`).
- Toast payloads include `launch="action=…"` so clicks navigate to overview or settings; unknown/missing args fall back to overview safely.
- Add focused unit coverage for launch-arg routing and payload launch attributes.

## Test plan
- [x] `dotnet test BSH.Test\BSH.Test.csproj -p:Platform=x64 --filter "FullyQualifiedName~ToastNotificationActivation|FullyQualifiedName~StatusServiceShowsBackup|FullyQualifiedName~StartAsyncShowsLowDisk|FullyQualifiedName~StartAsyncShowsOutdated"`
- [x] With the WinUI app running, trigger a backup-complete toast and click it → overview opens and window focuses
- [ ] Trigger a low-disk-space toast and click it → settings opens
- [x] Click a toast while the app is closed (cold start) → app launches to the mapped view without crashing
- [x] Click a toast with missing/unknown launch args → app focuses overview without crashing
