### PR TITLE
WinUI: Log and surface unhandled exceptions (#575)

### DIFF
--- a/src/BSH.MainApp/App.xaml.cs
+++ b/src/BSH.MainApp/App.xaml.cs
@@ -29,7 +29,9 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
+using Windows.UI.Popups;
 
 namespace BSH.MainApp;
 
@@ -51,6 +53,8 @@ public partial class App : Application
         get; private set;
     }
 
+    private readonly UnhandledExceptionHandler unhandledExceptionHandler;
+
     public static T GetService<T>()
         where T : class
     {
@@ -69,6 +73,10 @@ public partial class App : Application
     public App()
     {
         InitializeComponent();
+
+        unhandledExceptionHandler = new UnhandledExceptionHandler(
+            askContinueAsync: AskContinueAfterUnhandledExceptionAsync,
+            exitApplication: ExitAfterUnhandledException);
 
         Host = Microsoft.Extensions.Hosting.Host.
         CreateDefaultBuilder().
@@ -153,12 +161,57 @@ public partial class App : Application
         App.GetService<IAppNotificationService>().Initialize();
 
         UnhandledException += App_UnhandledException;
+        AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
+        TaskScheduler.UnobservedTaskException += TaskScheduler_UnobservedTaskException;
     }
 
     private void App_UnhandledException(object sender, Microsoft.UI.Xaml.UnhandledExceptionEventArgs e)
     {
-        // TODO: Log and handle exceptions as appropriate.
-        // https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.application.unhandledexception.
+        // Keep the process alive so we can log and surface the error instead of exiting silently.
+        e.Handled = true;
+        _ = unhandledExceptionHandler.HandleAsync(e.Exception, e.Message);
+    }
+
+    private void CurrentDomain_UnhandledException(object sender, System.UnhandledExceptionEventArgs e)
+    {
+        var exception = e.ExceptionObject as Exception;
+        if (e.IsTerminating)
+        {
+            unhandledExceptionHandler.HandleTerminating(exception);
+            return;
+        }
+
+        _ = unhandledExceptionHandler.HandleAsync(exception);
+    }
+
+    private void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
+    {
+        e.SetObserved();
+        _ = unhandledExceptionHandler.HandleAsync(e.Exception);
+    }
+
+    private static async Task<bool> AskContinueAfterUnhandledExceptionAsync(string title, string content)
+    {
+        var result = await GetService<IPresentationService>().ShowMessageBoxAsync(
+            title,
+            content,
+            [new UICommand("Continue"), new UICommand("Exit")]);
+
+        return result == ContentDialogResult.Primary;
+    }
+
+    private static void ExitAfterUnhandledException()
+    {
+        try
+        {
+            GetService<IOrchestrationService>().StopAsync().GetAwaiter().GetResult();
+        }
+        catch
+        {
+            // Best-effort shutdown before forced exit.
+        }
+
+        ExitApplication();
     }
 
     protected async override void OnLaunched(LaunchActivatedEventArgs args)

--- a/src/BSH.MainApp/Services/UnhandledExceptionHandler.cs
+++ b/src/BSH.MainApp/Services/UnhandledExceptionHandler.cs
@@ -1,0 +1,150 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Serilog;
+
+namespace BSH.MainApp.Services;
+
+/// <summary>
+/// Logs unhandled exceptions, shows a Continue/Exit prompt, and exits when needed.
+/// </summary>
+public sealed class UnhandledExceptionHandler
+{
+    private readonly Func<string, string, Task<bool>> askContinueAsync;
+    private readonly Action exitApplication;
+    private readonly Action<Exception> logError;
+    private readonly Action flushLogs;
+    private int isPresenting;
+
+    public UnhandledExceptionHandler(
+        Func<string, string, Task<bool>> askContinueAsync,
+        Action exitApplication,
+        Action<Exception>? logError = null,
+        Action? flushLogs = null)
+    {
+        this.askContinueAsync = askContinueAsync;
+        this.exitApplication = exitApplication;
+        this.logError = logError ?? DefaultLog;
+        this.flushLogs = flushLogs ?? Log.CloseAndFlush;
+    }
+
+    public Task HandleAsync(Exception? exception, string? preferredMessage = null) =>
+        PresentAsync(exception, preferredMessage, exitIfShowFails: true);
+
+    public void HandleTerminating(Exception? exception)
+    {
+        try
+        {
+            PresentAsync(exception, preferredMessage: null, exitIfShowFails: false)
+                .GetAwaiter()
+                .GetResult();
+        }
+        catch
+        {
+            // Best-effort surface during process teardown.
+        }
+        finally
+        {
+            flushLogs();
+        }
+    }
+
+    private async Task PresentAsync(Exception? exception, string? preferredMessage, bool exitIfShowFails)
+    {
+        var resolved = exception ?? new InvalidOperationException(
+            string.IsNullOrWhiteSpace(preferredMessage)
+                ? "An unexpected error occurred without exception details."
+                : preferredMessage);
+
+        logError(resolved);
+
+        if (Interlocked.Exchange(ref isPresenting, 1) == 1)
+        {
+            return;
+        }
+
+        try
+        {
+            var continueRunning = await askContinueAsync("Unexpected error", BuildContent(resolved, preferredMessage));
+            if (!continueRunning)
+            {
+                exitApplication();
+            }
+        }
+        catch
+        {
+            if (exitIfShowFails)
+            {
+                exitApplication();
+            }
+        }
+        finally
+        {
+            Interlocked.Exchange(ref isPresenting, 0);
+        }
+    }
+
+    private static string BuildContent(Exception exception, string? preferredMessage)
+    {
+        var message = !string.IsNullOrWhiteSpace(preferredMessage)
+            ? preferredMessage
+            : GetMessage(exception);
+        var source = string.IsNullOrWhiteSpace(exception.Source) ? "(unknown)" : exception.Source;
+        var stackTrace = GetStackTrace(exception);
+
+        return
+            "An unexpected problem occurred. The error has been logged." +
+            Environment.NewLine +
+            Environment.NewLine +
+            $"Message: {message}" +
+            Environment.NewLine +
+            $"Source: {source}" +
+            Environment.NewLine +
+            Environment.NewLine +
+            stackTrace;
+    }
+
+    private static string GetMessage(Exception exception)
+    {
+        if (exception is AggregateException aggregate)
+        {
+            var innerMessages = aggregate.Flatten().InnerExceptions
+                .Select(inner => inner.Message)
+                .Where(message => !string.IsNullOrWhiteSpace(message))
+                .Distinct()
+                .ToArray();
+
+            if (innerMessages.Length > 0)
+            {
+                return string.Join(Environment.NewLine, innerMessages);
+            }
+        }
+
+        return string.IsNullOrWhiteSpace(exception.Message) ? "(no message)" : exception.Message;
+    }
+
+    private static string GetStackTrace(Exception exception)
+    {
+        if (exception is AggregateException aggregate)
+        {
+            var flattened = aggregate.Flatten();
+            if (flattened.InnerExceptions.Count == 1)
+            {
+                return flattened.InnerExceptions[0].StackTrace
+                    ?? exception.StackTrace
+                    ?? "(no stack trace)";
+            }
+        }
+
+        return exception.StackTrace ?? "(no stack trace)";
+    }
+
+    private static void DefaultLog(Exception exception)
+    {
+        Log.Error(
+            exception,
+            "An unexpected error occurred. Source: {Source}. Message: {Message}",
+            string.IsNullOrWhiteSpace(exception.Source) ? "(unknown)" : exception.Source,
+            exception.Message);
+    }
+}

--- a/src/BSH.Test/UnhandledExceptionHandlerTests.cs
+++ b/src/BSH.Test/UnhandledExceptionHandlerTests.cs
@@ -1,0 +1,179 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using BSH.MainApp.Services;
+using NUnit.Framework;
+
+namespace BSH.Test;
+
+public class UnhandledExceptionHandlerTests
+{
+    [Test]
+    public async Task HandleAsyncLogsExceptionWithMessageAndSource()
+    {
+        var logged = new List<Exception>();
+        var handler = CreateHandler(logged.Add, askContinue: true);
+        var exception = CreateException("disk I/O failed", "BSH.MainApp.Services.JobService");
+
+        await handler.HandleAsync(exception);
+
+        Assert.That(logged, Has.Count.EqualTo(1));
+        Assert.That(logged[0], Is.SameAs(exception));
+        Assert.That(logged[0].Message, Is.EqualTo("disk I/O failed"));
+        Assert.That(logged[0].Source, Is.EqualTo("BSH.MainApp.Services.JobService"));
+    }
+
+    [Test]
+    public async Task HandleAsyncShowsNonCrypticContentWithMessageSourceAndStack()
+    {
+        string? shownContent = null;
+        var handler = CreateHandler(
+            _ => { },
+            askContinue: true,
+            onAsk: (_, content) => shownContent = content);
+        var exception = CreateException("database is locked", "BSH.Engine.Database");
+
+        await handler.HandleAsync(exception);
+
+        Assert.That(shownContent, Does.Contain("logged").IgnoreCase);
+        Assert.That(shownContent, Does.Contain("database is locked"));
+        Assert.That(shownContent, Does.Contain("BSH.Engine.Database"));
+        Assert.That(shownContent, Does.Contain("CreateException"));
+    }
+
+    [Test]
+    public async Task HandleAsyncNullExceptionStillLogsAndShowsContent()
+    {
+        var logged = new List<Exception>();
+        string? shownContent = null;
+        var handler = CreateHandler(
+            logged.Add,
+            askContinue: true,
+            onAsk: (_, content) => shownContent = content);
+
+        await handler.HandleAsync(null);
+
+        Assert.That(logged, Has.Count.EqualTo(1));
+        Assert.That(shownContent, Is.Not.Empty);
+    }
+
+    [Test]
+    public async Task HandleAsyncPrefersExplicitMessageWhenProvided()
+    {
+        string? shownContent = null;
+        var handler = CreateHandler(
+            _ => { },
+            askContinue: true,
+            onAsk: (_, content) => shownContent = content);
+
+        await handler.HandleAsync(
+            new InvalidOperationException("generic wrapper"),
+            preferredMessage: "Original WinUI fault message");
+
+        Assert.That(shownContent, Does.Contain("Original WinUI fault message"));
+        Assert.That(shownContent, Does.Not.Contain("generic wrapper"));
+    }
+
+    [Test]
+    public async Task HandleAsyncUnwrapsAggregateExceptionForUserContent()
+    {
+        string? shownContent = null;
+        var handler = CreateHandler(
+            _ => { },
+            askContinue: true,
+            onAsk: (_, content) => shownContent = content);
+
+        await handler.HandleAsync(new AggregateException(
+            new InvalidOperationException("inner disk failure"),
+            new IOException("inner path missing")));
+
+        Assert.That(shownContent, Does.Contain("inner disk failure"));
+        Assert.That(shownContent, Does.Contain("inner path missing"));
+        Assert.That(shownContent, Does.Not.Contain("One or more errors occurred"));
+    }
+
+    [Test]
+    public async Task HandleAsyncExitsWhenUserChoosesExit()
+    {
+        var exited = false;
+        var handler = CreateHandler(_ => { }, askContinue: false, onExit: () => exited = true);
+
+        await handler.HandleAsync(new InvalidOperationException("boom"));
+
+        Assert.That(exited, Is.True);
+    }
+
+    [Test]
+    public async Task HandleAsyncDoesNotExitWhenUserContinues()
+    {
+        var exited = false;
+        var handler = CreateHandler(_ => { }, askContinue: true, onExit: () => exited = true);
+
+        await handler.HandleAsync(new InvalidOperationException("boom"));
+
+        Assert.That(exited, Is.False);
+    }
+
+    [Test]
+    public async Task HandleAsyncExitsWhenPresentationFails()
+    {
+        var exited = false;
+        var handler = new UnhandledExceptionHandler(
+            askContinueAsync: (_, _) => throw new InvalidOperationException("no UI"),
+            exitApplication: () => exited = true,
+            logError: _ => { });
+
+        await handler.HandleAsync(new InvalidOperationException("boom"));
+
+        Assert.That(exited, Is.True);
+    }
+
+    [Test]
+    public void HandleTerminatingFlushesLogsWithoutRequiringExit()
+    {
+        var flushed = false;
+        var exited = false;
+        var handler = new UnhandledExceptionHandler(
+            askContinueAsync: (_, _) => Task.FromResult(true),
+            exitApplication: () => exited = true,
+            logError: _ => { },
+            flushLogs: () => flushed = true);
+
+        handler.HandleTerminating(new InvalidOperationException("fatal"));
+
+        Assert.That(flushed, Is.True);
+        Assert.That(exited, Is.False);
+    }
+
+    private static UnhandledExceptionHandler CreateHandler(
+        Action<Exception> logError,
+        bool askContinue,
+        Action? onExit = null,
+        Action<string, string>? onAsk = null)
+    {
+        return new UnhandledExceptionHandler(
+            askContinueAsync: (title, content) =>
+            {
+                onAsk?.Invoke(title, content);
+                return Task.FromResult(askContinue);
+            },
+            exitApplication: () => onExit?.Invoke(),
+            logError: logError);
+    }
+
+    private static Exception CreateException(string message, string source)
+    {
+        try
+        {
+            throw new InvalidOperationException(message) { Source = source };
+        }
+        catch (Exception ex)
+        {
+            return ex;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Implement WinUI unhandled-exception handling for `Application.UnhandledException`, `AppDomain.UnhandledException`, and `TaskScheduler.UnobservedTaskException`.
- Centralize log + Continue/Exit prompt + exit/flush policy in `UnhandledExceptionHandler` (Serilog), with thin wiring in `App.xaml.cs`.
- Add unit tests for logging, user-facing content, AggregateException unwrapping, Continue/Exit, presentation failure, and terminating flush.

## Test plan
- [x] `dotnet test BSH.Test/BSH.Test.csproj -p:Platform=x64 --filter FullyQualifiedName~UnhandledExceptionHandlerTests`
- [x] Launch WinUI app and force a UI-thread exception; confirm dialog shows message/source/stack and Continue keeps the app running
- [x] Choose Exit in the dialog; confirm orchestration stops and the process exits
- [x] Confirm app log receives a Serilog error with exception details
