### PR TITLE
WinUI: Declutter schedule, progress, and settings dialogs

### DIFF
--- a/src/BSH.MainApp/App.xaml
+++ b/src/BSH.MainApp/App.xaml
@@ -9,6 +9,7 @@
                 <ResourceDictionary Source="/Styles/FontSizes.xaml" />
                 <ResourceDictionary Source="/Styles/Thickness.xaml" />
                 <ResourceDictionary Source="/Styles/TextBlock.xaml" />
+                <ResourceDictionary Source="/Styles/SettingsResources.xaml" />
                 <ResourceDictionary Source="/TrayIconResources.xaml" />
             </ResourceDictionary.MergedDictionaries>
             

--- a/src/BSH.MainApp/Styles/SettingsResources.xaml
+++ b/src/BSH.MainApp/Styles/SettingsResources.xaml
@@ -1,0 +1,29 @@
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <x:Double x:Key="SettingsCardSpacing">4</x:Double>
+
+    <Style
+        x:Key="SettingsSectionHeaderTextBlockStyle"
+        BasedOn="{StaticResource BodyStrongTextBlockStyle}"
+        TargetType="TextBlock">
+        <Style.Setters>
+            <Setter Property="Margin" Value="1,24,0,6" />
+        </Style.Setters>
+    </Style>
+
+    <Style x:Key="SettingsPageScrollViewerStyle" TargetType="ScrollViewer">
+        <Setter Property="Padding" Value="0,0,0,12" />
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="VerticalScrollBarVisibility" Value="Auto" />
+        <Setter Property="VerticalScrollMode" Value="Auto" />
+    </Style>
+
+    <Style x:Key="SettingsRadioDescriptionStyle" TargetType="TextBlock">
+        <Setter Property="Margin" Value="28,0,0,0" />
+        <Setter Property="Foreground" Value="{ThemeResource TextFillColorSecondaryBrush}" />
+        <Setter Property="TextWrapping" Value="WrapWholeWords" />
+        <Setter Property="FontSize" Value="12" />
+    </Style>
+</ResourceDictionary>

--- a/src/BSH.MainApp/ViewModels/SettingsViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/SettingsViewModel.cs
@@ -475,10 +475,13 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(DisableEncryptionCommand))]
+    [NotifyPropertyChangedFor(nameof(IsCompressionMode))]
     private ModeType modeType = ModeType.Unset;
 
     [ObservableProperty]
     private bool waitForDevice;
+
+    public bool IsCompressionMode => ModeType == ModeType.Compression;
 
     private void InitOptionsSettings()
     {
@@ -608,10 +611,14 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
     #region Mode Settings
 
     [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(ShowScheduleEditorWindowCommand))]
+    [NotifyPropertyChangedFor(nameof(IsScheduleMode))]
     private TaskType taskType = TaskType.Unset;
 
     [ObservableProperty]
     private bool stopBackupWhenBatteryMode;
+
+    public bool IsScheduleMode => TaskType == TaskType.Schedule;
 
     private void InitModeSettings()
     {
@@ -641,11 +648,13 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
         this.configurationManager.TaskType = newValue;
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanShowScheduleEditorWindow))]
     private async Task ShowScheduleEditorWindow()
     {
         await this.presentationController.ShowScheduleEditorWindowAsync();
     }
+
+    private bool CanShowScheduleEditorWindow() => TaskType == TaskType.Schedule;
 
     #endregion
 

--- a/src/BSH.MainApp/ViewModels/Windows/ScheduleEditorViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/Windows/ScheduleEditorViewModel.cs
@@ -80,6 +80,7 @@ public partial class ScheduleEditorViewModel : ObservableObject
     [NotifyPropertyChangedFor(nameof(ShowDatePicker))]
     [NotifyPropertyChangedFor(nameof(ShowWeeklyDayPicker))]
     [NotifyPropertyChangedFor(nameof(ShowMonthlyDayPicker))]
+    [NotifyPropertyChangedFor(nameof(ShowScheduleDayOrDatePicker))]
     [NotifyPropertyChangedFor(nameof(TimeHeader))]
     [NotifyPropertyChangedFor(nameof(AddScheduleHelpText))]
     private ScheduleEntryKind selectedScheduleKind = ScheduleEntryKind.Daily;
@@ -101,6 +102,8 @@ public partial class ScheduleEditorViewModel : ObservableObject
     private ScheduleEditorEntryViewModel? selectedEntry;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ShowRetentionIntervalControls))]
+    [NotifyPropertyChangedFor(nameof(ShowAutomaticHourlyThreshold))]
     private ScheduleRetentionMode retentionMode = ScheduleRetentionMode.None;
 
     [ObservableProperty]
@@ -113,6 +116,7 @@ public partial class ScheduleEditorViewModel : ObservableObject
     private int automaticHourlyBackupThreshold = 24;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ShowFullBackupDays))]
     private bool enableScheduledFullBackups;
 
     [ObservableProperty]
@@ -121,11 +125,26 @@ public partial class ScheduleEditorViewModel : ObservableObject
     [ObservableProperty]
     private bool performMissedBackupsLater;
 
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ShowEmptyScheduleState))]
+    private bool hasEntries;
+
     public bool ShowDatePicker => SelectedScheduleKind == ScheduleEntryKind.Once;
 
     public bool ShowWeeklyDayPicker => SelectedScheduleKind == ScheduleEntryKind.Weekly;
 
     public bool ShowMonthlyDayPicker => SelectedScheduleKind == ScheduleEntryKind.Monthly;
+
+    public bool ShowScheduleDayOrDatePicker =>
+        ShowDatePicker || ShowWeeklyDayPicker || ShowMonthlyDayPicker;
+
+    public bool ShowRetentionIntervalControls => RetentionMode == ScheduleRetentionMode.Interval;
+
+    public bool ShowAutomaticHourlyThreshold => RetentionMode == ScheduleRetentionMode.Automatic;
+
+    public bool ShowFullBackupDays => EnableScheduledFullBackups;
+
+    public bool ShowEmptyScheduleState => !HasEntries;
 
     public string TimeHeader => SelectedScheduleKind == ScheduleEntryKind.Hourly
         ? "Minute"
@@ -226,5 +245,7 @@ public partial class ScheduleEditorViewModel : ObservableObject
         {
             Entries.Add(new ScheduleEditorEntryViewModel(entry));
         }
+
+        HasEntries = Entries.Count > 0;
     }
 }

--- a/src/BSH.MainApp/ViewModels/Windows/StatusViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/Windows/StatusViewModel.cs
@@ -14,7 +14,11 @@ namespace BSH.MainApp.ViewModels.Windows;
 
 public partial class StatusViewModel : ObservableObject, IStatusReport
 {
+    private static readonly TimeSpan UiRefreshInterval = TimeSpan.FromMilliseconds(100);
+
     private readonly DispatcherQueue? dispatcherQueue;
+    private DateTime lastProgressRefresh = DateTime.MinValue;
+    private DateTime lastFileRefresh = DateTime.MinValue;
 
     [ObservableProperty]
     private string statusTitle = "";
@@ -26,13 +30,25 @@ public partial class StatusViewModel : ObservableObject, IStatusReport
     private string currentFileText = "";
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsProgressIndeterminate))]
+    [NotifyPropertyChangedFor(nameof(ProgressMaximum))]
+    [NotifyPropertyChangedFor(nameof(ProgressFilesText))]
     private int totalProgress = 100;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ProgressFilesText))]
     private int currentProgress = 0;
 
     [ObservableProperty]
     private int selectedCompletionActionIndex = 0;
+
+    public bool IsProgressIndeterminate => TotalProgress <= 0;
+
+    public int ProgressMaximum => TotalProgress > 0 ? TotalProgress : 1;
+
+    public string ProgressFilesText => TotalProgress > 0
+        ? $"{CurrentProgress} of {TotalProgress} files"
+        : "Preparing…";
 
     public TaskCompleteAction SelectedCompletionAction => SelectedCompletionActionIndex switch
     {
@@ -60,6 +76,7 @@ public partial class StatusViewModel : ObservableObject, IStatusReport
     {
         // not used
     }
+
     public void ReportSystemStatus(SystemStatus systemStatus)
     {
         // not used
@@ -67,6 +84,12 @@ public partial class StatusViewModel : ObservableObject, IStatusReport
 
     public void ReportFileProgress(string file)
     {
+        if (DateTime.Now - lastFileRefresh < UiRefreshInterval)
+        {
+            return;
+        }
+
+        lastFileRefresh = DateTime.Now;
         UpdateOnUiThread(() =>
         {
             CurrentFileText = file;
@@ -75,6 +98,12 @@ public partial class StatusViewModel : ObservableObject, IStatusReport
 
     public void ReportProgress(int total, int current)
     {
+        if (DateTime.Now - lastProgressRefresh < UiRefreshInterval)
+        {
+            return;
+        }
+
+        lastProgressRefresh = DateTime.Now;
         UpdateOnUiThread(() =>
         {
             TotalProgress = total;

--- a/src/BSH.MainApp/Views/SettingsPage.xaml
+++ b/src/BSH.MainApp/Views/SettingsPage.xaml
@@ -5,34 +5,36 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
-    Background="White">
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-    <Grid Margin="30">
+    <Grid Margin="30,24,30,20">
         <Grid.RowDefinitions>
-            <RowDefinition Height="40" />
-            <RowDefinition />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" MaxWidth="1400" />
-        </Grid.ColumnDefinitions>
 
-        <TextBlock Grid.Row="0" FontSize="24" FontWeight="SemiBold">Settings</TextBlock>
+        <TextBlock
+            Grid.Row="0"
+            FontSize="24"
+            FontWeight="SemiBold"
+            Text="Settings" />
 
-        <Grid Grid.Row="1" Margin="0, 20, 0, 0">
-            <NavigationView x:Name="navSettings" 
-                            PaneDisplayMode="Top" 
-                            IsBackButtonVisible="Collapsed" 
-                            IsSettingsVisible="False"
-                            ItemInvoked="navSettings_ItemInvoked">
-                <NavigationView.MenuItems>
-                    <NavigationViewItem x:Name="nviSources" IsSelected="True" Content="Sources" />
-                    <NavigationViewItem x:Name="nviTarget" Content="Backup Target" />
-                    <NavigationViewItem x:Name="nviMode" Content="Automation" />
-                    <NavigationViewItem x:Name="nviOptions" Content="Backup Options" />
-                    <NavigationViewItem x:Name="nviEnhanced" Content="Behavior" />
-                </NavigationView.MenuItems>
-                <Frame Margin="0,20,0,0" x:Name="contentFrame" />
-            </NavigationView>
-        </Grid>
+        <NavigationView
+            x:Name="navSettings"
+            Grid.Row="1"
+            Margin="0,16,0,0"
+            PaneDisplayMode="Top"
+            IsBackButtonVisible="Collapsed"
+            IsSettingsVisible="False"
+            ItemInvoked="navSettings_ItemInvoked">
+            <NavigationView.MenuItems>
+                <NavigationViewItem x:Name="nviSources" IsSelected="True" Content="Sources" />
+                <NavigationViewItem x:Name="nviTarget" Content="Backup Target" />
+                <NavigationViewItem x:Name="nviMode" Content="Automation" />
+                <NavigationViewItem x:Name="nviOptions" Content="Backup Options" />
+                <NavigationViewItem x:Name="nviEnhanced" Content="Behavior" />
+            </NavigationView.MenuItems>
+            <Frame Margin="0,12,0,0" x:Name="contentFrame" />
+        </NavigationView>
     </Grid>
 </Page>

--- a/src/BSH.MainApp/Views/SettingsPages/EnhancedSettingsPage.xaml
+++ b/src/BSH.MainApp/Views/SettingsPages/EnhancedSettingsPage.xaml
@@ -8,91 +8,101 @@
     d:DataContext="{d:DesignInstance Type=viewmodels:SettingsViewModel}"
     mc:Ignorable="d"
     xmlns:toolkit="using:CommunityToolkit.WinUI.Controls"
-    Background="White">
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-    <Page.Resources>
-        <x:Double x:Key="SettingsCardSpacing">3</x:Double>
+    <ScrollViewer Style="{StaticResource SettingsPageScrollViewerStyle}">
+        <StackPanel Spacing="{StaticResource SettingsCardSpacing}">
+            <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="Application" />
 
-        <Style
-            x:Key="SettingsSectionHeaderTextBlockStyle"
-            BasedOn="{StaticResource BodyStrongTextBlockStyle}"
-            TargetType="TextBlock">
-            <Style.Setters>
-                <Setter Property="Margin" Value="1,29,0,5" />
-            </Style.Setters>
-        </Style>
-    </Page.Resources>
+            <toolkit:SettingsCard
+                Header="Launch at Windows startup"
+                Description="Start Backup Service Home when you sign in.">
+                <toolkit:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE7E8;" />
+                </toolkit:SettingsCard.HeaderIcon>
+                <ToggleSwitch IsOn="{Binding LaunchAtWindowsStartup, Mode=TwoWay}" />
+            </toolkit:SettingsCard>
 
-    <Grid>
-        <ScrollViewer
-            Padding="20,0,20,0"
-            IsTabStop="False"
-            VerticalScrollBarVisibility="Auto"
-            VerticalScrollMode="Auto">
-            <StackPanel Spacing="{StaticResource SettingsCardSpacing}">
-                <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}">Application</TextBlock>
-                <toolkit:SettingsCard Header="Launch at Windows startup" Description="Start Backup Service Home when you sign in to Windows">
-                    <toolkit:SettingsCard.HeaderIcon>
-                        <FontIcon Glyph="&#xE7E8;" />
-                    </toolkit:SettingsCard.HeaderIcon>
-                    <ToggleSwitch IsOn="{Binding LaunchAtWindowsStartup, Mode=TwoWay}" />
-                </toolkit:SettingsCard>
+            <toolkit:SettingsCard
+                Header="Automatically check for updates"
+                Description="Look for updates when the application starts.">
+                <toolkit:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE895;" />
+                </toolkit:SettingsCard.HeaderIcon>
+                <ToggleSwitch IsOn="{Binding AutomaticallyCheckForUpdates, Mode=TwoWay}" />
+            </toolkit:SettingsCard>
 
-                <toolkit:SettingsCard Header="Automatically check for updates" Description="Look for updates when the application starts">
-                    <toolkit:SettingsCard.HeaderIcon>
-                        <FontIcon Glyph="&#xE895;" />
-                    </toolkit:SettingsCard.HeaderIcon>
-                    <ToggleSwitch IsOn="{Binding AutomaticallyCheckForUpdates, Mode=TwoWay}" />
-                </toolkit:SettingsCard>
+            <toolkit:SettingsCard
+                Header="Download beta updates"
+                Description="Include prerelease versions when checking for updates.">
+                <toolkit:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE945;" />
+                </toolkit:SettingsCard.HeaderIcon>
+                <ToggleSwitch IsOn="{Binding DownloadBetaUpdates, Mode=TwoWay}" />
+            </toolkit:SettingsCard>
 
-                <toolkit:SettingsCard Header="Download beta updates" Description="Include prerelease versions when checking for updates">
-                    <toolkit:SettingsCard.HeaderIcon>
-                        <FontIcon Glyph="&#xE945;" />
-                    </toolkit:SettingsCard.HeaderIcon>
-                    <ToggleSwitch IsOn="{Binding DownloadBetaUpdates, Mode=TwoWay}" />
-                </toolkit:SettingsCard>
+            <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="Backup browser" />
 
-                <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}">Backupbrowser</TextBlock>
-                <toolkit:SettingsCard Header="Directory localization" Description="Show directory localization names if available">
-                    <toolkit:SettingsCard.HeaderIcon>
-                        <FontIcon Glyph="&#xF2B7;" />
-                    </toolkit:SettingsCard.HeaderIcon>
-                    <ToggleSwitch IsOn="{Binding EnableDirectoryLocalization, Mode=TwoWay}" />
-                </toolkit:SettingsCard>
+            <toolkit:SettingsCard
+                Header="Directory localization"
+                Description="Show localized folder names when available.">
+                <toolkit:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xF2B7;" />
+                </toolkit:SettingsCard.HeaderIcon>
+                <ToggleSwitch IsOn="{Binding EnableDirectoryLocalization, Mode=TwoWay}" />
+            </toolkit:SettingsCard>
 
-                <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}">Notifications</TextBlock>
-                <toolkit:SettingsExpander Header="Low diskspace" Description="Show notification if less diskspace is available">
-                    <ToggleSwitch IsOn="{Binding EnableNotificationWhenDiskspaceLow, Mode=TwoWay}" />
-                    <toolkit:SettingsExpander.Items>
-                        <toolkit:SettingsCard Header="Diskspace lower than">
-                            <StackPanel Orientation="Horizontal" Margin="30,0,0,0">
-                                <NumberBox Minimum="1" Value="{Binding NotificationWhenDiskspaceLow, Mode=TwoWay}" />
-                                <TextBlock VerticalAlignment="Center" Margin="10,0,0,0" Text="MB" />
-                            </StackPanel>
-                        </toolkit:SettingsCard>
-                    </toolkit:SettingsExpander.Items>
-                </toolkit:SettingsExpander>
+            <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="Notifications" />
 
-                <toolkit:SettingsCard Header="Backup completed" Description="Show notification if backup is completed">
-                    <ToggleSwitch IsOn="{Binding EnableNotificationWhenBackupFinished, Mode=TwoWay}" />
-                </toolkit:SettingsCard>
+            <toolkit:SettingsExpander
+                Header="Low disk space"
+                Description="Notify when free space drops below a threshold."
+                IsExpanded="{Binding EnableNotificationWhenDiskspaceLow, Mode=OneWay}">
+                <ToggleSwitch IsOn="{Binding EnableNotificationWhenDiskspaceLow, Mode=TwoWay}" />
+                <toolkit:SettingsExpander.Items>
+                    <toolkit:SettingsCard Header="Warn when below">
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <NumberBox
+                                Minimum="1"
+                                SpinButtonPlacementMode="Compact"
+                                Value="{Binding NotificationWhenDiskspaceLow, Mode=TwoWay}"
+                                IsEnabled="{Binding EnableNotificationWhenDiskspaceLow}" />
+                            <TextBlock VerticalAlignment="Center" Text="MB" />
+                        </StackPanel>
+                    </toolkit:SettingsCard>
+                </toolkit:SettingsExpander.Items>
+            </toolkit:SettingsExpander>
 
-                <toolkit:SettingsCard Header="Storage device" Description="Show notification to request storage device if not available">
-                    <ToggleSwitch IsOn="{Binding EnableNotificationWhenBackupDeviceNotReady, Mode=TwoWay}" />
-                </toolkit:SettingsCard>
+            <toolkit:SettingsCard
+                Header="Backup completed"
+                Description="Notify when a backup finishes.">
+                <ToggleSwitch IsOn="{Binding EnableNotificationWhenBackupFinished, Mode=TwoWay}" />
+            </toolkit:SettingsCard>
 
-                <toolkit:SettingsExpander Header="Backup outdated" Description="Show notification if backup is outdated">
-                    <ToggleSwitch IsOn="{Binding EnableNotificationWhenBackupOutdated, Mode=TwoWay}" />
-                    <toolkit:SettingsExpander.Items>
-                        <toolkit:SettingsCard Header="Backup is outdated when older than">
-                            <StackPanel Orientation="Horizontal" Margin="30,0,0,0">
-                                <NumberBox Minimum="1" Value="{Binding NotificationWhenBackupOutdated, Mode=TwoWay}" />
-                                <TextBlock VerticalAlignment="Center" Margin="10,0,0,0" Text="Days" />
-                            </StackPanel>
-                        </toolkit:SettingsCard>
-                    </toolkit:SettingsExpander.Items>
-                </toolkit:SettingsExpander>
-            </StackPanel>
-        </ScrollViewer>
-    </Grid>
+            <toolkit:SettingsCard
+                Header="Storage device"
+                Description="Notify when the backup target is not available.">
+                <ToggleSwitch IsOn="{Binding EnableNotificationWhenBackupDeviceNotReady, Mode=TwoWay}" />
+            </toolkit:SettingsCard>
+
+            <toolkit:SettingsExpander
+                Header="Backup outdated"
+                Description="Notify when the latest backup is older than a threshold."
+                IsExpanded="{Binding EnableNotificationWhenBackupOutdated, Mode=OneWay}">
+                <ToggleSwitch IsOn="{Binding EnableNotificationWhenBackupOutdated, Mode=TwoWay}" />
+                <toolkit:SettingsExpander.Items>
+                    <toolkit:SettingsCard Header="Warn when older than">
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <NumberBox
+                                Minimum="1"
+                                SpinButtonPlacementMode="Compact"
+                                Value="{Binding NotificationWhenBackupOutdated, Mode=TwoWay}"
+                                IsEnabled="{Binding EnableNotificationWhenBackupOutdated}" />
+                            <TextBlock VerticalAlignment="Center" Text="Days" />
+                        </StackPanel>
+                    </toolkit:SettingsCard>
+                </toolkit:SettingsExpander.Items>
+            </toolkit:SettingsExpander>
+        </StackPanel>
+    </ScrollViewer>
 </Page>

--- a/src/BSH.MainApp/Views/SettingsPages/ModeSettingsPage.xaml
+++ b/src/BSH.MainApp/Views/SettingsPages/ModeSettingsPage.xaml
@@ -10,88 +10,78 @@
     d:DataContext="{d:DesignInstance Type=viewmodels:SettingsViewModel}"
     mc:Ignorable="d"
     xmlns:toolkit="using:CommunityToolkit.WinUI.Controls"
-    Background="White">
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Page.Resources>
-        <x:Double x:Key="SettingsCardSpacing">3</x:Double>
-
-        <Style
-            x:Key="SettingsSectionHeaderTextBlockStyle"
-            BasedOn="{StaticResource BodyStrongTextBlockStyle}"
-            TargetType="TextBlock">
-            <Style.Setters>
-                <Setter Property="Margin" Value="1,29,0,5" />
-            </Style.Setters>
-        </Style>
-
         <converters:EnumComparisonConverter x:Key="EnumComparisonConverter" />
-
         <engine:TaskType x:Key="TaskType_Auto">Auto</engine:TaskType>
         <engine:TaskType x:Key="TaskType_Schedule">Schedule</engine:TaskType>
         <engine:TaskType x:Key="TaskType_Manual">Manual</engine:TaskType>
     </Page.Resources>
 
-    <Grid>
-        <ScrollViewer
-            Padding="20,0,20,0"
-            IsTabStop="False"
-            VerticalScrollBarVisibility="Auto"
-            VerticalScrollMode="Auto">
-            <StackPanel Spacing="{StaticResource SettingsCardSpacing}">
-                <toolkit:SettingsExpander Header="Backup mode" Description="Specify the automation of backups" IsExpanded="True">
-                    <toolkit:SettingsExpander.HeaderIcon>
-                        <FontIcon Glyph="&#xE787;" />
-                    </toolkit:SettingsExpander.HeaderIcon>
-                    <toolkit:SettingsExpander.Items>
-                        <toolkit:SettingsCard>
-                            <toolkit:SettingsCard.Header>
-                                <StackPanel Margin="-12,0,0,0" Orientation="Vertical">
-                                    <RadioButton IsChecked="{Binding TaskType, Mode=TwoWay, Converter={StaticResource EnumComparisonConverter}, ConverterParameter={StaticResource TaskType_Auto}}">
-                                        Full automatic backups (recommended)
-                                    </RadioButton>
-                                    <TextBlock Margin="29,0,0,0" TextWrapping="WrapWholeWords">
-                                    The full automatic backup model backups your files hourly. These backups are available for 24 hours. Afterwards, daily backups are available for 30 days. Then, weekly backups are available as long as enough disk space is available.
-                                    </TextBlock>
-                                </StackPanel>
-                            </toolkit:SettingsCard.Header>
-                        </toolkit:SettingsCard>
+    <ScrollViewer Style="{StaticResource SettingsPageScrollViewerStyle}">
+        <StackPanel Spacing="{StaticResource SettingsCardSpacing}">
+            <toolkit:SettingsExpander
+                Header="Backup mode"
+                Description="How backups are started."
+                IsExpanded="True">
+                <toolkit:SettingsExpander.HeaderIcon>
+                    <FontIcon Glyph="&#xE787;" />
+                </toolkit:SettingsExpander.HeaderIcon>
+                <toolkit:SettingsExpander.Items>
+                    <toolkit:SettingsCard>
+                        <toolkit:SettingsCard.Header>
+                            <StackPanel Margin="-12,0,0,0" Spacing="2">
+                                <RadioButton IsChecked="{Binding TaskType, Mode=TwoWay, Converter={StaticResource EnumComparisonConverter}, ConverterParameter={StaticResource TaskType_Auto}}">
+                                    Full automatic (recommended)
+                                </RadioButton>
+                                <TextBlock Style="{StaticResource SettingsRadioDescriptionStyle}">
+                                    Hourly for 24 hours, then daily for 30 days, then weekly while space remains.
+                                </TextBlock>
+                            </StackPanel>
+                        </toolkit:SettingsCard.Header>
+                    </toolkit:SettingsCard>
 
-                        <toolkit:SettingsCard>
-                            <toolkit:SettingsCard.Header>
-                                <StackPanel Margin="-12,0,0,0" Orientation="Vertical">
-                                    <RadioButton IsChecked="{Binding TaskType, Mode=TwoWay, Converter={StaticResource EnumComparisonConverter}, ConverterParameter={StaticResource TaskType_Schedule}}">
-                                        Scheduled backups
-                                    </RadioButton>
-                                    <TextBlock Margin="29,0,0,0" TextWrapping="WrapWholeWords">
-                                        You define when backups should be performed and how long these should stay available.
-                                    </TextBlock>
-                                </StackPanel>
-                            </toolkit:SettingsCard.Header>
-                            <Button Command="{x:Bind ViewModel.ShowScheduleEditorWindowCommand}" Content="Set schedule" />
-                        </toolkit:SettingsCard>
+                    <toolkit:SettingsCard>
+                        <toolkit:SettingsCard.Header>
+                            <StackPanel Margin="-12,0,0,0" Spacing="2">
+                                <RadioButton IsChecked="{Binding TaskType, Mode=TwoWay, Converter={StaticResource EnumComparisonConverter}, ConverterParameter={StaticResource TaskType_Schedule}}">
+                                    Scheduled
+                                </RadioButton>
+                                <TextBlock Style="{StaticResource SettingsRadioDescriptionStyle}">
+                                    You choose the times and retention.
+                                </TextBlock>
+                            </StackPanel>
+                        </toolkit:SettingsCard.Header>
+                        <Button
+                            Command="{x:Bind ViewModel.ShowScheduleEditorWindowCommand}"
+                            Content="Set schedule"
+                            IsEnabled="{x:Bind ViewModel.IsScheduleMode, Mode=OneWay}" />
+                    </toolkit:SettingsCard>
 
-                        <toolkit:SettingsCard>
-                            <toolkit:SettingsCard.Header>
-                                <StackPanel Margin="-12,0,0,0" Orientation="Vertical">
-                                    <RadioButton IsChecked="{Binding TaskType, Mode=TwoWay, Converter={StaticResource EnumComparisonConverter}, ConverterParameter={StaticResource TaskType_Manual}}">
-                                        Manual backups
-                                    </RadioButton>
-                                    <TextBlock Margin="29,0,0,0" TextWrapping="WrapWholeWords">
-                                        Backups are not executed automatically, but you manually start the backup.
-                                    </TextBlock>
-                                </StackPanel>
-                            </toolkit:SettingsCard.Header>
-                        </toolkit:SettingsCard>
-                    </toolkit:SettingsExpander.Items>
-                </toolkit:SettingsExpander>
+                    <toolkit:SettingsCard>
+                        <toolkit:SettingsCard.Header>
+                            <StackPanel Margin="-12,0,0,0" Spacing="2">
+                                <RadioButton IsChecked="{Binding TaskType, Mode=TwoWay, Converter={StaticResource EnumComparisonConverter}, ConverterParameter={StaticResource TaskType_Manual}}">
+                                    Manual
+                                </RadioButton>
+                                <TextBlock Style="{StaticResource SettingsRadioDescriptionStyle}">
+                                    Start backups yourself when needed.
+                                </TextBlock>
+                            </StackPanel>
+                        </toolkit:SettingsCard.Header>
+                    </toolkit:SettingsCard>
+                </toolkit:SettingsExpander.Items>
+            </toolkit:SettingsExpander>
 
-                <toolkit:SettingsCard Header="Battery saver mode" Description="Stops automatic and scheduled backups when device is in battery mode">
-                    <toolkit:SettingsCard.HeaderIcon>
-                        <FontIcon Glyph="&#xE865;" />
-                    </toolkit:SettingsCard.HeaderIcon>
-                    <ToggleSwitch IsOn="{Binding StopBackupWhenBatteryMode, Mode=TwoWay}" />
-                </toolkit:SettingsCard>
-            </StackPanel>
-        </ScrollViewer>
-    </Grid>
+            <toolkit:SettingsCard
+                Header="Battery saver"
+                Description="Pause automatic and scheduled backups on battery power.">
+                <toolkit:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE865;" />
+                </toolkit:SettingsCard.HeaderIcon>
+                <ToggleSwitch IsOn="{Binding StopBackupWhenBatteryMode, Mode=TwoWay}" />
+            </toolkit:SettingsCard>
+        </StackPanel>
+    </ScrollViewer>
 </Page>

--- a/src/BSH.MainApp/Views/SettingsPages/OptionsSettingsPage.xaml
+++ b/src/BSH.MainApp/Views/SettingsPages/OptionsSettingsPage.xaml
@@ -9,119 +9,113 @@
     d:DataContext="{d:DesignInstance Type=viewmodels:SettingsViewModel}"
     mc:Ignorable="d"
     xmlns:toolkit="using:CommunityToolkit.WinUI.Controls"
-    Background="White">
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Page.Resources>
-        <x:Double x:Key="SettingsCardSpacing">3</x:Double>
-
-        <Style
-            x:Key="SettingsSectionHeaderTextBlockStyle"
-            BasedOn="{StaticResource BodyStrongTextBlockStyle}"
-            TargetType="TextBlock">
-            <Style.Setters>
-                <Setter Property="Margin" Value="1,29,0,5" />
-            </Style.Setters>
-        </Style>
-
         <converters:EnumComparisonConverter x:Key="EnumComparisonConverter" />
-
         <viewmodels:ModeType x:Key="ModeType_RegularCopy">RegularCopy</viewmodels:ModeType>
         <viewmodels:ModeType x:Key="ModeType_Compression">Compression</viewmodels:ModeType>
         <viewmodels:ModeType x:Key="ModeType_Encryption">Encryption</viewmodels:ModeType>
     </Page.Resources>
 
-    <Grid>
-        <ScrollViewer
-            Padding="20,0,20,0"
-            IsTabStop="False"
-            VerticalScrollBarVisibility="Auto"
-            VerticalScrollMode="Auto">
-            <StackPanel Spacing="{StaticResource SettingsCardSpacing}">
-                <toolkit:SettingsExpander Header="Storage options" Description="Specify how the backup should be stored." IsExpanded="True">
-                    <toolkit:SettingsExpander.HeaderIcon>
-                        <FontIcon Glyph="&#xF8A6;" />
-                    </toolkit:SettingsExpander.HeaderIcon>
-                    <toolkit:SettingsExpander.Items>
-                        <toolkit:SettingsCard>
-                            <toolkit:SettingsCard.Header>
-                                <StackPanel Margin="-12,0,0,0" Orientation="Vertical">
-                                    <RadioButton x:Name="RegularCopyRadioButton"
-                                                 IsChecked="{Binding ModeType, Mode=OneWay, Converter={StaticResource EnumComparisonConverter}, ConverterParameter={StaticResource ModeType_RegularCopy}}"
-                                                 Checked="ModeTypeRadioButton_Checked">
-                                        No compression or encryption
-                                    </RadioButton>
-                                </StackPanel>
-                            </toolkit:SettingsCard.Header>
-                        </toolkit:SettingsCard>
+    <ScrollViewer Style="{StaticResource SettingsPageScrollViewerStyle}">
+        <StackPanel Spacing="{StaticResource SettingsCardSpacing}">
+            <toolkit:SettingsExpander
+                Header="Storage options"
+                Description="How backup data is written to the target."
+                IsExpanded="True">
+                <toolkit:SettingsExpander.HeaderIcon>
+                    <FontIcon Glyph="&#xF8A6;" />
+                </toolkit:SettingsExpander.HeaderIcon>
+                <toolkit:SettingsExpander.Items>
+                    <toolkit:SettingsCard>
+                        <toolkit:SettingsCard.Header>
+                            <RadioButton
+                                x:Name="RegularCopyRadioButton"
+                                Margin="-12,0,0,0"
+                                IsChecked="{Binding ModeType, Mode=OneWay, Converter={StaticResource EnumComparisonConverter}, ConverterParameter={StaticResource ModeType_RegularCopy}}"
+                                Checked="ModeTypeRadioButton_Checked"
+                                Content="No compression or encryption" />
+                        </toolkit:SettingsCard.Header>
+                    </toolkit:SettingsCard>
 
-                        <toolkit:SettingsCard>
-                            <toolkit:SettingsCard.Header>
-                                <StackPanel Margin="-12,0,0,0" Orientation="Vertical">
-                                    <RadioButton x:Name="CompressionRadioButton"
-                                                 IsChecked="{Binding ModeType, Mode=OneWay, Converter={StaticResource EnumComparisonConverter}, ConverterParameter={StaticResource ModeType_Compression}}"
-                                                 Checked="ModeTypeRadioButton_Checked">
-                                        Compress backups
-                                    </RadioButton>
-                                    <TextBlock Margin="29,0,0,0" TextWrapping="WrapWholeWords">
-                                        (requires more computation power; slower backups)
-                                    </TextBlock>
-                                </StackPanel>
-                            </toolkit:SettingsCard.Header>
-                            <StackPanel Spacing="8">
-                                <ListView Height="120"
-                                          ItemsSource="{Binding CompressionExclusions}"
-                                          SelectedItem="{Binding SelectedCompressionExclusion, Mode=TwoWay}">
-                                    <ListView.Header>
-                                        <TextBlock FontWeight="SemiBold">Excluded extensions</TextBlock>
-                                    </ListView.Header>
-                                </ListView>
-                                <Grid ColumnSpacing="8">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition />
-                                        <ColumnDefinition Width="Auto" />
-                                        <ColumnDefinition Width="Auto" />
-                                    </Grid.ColumnDefinitions>
-                                    <TextBox PlaceholderText="Extension"
-                                             Text="{Binding CompressionExclusionInputText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                                    <Button Grid.Column="1"
-                                            Content="Add"
-                                            Command="{Binding AddCompressionExclusionCommand}"
-                                            CommandParameter="{Binding CompressionExclusionInputText}" />
-                                    <Button Grid.Column="2"
-                                            Content="Remove"
-                                            Command="{Binding RemoveCompressionExclusionCommand}" />
-                                </Grid>
+                    <toolkit:SettingsCard>
+                        <toolkit:SettingsCard.Header>
+                            <StackPanel Margin="-12,0,0,0" Spacing="2">
+                                <RadioButton
+                                    x:Name="CompressionRadioButton"
+                                    IsChecked="{Binding ModeType, Mode=OneWay, Converter={StaticResource EnumComparisonConverter}, ConverterParameter={StaticResource ModeType_Compression}}"
+                                    Checked="ModeTypeRadioButton_Checked"
+                                    Content="Compress backups" />
+                                <TextBlock Style="{StaticResource SettingsRadioDescriptionStyle}">
+                                    Uses more CPU; backups take longer.
+                                </TextBlock>
                             </StackPanel>
-                        </toolkit:SettingsCard>
+                        </toolkit:SettingsCard.Header>
+                    </toolkit:SettingsCard>
 
-                        <toolkit:SettingsCard>
-                            <toolkit:SettingsCard.Header>
-                                <StackPanel Margin="-12,0,0,0" Orientation="Vertical">
-                                    <RadioButton x:Name="EncryptionRadioButton"
-                                                 IsChecked="{Binding ModeType, Mode=OneWay, Converter={StaticResource EnumComparisonConverter}, ConverterParameter={StaticResource ModeType_Encryption}}"
-                                                 Checked="ModeTypeRadioButton_Checked">
-                                        Encrypt backups
-                                    </RadioButton>
-                                    <TextBlock Margin="29,0,0,0" TextWrapping="WrapWholeWords">
-                                        (requires more computation power; slower backups)
-                                    </TextBlock>
-                                    <TextBlock Margin="29,10,0,0" TextWrapping="WrapWholeWords" Text="To protect the backup from unauthorized access, it can be encrypted. You will then be asked for your password at each session. The encryption cannot be applied retroactively." />
-                                </StackPanel>
-                            </toolkit:SettingsCard.Header>
-                            <ContentControl IsEnabled="{Binding ModeType, Converter={StaticResource EnumComparisonConverter}, ConverterParameter={StaticResource ModeType_Encryption}}">
-                                <Button Content="Turn off" Command="{x:Bind ViewModel.DisableEncryptionCommand}" />
-                            </ContentControl>
-                        </toolkit:SettingsCard>
-                    </toolkit:SettingsExpander.Items>
-                </toolkit:SettingsExpander>
+                    <toolkit:SettingsCard
+                        Header="Excluded extensions"
+                        Description="File types that stay uncompressed."
+                        ContentAlignment="Vertical"
+                        HorizontalContentAlignment="Stretch"
+                        Visibility="{x:Bind ViewModel.IsCompressionMode, Mode=OneWay}">
+                        <StackPanel Spacing="8">
+                            <ListView
+                                Height="100"
+                                ItemsSource="{Binding CompressionExclusions}"
+                                SelectedItem="{Binding SelectedCompressionExclusion, Mode=TwoWay}" />
+                            <Grid ColumnSpacing="8">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <TextBox
+                                    PlaceholderText="e.g. jpg"
+                                    Text="{Binding CompressionExclusionInputText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                <Button
+                                    Grid.Column="1"
+                                    Content="Add"
+                                    Command="{Binding AddCompressionExclusionCommand}"
+                                    CommandParameter="{Binding CompressionExclusionInputText}" />
+                                <Button
+                                    Grid.Column="2"
+                                    Content="Remove"
+                                    Command="{Binding RemoveCompressionExclusionCommand}" />
+                            </Grid>
+                        </StackPanel>
+                    </toolkit:SettingsCard>
 
-                <toolkit:SettingsCard Header="Storage device behavior" Description="Wait for storage device if not available">
-                    <toolkit:SettingsCard.HeaderIcon>
-                        <FontIcon Glyph="&#xEDA2;" />
-                    </toolkit:SettingsCard.HeaderIcon>
-                    <ToggleSwitch IsOn="{Binding WaitForDevice, Mode=TwoWay}" />
-                </toolkit:SettingsCard>
-            </StackPanel>
-        </ScrollViewer>
-    </Grid>
+                    <toolkit:SettingsCard>
+                        <toolkit:SettingsCard.Header>
+                            <StackPanel Margin="-12,0,0,0" Spacing="2">
+                                <RadioButton
+                                    x:Name="EncryptionRadioButton"
+                                    IsChecked="{Binding ModeType, Mode=OneWay, Converter={StaticResource EnumComparisonConverter}, ConverterParameter={StaticResource ModeType_Encryption}}"
+                                    Checked="ModeTypeRadioButton_Checked"
+                                    Content="Encrypt backups" />
+                                <TextBlock Style="{StaticResource SettingsRadioDescriptionStyle}">
+                                    Password required each session. Cannot be applied retroactively.
+                                </TextBlock>
+                            </StackPanel>
+                        </toolkit:SettingsCard.Header>
+                        <Button
+                            Content="Turn off"
+                            Command="{x:Bind ViewModel.DisableEncryptionCommand}"
+                            IsEnabled="{Binding ModeType, Converter={StaticResource EnumComparisonConverter}, ConverterParameter={StaticResource ModeType_Encryption}}" />
+                    </toolkit:SettingsCard>
+                </toolkit:SettingsExpander.Items>
+            </toolkit:SettingsExpander>
+
+            <toolkit:SettingsCard
+                Header="Wait for storage device"
+                Description="If the backup target is offline, wait until it becomes available.">
+                <toolkit:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xEDA2;" />
+                </toolkit:SettingsCard.HeaderIcon>
+                <ToggleSwitch IsOn="{Binding WaitForDevice, Mode=TwoWay}" />
+            </toolkit:SettingsCard>
+        </StackPanel>
+    </ScrollViewer>
 </Page>

--- a/src/BSH.MainApp/Views/SettingsPages/SourcesSettingsPage.xaml
+++ b/src/BSH.MainApp/Views/SettingsPages/SourcesSettingsPage.xaml
@@ -8,92 +8,80 @@
     d:DataContext="{d:DesignInstance Type=viewmodels:SettingsViewModel}"
     mc:Ignorable="d"
     xmlns:toolkit="using:CommunityToolkit.WinUI.Controls"
-    Background="White">
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Page.Resources>
-        <x:Double x:Key="SettingsCardSpacing">3</x:Double>
-
-        <Style
-            x:Key="SettingsSectionHeaderTextBlockStyle"
-            BasedOn="{StaticResource BodyStrongTextBlockStyle}"
-            TargetType="TextBlock">
-            <Style.Setters>
-                <Setter Property="Margin" Value="1,29,0,5" />
-            </Style.Setters>
-        </Style>
-
         <DataTemplate x:Name="SourceFolderTemplate" x:DataType="x:String">
-            <StackPanel Orientation="Horizontal">
-                <FontIcon VerticalAlignment="Center" FontSize="16" FontFamily="Segoe MDL2 Assets" Glyph="&#xE838;" Margin="0,0,10,0"/>
-                <TextBlock VerticalAlignment="Center" Text="{x:Bind}" x:Phase="1" Margin="0,5,0,5" />
-            </StackPanel>
+            <Grid MinHeight="36" ColumnSpacing="10">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <FontIcon
+                    VerticalAlignment="Center"
+                    FontSize="16"
+                    FontFamily="Segoe MDL2 Assets"
+                    Glyph="&#xE838;" />
+                <TextBlock
+                    Grid.Column="1"
+                    VerticalAlignment="Center"
+                    Text="{x:Bind}"
+                    TextTrimming="CharacterEllipsis"
+                    ToolTipService.ToolTip="{x:Bind}" />
+            </Grid>
         </DataTemplate>
     </Page.Resources>
 
-    <Grid>
-        <ScrollViewer
-            Padding="20,0,20,0"
-            IsTabStop="False"
-            VerticalScrollBarVisibility="Auto"
-            VerticalScrollMode="Auto">
-            <StackPanel Spacing="{StaticResource SettingsCardSpacing}">
-                <toolkit:SettingsExpander Header="Source directories" Description="Select the directories to be included in the backup." IsExpanded="True">
-                    <toolkit:SettingsExpander.HeaderIcon>
-                        <FontIcon Glyph="&#xE8F4;" />
-                    </toolkit:SettingsExpander.HeaderIcon>
-                    <toolkit:SettingsExpander.Items>
-                        <toolkit:SettingsCard
-                            ContentAlignment="Vertical"
-                            HorizontalContentAlignment="Stretch">
-                            <Grid Height="250">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition />
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="40" />
-                                </Grid.RowDefinitions>
+    <ScrollViewer Style="{StaticResource SettingsPageScrollViewerStyle}">
+        <StackPanel Spacing="{StaticResource SettingsCardSpacing}">
+            <toolkit:SettingsExpander
+                Header="Source directories"
+                Description="Folders included in every backup."
+                IsExpanded="True">
+                <toolkit:SettingsExpander.HeaderIcon>
+                    <FontIcon Glyph="&#xE8F4;" />
+                </toolkit:SettingsExpander.HeaderIcon>
 
-                                <ListView ItemsSource="{Binding Sources}"
-                                    SelectedItem="{Binding SelectedSource, Mode=TwoWay}"
-                                    Grid.Row="0" 
-                                    ItemTemplate="{StaticResource SourceFolderTemplate}">
-                                    <ListView.HeaderTemplate>
-                                        <DataTemplate>
-                                            <TextBlock FontWeight="Bold" Margin="0,5,0,5">Directory</TextBlock>
-                                        </DataTemplate>
-                                    </ListView.HeaderTemplate>
-                                </ListView>
+                <Grid MinHeight="220" RowSpacing="8">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="*" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
 
-                                <TextBlock Grid.Row="1"
-                                           Foreground="Red"
-                                           Text="{Binding SourceValidationErrorMessage}"
-                                           TextWrapping="Wrap" />
+                    <ListView
+                        Grid.Row="0"
+                        MinHeight="160"
+                        ItemsSource="{Binding Sources}"
+                        SelectedItem="{Binding SelectedSource, Mode=TwoWay}"
+                        ItemTemplate="{StaticResource SourceFolderTemplate}"
+                        SelectionMode="Single" />
 
-                                <Grid Grid.Row="2">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition />
-                                        <ColumnDefinition />
-                                    </Grid.ColumnDefinitions>
+                    <TextBlock
+                        Grid.Row="1"
+                        Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                        Text="{Binding SourceValidationErrorMessage}"
+                        TextWrapping="WrapWholeWords" />
 
-                                    <StackPanel Orientation="Horizontal" Grid.Column="0">
-                                        <Button Command="{x:Bind ViewModel.AddSourceFolderCommand}" Content="Add Directory" />
-                                        <Button Command="{x:Bind ViewModel.DeleteSourceFolderCommand}" Content="Delete" Margin="10,0,0,0" />
-                                    </StackPanel>
-                                </Grid>
-                            </Grid>
-                        </toolkit:SettingsCard>
-                    </toolkit:SettingsExpander.Items>
-                </toolkit:SettingsExpander>
+                    <StackPanel
+                        Grid.Row="2"
+                        Orientation="Horizontal"
+                        Spacing="8">
+                        <Button Command="{x:Bind ViewModel.AddSourceFolderCommand}" Content="Add directory" />
+                        <Button Command="{x:Bind ViewModel.DeleteSourceFolderCommand}" Content="Delete" />
+                    </StackPanel>
+                </Grid>
+            </toolkit:SettingsExpander>
 
-                <toolkit:SettingsCard
-                    Header="Exclude files and folders"
-                    Description="Exclude single files and folder, or define custom rules for exclusion."
-                    IsClickEnabled="True"
-                    Command="{x:Bind ViewModel.ShowExcludeFileFolderWindowCommand}">
-                    <toolkit:SettingsCard.HeaderIcon>
-                        <FontIcon Glyph="&#xECC9;" />
-                    </toolkit:SettingsCard.HeaderIcon>
-                </toolkit:SettingsCard>
-            </StackPanel>
-        </ScrollViewer>
-    </Grid>
+            <toolkit:SettingsCard
+                Header="Exclude files and folders"
+                Description="Skip individual files, folders, types, or custom rules."
+                IsClickEnabled="True"
+                Command="{x:Bind ViewModel.ShowExcludeFileFolderWindowCommand}">
+                <toolkit:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xECC9;" />
+                </toolkit:SettingsCard.HeaderIcon>
+            </toolkit:SettingsCard>
+        </StackPanel>
+    </ScrollViewer>
 </Page>

--- a/src/BSH.MainApp/Views/SettingsPages/TargetSettingsPage.xaml
+++ b/src/BSH.MainApp/Views/SettingsPages/TargetSettingsPage.xaml
@@ -5,150 +5,130 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:viewmodels="using:BSH.MainApp.ViewModels"
+    xmlns:engine="using:Brightbits.BSH.Engine"
     d:DataContext="{d:DesignInstance Type=viewmodels:SettingsViewModel}"
     mc:Ignorable="d"
-    xmlns:toolkit="using:CommunityToolkit.WinUI.Controls" xmlns:engine="using:Brightbits.BSH.Engine"
-    Background="White">
+    xmlns:toolkit="using:CommunityToolkit.WinUI.Controls"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-    <Page.Resources>
-        <x:Double x:Key="SettingsCardSpacing">3</x:Double>
+    <ScrollViewer Style="{StaticResource SettingsPageScrollViewerStyle}">
+        <StackPanel Spacing="{StaticResource SettingsCardSpacing}">
+            <toolkit:SettingsExpander
+                Header="Storage device"
+                Description="Where backup data is stored."
+                IsExpanded="True">
+                <toolkit:SettingsExpander.HeaderIcon>
+                    <FontIcon Glyph="&#xE8CE;" />
+                </toolkit:SettingsExpander.HeaderIcon>
 
-        <Style
-        x:Key="SettingsSectionHeaderTextBlockStyle"
-        BasedOn="{StaticResource BodyStrongTextBlockStyle}"
-        TargetType="TextBlock">
-            <Style.Setters>
-                <Setter Property="Margin" Value="1,29,0,5" />
-            </Style.Setters>
-        </Style>
-    </Page.Resources>
+                <ComboBox
+                    x:Name="MediaTypeComboBox"
+                    MinWidth="260"
+                    Header="Backup storage"
+                    ItemsSource="{Binding MediaTypes}"
+                    SelectedItem="{Binding SelectedMediaType, Mode=OneWay}"
+                    SelectionChanged="MediaTypeComboBox_SelectionChanged">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate x:DataType="engine:MediaType">
+                            <TextBlock Text="{x:Bind viewmodels:SettingsViewModel.GetMediaTypeDisplayName((engine:MediaType))}" />
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
 
-    <Grid>
-        <ScrollViewer
-        Padding="20,0,20,0"
-        IsTabStop="False"
-        VerticalScrollBarVisibility="Auto"
-        VerticalScrollMode="Auto">
-            <StackPanel Spacing="{StaticResource SettingsCardSpacing}">
-                <toolkit:SettingsExpander Header="Storage device" Description="Select the device to store the backup on." IsExpanded="True">
-                    <toolkit:SettingsExpander.HeaderIcon>
-                        <FontIcon Glyph="&#xE8CE;" />
-                    </toolkit:SettingsExpander.HeaderIcon>
+                <toolkit:SettingsExpander.Items>
+                    <!-- Local path -->
+                    <toolkit:SettingsCard
+                        Header="Storage path"
+                        Visibility="{Binding LocalDeviceVisibility}">
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <TextBox
+                                MinWidth="280"
+                                MaxWidth="420"
+                                IsReadOnly="True"
+                                Text="{Binding LocalDevicePath}" />
+                            <ProgressRing
+                                Width="20"
+                                Height="20"
+                                IsActive="{Binding IsMovingBackupTarget, Mode=OneWay}"
+                                Visibility="{Binding BackupTargetMoveProgressVisibility, Mode=OneWay}" />
+                            <Button
+                                Content="Change"
+                                Command="{x:Bind ViewModel.ChangeLocalPathCommand}"
+                                IsEnabled="{Binding IsBackupTargetChangeEnabled, Mode=OneWay}" />
+                        </StackPanel>
+                    </toolkit:SettingsCard>
 
-                    <!-- target type selection -->
-                    <StackPanel Orientation="Horizontal" Spacing="20">
-                        <TextBlock HorizontalAlignment="Right" VerticalAlignment="Center" Grid.Row="0" Grid.Column="0" Text="Backup storage:" />
-                        <ComboBox x:Name="MediaTypeComboBox"
-                            VerticalAlignment="Center" Grid.Row="0" Grid.Column="1" Width="300"
-                            ItemsSource="{Binding MediaTypes}"
-                            SelectedItem="{Binding SelectedMediaType, Mode=OneWay}"
-                            SelectionChanged="MediaTypeComboBox_SelectionChanged">
-                            <ComboBox.ItemTemplate>
-                                <DataTemplate x:DataType="engine:MediaType">
-                                    <TextBlock Text="{x:Bind viewmodels:SettingsViewModel.GetMediaTypeDisplayName((engine:MediaType))}" />
-                                </DataTemplate>
-                            </ComboBox.ItemTemplate>
+                    <toolkit:SettingsCard
+                        Header="Network username"
+                        Description="Optional credentials for UNC paths."
+                        Visibility="{Binding LocalDeviceVisibility}">
+                        <TextBox
+                            MinWidth="220"
+                            Text="{Binding LocalUNCUser, Mode=TwoWay}" />
+                    </toolkit:SettingsCard>
+
+                    <toolkit:SettingsCard
+                        Header="Network password"
+                        Visibility="{Binding LocalDeviceVisibility}">
+                        <PasswordBox
+                            MinWidth="220"
+                            Password="{Binding LocalUNCPassword, Mode=TwoWay}" />
+                    </toolkit:SettingsCard>
+
+                    <!-- FTP -->
+                    <toolkit:SettingsCard Header="Server" Visibility="{Binding FtpRemoteVisibility}">
+                        <TextBox MinWidth="220" Text="{Binding FtpRemoteHost}" />
+                    </toolkit:SettingsCard>
+
+                    <toolkit:SettingsCard Header="Port" Visibility="{Binding FtpRemoteVisibility}">
+                        <NumberBox MinWidth="120" Value="{Binding FtpRemotePort}" />
+                    </toolkit:SettingsCard>
+
+                    <toolkit:SettingsCard Header="Username" Visibility="{Binding FtpRemoteVisibility}">
+                        <TextBox MinWidth="220" Text="{Binding FtpRemoteUser}" />
+                    </toolkit:SettingsCard>
+
+                    <toolkit:SettingsCard Header="Password" Visibility="{Binding FtpRemoteVisibility}">
+                        <PasswordBox MinWidth="220" Password="{Binding FtpRemotePassword}" />
+                    </toolkit:SettingsCard>
+
+                    <toolkit:SettingsCard Header="Path" Visibility="{Binding FtpRemoteVisibility}">
+                        <TextBox MinWidth="280" Text="{Binding FtpRemotePath}" />
+                    </toolkit:SettingsCard>
+
+                    <toolkit:SettingsCard Header="Encoding" Visibility="{Binding FtpRemoteVisibility}">
+                        <ComboBox
+                            MinWidth="160"
+                            SelectedValue="{Binding FtpRemoteEncoding, Mode=TwoWay}">
+                            <x:String>ISO-8859-1</x:String>
+                            <x:String>UTF8</x:String>
                         </ComboBox>
-                    </StackPanel>
+                    </toolkit:SettingsCard>
 
-                    <toolkit:SettingsExpander.Items>
-                        <toolkit:SettingsCard
-                            ContentAlignment="Vertical"
-                            HorizontalContentAlignment="Stretch">
-                            <Grid ColumnSpacing="20" RowSpacing="20">
-                                <!-- local file system options -->
-                                <StackPanel Visibility="{Binding LocalDeviceVisibility}">
-                                    <Grid ColumnSpacing="20">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="200" />
-                                            <ColumnDefinition Width="*" />
-                                            <ColumnDefinition Width="Auto" />
-                                        </Grid.ColumnDefinitions>
+                    <toolkit:SettingsCard
+                        Header="Unencrypted connection"
+                        Description="Force plain FTP instead of FTPS."
+                        Visibility="{Binding FtpRemoteVisibility}">
+                        <ToggleSwitch IsOn="{Binding FtpRemoteEnforceUnencrypted, Mode=TwoWay}" />
+                    </toolkit:SettingsCard>
 
-                                        <TextBlock Grid.Column="0" Text="Storage path:" />
-                                        <TextBox Grid.Column="1" Text="{Binding LocalDevicePath}" IsReadOnly="True" />
-                                        <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="8">
-                                            <ProgressRing Width="20"
-                                                          Height="20"
-                                                          IsActive="{Binding IsMovingBackupTarget, Mode=OneWay}"
-                                                          Visibility="{Binding BackupTargetMoveProgressVisibility, Mode=OneWay}" />
-                                            <Button Content="Change"
-                                                    Command="{x:Bind ViewModel.ChangeLocalPathCommand}"
-                                                    IsEnabled="{Binding IsBackupTargetChangeEnabled, Mode=OneWay}" />
-                                        </StackPanel>
-                                    </Grid>
+                    <toolkit:SettingsCard
+                        Header="Connection test"
+                        Visibility="{Binding FtpRemoteVisibility}">
+                        <Button Content="Test connection" Command="{Binding CheckFtpRemoteCommand}" />
+                    </toolkit:SettingsCard>
+                </toolkit:SettingsExpander.Items>
+            </toolkit:SettingsExpander>
 
-                                    <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}">Network authentication</TextBlock>
-                                    <Grid ColumnSpacing="20">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="200" />
-                                            <ColumnDefinition />
-                                            <ColumnDefinition Width="200" />
-                                            <ColumnDefinition />
-                                        </Grid.ColumnDefinitions>
-                                        <TextBlock VerticalAlignment="Center" Grid.Column="0" Grid.Row="0">Username:</TextBlock>
-                                        <TextBox Grid.Column="1" Grid.Row="0" Text="{Binding LocalUNCUser, Mode=TwoWay}"></TextBox>
-
-                                        <TextBlock VerticalAlignment="Center" Grid.Column="2" Grid.Row="0">Password:</TextBlock>
-                                        <PasswordBox Grid.Column="3" Grid.Row="0" Password="{Binding LocalUNCPassword, Mode=TwoWay}"></PasswordBox>
-                                    </Grid>
-                                </StackPanel>
-
-                                <!-- ftp server options -->
-                                <Grid RowSpacing="10" ColumnSpacing="20" Visibility="{Binding FtpRemoteVisibility}">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="200" />
-                                        <ColumnDefinition />
-                                        <ColumnDefinition Width="200" />
-                                        <ColumnDefinition />
-                                    </Grid.ColumnDefinitions>
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition />
-                                        <RowDefinition />
-                                        <RowDefinition />
-                                        <RowDefinition />
-                                        <RowDefinition />
-                                        <RowDefinition />
-                                    </Grid.RowDefinitions>
-
-                                    <TextBlock VerticalAlignment="Center" Grid.Column="0" Grid.Row="0" Text="Server:" />
-                                    <TextBox Grid.Column="1" Text="{Binding FtpRemoteHost}" />
-                                    <TextBlock VerticalAlignment="Center" Grid.Column="2" Grid.Row="0" Text="Port:" />
-                                    <NumberBox Grid.Column="3" Grid.Row="0" Value="{Binding FtpRemotePort}" />
-
-                                    <TextBlock VerticalAlignment="Center" Grid.Column="0" Grid.Row="1" Text="Username:" />
-                                    <TextBox Grid.Column="1" Grid.Row="1"  Text="{Binding FtpRemoteUser}" />
-                                    <TextBlock VerticalAlignment="Center" Grid.Column="2" Grid.Row="1" Text="Password:" />
-                                    <PasswordBox Grid.Column="3" Grid.Row="1" Password="{Binding FtpRemotePassword}" />
-
-                                    <TextBlock VerticalAlignment="Center" Grid.Column="0" Grid.Row="2" Text="Path:" />
-                                    <TextBox Grid.Column="1" Grid.ColumnSpan="3" Grid.Row="2"  Text="{Binding FtpRemotePath}" />
-
-                                    <TextBlock VerticalAlignment="Center" Grid.Column="0" Grid.Row="3" Text="Encoding:" />
-                                    <ComboBox Grid.Column="1" Grid.Row="3" HorizontalAlignment="Stretch" SelectedValue="{Binding FtpRemoteEncoding, Mode=TwoWay}">
-                                        <x:String>ISO-8859-1</x:String>
-                                        <x:String>UTF8</x:String>
-                                    </ComboBox>
-
-                                    <CheckBox Grid.Column="1" Grid.Row="4" Content="Enforce unencrypted connection" IsChecked="{Binding FtpRemoteEnforceUnencrypted, Mode=TwoWay}" />
-
-                                    <Button Grid.Column="1" Grid.Row="5" Content="Test connection" Command="{Binding CheckFtpRemoteCommand}" />
-                                </Grid>
-                            </Grid>
-                        </toolkit:SettingsCard>
-                    </toolkit:SettingsExpander.Items>
-                </toolkit:SettingsExpander>
-
-                <toolkit:SettingsCard
-                    Header="Switch storage"
-                    Description="Allows changing the backup medium to a new (empty) medium without losing the settings."
-                    IsClickEnabled="True"
-                    Command="{x:Bind ViewModel.SwitchStorageCommand}">
-                    <toolkit:SettingsCard.HeaderIcon>
-                        <FontIcon Glyph="&#xE8CD;" />
-                    </toolkit:SettingsCard.HeaderIcon>
-                </toolkit:SettingsCard>
-            </StackPanel>
-        </ScrollViewer>
-    </Grid>
+            <toolkit:SettingsCard
+                Header="Switch storage"
+                Description="Move to a new empty medium without losing settings."
+                IsClickEnabled="True"
+                Command="{x:Bind ViewModel.SwitchStorageCommand}">
+                <toolkit:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE8CD;" />
+                </toolkit:SettingsCard.HeaderIcon>
+            </toolkit:SettingsCard>
+        </StackPanel>
+    </ScrollViewer>
 </Page>

--- a/src/BSH.MainApp/Windows/ScheduleEditorWindow.xaml
+++ b/src/BSH.MainApp/Windows/ScheduleEditorWindow.xaml
@@ -8,8 +8,8 @@
     xmlns:viewmodels="using:BSH.MainApp.ViewModels.Windows"
     xmlns:winex="using:WinUIEx"
     Title="Schedule"
-    Width="920"
-    Height="720"
+    Width="880"
+    Height="700"
     IsAlwaysOnTop="True"
     IsMaximizable="False"
     IsMinimizable="False"
@@ -22,226 +22,256 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <ScrollViewer Grid.Row="0" Padding="28,24,28,20" VerticalScrollBarVisibility="Auto">
-            <Grid MaxWidth="980" HorizontalAlignment="Center" RowSpacing="20">
+        <ScrollViewer Grid.Row="0" Padding="28,24,28,16" VerticalScrollBarVisibility="Auto">
+            <Grid MaxWidth="820" HorizontalAlignment="Stretch" RowSpacing="16">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
 
-                <StackPanel Grid.Row="0" Spacing="4">
-                    <TextBlock FontSize="26" FontWeight="SemiBold" Text="Schedule" />
+                <StackPanel Grid.Row="0" Spacing="2">
+                    <TextBlock FontSize="24" FontWeight="SemiBold" Text="Schedule" />
                     <TextBlock
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                        Text="Create schedule entries and choose how scheduled backups are retained."
+                        Text="Define when backups run and how long versions are kept."
                         TextWrapping="WrapWholeWords" />
                 </StackPanel>
 
+                <!-- Backup times -->
                 <Border
                     Grid.Row="1"
-                    Padding="18"
+                    Padding="16"
                     Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                     BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                     BorderThickness="1"
                     CornerRadius="8">
-                    <Grid RowSpacing="16">
+                    <Grid RowSpacing="12">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
-                            <RowDefinition Height="220" />
+                            <RowDefinition Height="200" />
+                            <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
 
-                        <Grid Grid.Row="0" ColumnSpacing="12">
+                        <TextBlock Grid.Row="0" FontWeight="SemiBold" Text="Backup times" />
+
+                        <!-- Compact add form: wrap-friendly grid -->
+                        <Grid Grid.Row="1" ColumnSpacing="10" RowSpacing="8">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="150" />
+                                <ColumnDefinition Width="Auto" MinWidth="140" />
+                                <ColumnDefinition Width="170" />
                                 <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
-                            <StackPanel Spacing="2">
-                                <TextBlock FontWeight="SemiBold" Text="Backup times" />
-                                <TextBlock
-                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                    Text="Add one-time or recurring backup entries."
-                                    TextWrapping="WrapWholeWords" />
-                            </StackPanel>
-                            <CommandBar
-                                Grid.Column="1"
-                                Background="Transparent"
-                                DefaultLabelPosition="Right"
-                                IsOpen="False">
-                                <AppBarButton
-                                    Command="{Binding DeleteScheduleCommand}"
-                                    Icon="Delete"
-                                    Label="Delete" />
-                            </CommandBar>
-                        </Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
 
-                        <StackPanel Grid.Row="1" Spacing="8">
-                            <StackPanel Orientation="Horizontal" Spacing="12">
-                                <ComboBox
-                                    Header="Repeat"
-                                    ItemsSource="{Binding ScheduleKinds}"
-                                    SelectedItem="{Binding SelectedScheduleKind, Mode=TwoWay}"
-                                    Width="170" />
+                            <ComboBox
+                                Grid.Row="0"
+                                Grid.Column="0"
+                                Header="Repeat"
+                                HorizontalAlignment="Stretch"
+                                ItemsSource="{Binding ScheduleKinds}"
+                                SelectedItem="{Binding SelectedScheduleKind, Mode=TwoWay}" />
+
+                            <Grid
+                                Grid.Row="0"
+                                Grid.Column="1"
+                                Visibility="{x:Bind ViewModel.ShowScheduleDayOrDatePicker, Mode=OneWay}">
                                 <DatePicker
                                     Header="Date"
+                                    HorizontalAlignment="Stretch"
                                     Date="{Binding StartDate, Mode=TwoWay}"
-                                    Visibility="{x:Bind ViewModel.ShowDatePicker, Mode=OneWay}"
-                                    Width="240" />
+                                    Visibility="{x:Bind ViewModel.ShowDatePicker, Mode=OneWay}" />
                                 <ComboBox
                                     Header="Day"
+                                    HorizontalAlignment="Stretch"
                                     ItemsSource="{Binding WeeklyDays}"
                                     SelectedItem="{Binding SelectedWeeklyDay, Mode=TwoWay}"
-                                    Visibility="{x:Bind ViewModel.ShowWeeklyDayPicker, Mode=OneWay}"
-                                    Width="160" />
+                                    Visibility="{x:Bind ViewModel.ShowWeeklyDayPicker, Mode=OneWay}" />
                                 <NumberBox
                                     Header="Day of month"
+                                    HorizontalAlignment="Stretch"
                                     Minimum="1"
                                     Maximum="31"
-                                    SpinButtonPlacementMode="Inline"
+                                    SpinButtonPlacementMode="Compact"
                                     Value="{Binding SelectedMonthlyDay, Mode=TwoWay}"
-                                    Visibility="{x:Bind ViewModel.ShowMonthlyDayPicker, Mode=OneWay}"
-                                    Width="160" />
-                                <TimePicker
-                                    Header="{x:Bind ViewModel.TimeHeader, Mode=OneWay}"
-                                    Time="{Binding StartTime, Mode=TwoWay}"
-                                    Width="200" />
-                                <Button
-                                    MinWidth="78"
-                                    Margin="0,28,0,0"
-                                    Command="{Binding AddScheduleCommand}"
-                                    Style="{StaticResource AccentButtonStyle}">
-                                    Add
-                                </Button>
-                            </StackPanel>
+                                    Visibility="{x:Bind ViewModel.ShowMonthlyDayPicker, Mode=OneWay}" />
+                            </Grid>
+
+                            <TimePicker
+                                Grid.Row="0"
+                                Grid.Column="2"
+                                Header="{x:Bind ViewModel.TimeHeader, Mode=OneWay}"
+                                Time="{Binding StartTime, Mode=TwoWay}" />
+
+                            <Button
+                                Grid.Row="0"
+                                Grid.Column="3"
+                                MinWidth="72"
+                                Margin="0,28,0,0"
+                                VerticalAlignment="Top"
+                                Command="{Binding AddScheduleCommand}"
+                                Style="{StaticResource AccentButtonStyle}"
+                                Content="Add" />
+
                             <TextBlock
+                                Grid.Row="1"
+                                Grid.Column="0"
+                                Grid.ColumnSpan="4"
                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                 Text="{x:Bind ViewModel.AddScheduleHelpText, Mode=OneWay}"
                                 TextWrapping="WrapWholeWords" />
-                        </StackPanel>
+                        </Grid>
 
-                        <Grid Grid.Row="2" Padding="12,0" ColumnSpacing="16">
+                        <Grid Grid.Row="2" Padding="4,0" ColumnSpacing="16">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="180" />
+                                <ColumnDefinition Width="160" />
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
                             <TextBlock
+                                FontSize="12"
                                 FontWeight="SemiBold"
                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                 Text="Repeat" />
                             <TextBlock
                                 Grid.Column="1"
+                                FontSize="12"
                                 FontWeight="SemiBold"
                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                 Text="Date / time" />
                         </Grid>
 
-                        <ListView
-                            Grid.Row="3"
-                            ItemsSource="{Binding Entries}"
-                            SelectedItem="{Binding SelectedEntry, Mode=TwoWay}"
-                            SelectionMode="Single">
-                            <ListView.ItemTemplate>
-                                <DataTemplate x:DataType="viewmodels:ScheduleEditorEntryViewModel">
-                                    <Grid MinHeight="42" Padding="12,6" ColumnSpacing="16">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="180" />
-                                            <ColumnDefinition Width="*" />
-                                        </Grid.ColumnDefinitions>
-                                        <TextBlock VerticalAlignment="Center" Text="{x:Bind RepeatText}" />
-                                        <TextBlock
-                                            Grid.Column="1"
-                                            VerticalAlignment="Center"
-                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                            Text="{x:Bind ScheduleText}" />
-                                    </Grid>
-                                </DataTemplate>
-                            </ListView.ItemTemplate>
-                        </ListView>
+                        <Grid Grid.Row="3">
+                            <Border
+                                Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
+                                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                                BorderThickness="1"
+                                CornerRadius="4">
+                                <ListView
+                                    ItemsSource="{Binding Entries}"
+                                    SelectedItem="{Binding SelectedEntry, Mode=TwoWay}"
+                                    SelectionMode="Single"
+                                    Visibility="{x:Bind ViewModel.HasEntries, Mode=OneWay}">
+                                    <ListView.ItemTemplate>
+                                        <DataTemplate x:DataType="viewmodels:ScheduleEditorEntryViewModel">
+                                            <Grid MinHeight="40" Padding="8,4" ColumnSpacing="16">
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="160" />
+                                                    <ColumnDefinition Width="*" />
+                                                </Grid.ColumnDefinitions>
+                                                <TextBlock VerticalAlignment="Center" Text="{x:Bind RepeatText}" />
+                                                <TextBlock
+                                                    Grid.Column="1"
+                                                    VerticalAlignment="Center"
+                                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                    Text="{x:Bind ScheduleText}" />
+                                            </Grid>
+                                        </DataTemplate>
+                                    </ListView.ItemTemplate>
+                                </ListView>
+                            </Border>
+
+                            <StackPanel
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                Spacing="4"
+                                Visibility="{x:Bind ViewModel.ShowEmptyScheduleState, Mode=OneWay}">
+                                <FontIcon
+                                    FontSize="28"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    Glyph="&#xE787;" />
+                                <TextBlock
+                                    HorizontalAlignment="Center"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    Text="No schedule entries yet" />
+                                <TextBlock
+                                    HorizontalAlignment="Center"
+                                    FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                                    Text="Choose a repeat pattern above and click Add." />
+                            </StackPanel>
+                        </Grid>
+
+                        <Button
+                            Grid.Row="4"
+                            HorizontalAlignment="Left"
+                            Command="{Binding DeleteScheduleCommand}"
+                            Content="Delete selected" />
                     </Grid>
                 </Border>
 
-                <Grid Grid.Row="2" ColumnSpacing="16">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="*" />
-                    </Grid.ColumnDefinitions>
+                <!-- Retention & full backups in one card -->
+                <Border
+                    Grid.Row="2"
+                    Padding="16"
+                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    CornerRadius="8">
+                    <Grid ColumnSpacing="24" RowSpacing="16">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
 
-                    <Border
-                        Padding="18"
-                        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                        BorderThickness="1"
-                        CornerRadius="8">
-                        <StackPanel Spacing="12">
-                            <StackPanel Spacing="2">
-                                <TextBlock FontWeight="SemiBold" Text="Retention" />
-                                <TextBlock
-                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                    Text="Choose how long scheduled backup versions stay available."
-                                    TextWrapping="WrapWholeWords" />
-                            </StackPanel>
-
+                        <StackPanel Grid.Column="0" Spacing="10">
+                            <TextBlock FontWeight="SemiBold" Text="Retention" />
                             <ComboBox
                                 Header="Mode"
-                                Width="240"
-                                HorizontalAlignment="Left"
+                                HorizontalAlignment="Stretch"
+                                MaxWidth="280"
                                 ItemsSource="{Binding RetentionModes}"
                                 SelectedItem="{Binding RetentionMode, Mode=TwoWay}" />
 
-                            <StackPanel Orientation="Horizontal" Spacing="10">
+                            <StackPanel
+                                Orientation="Horizontal"
+                                Spacing="10"
+                                Visibility="{x:Bind ViewModel.ShowRetentionIntervalControls, Mode=OneWay}">
                                 <NumberBox
-                                    Header="Delete interval"
+                                    Header="Delete after"
                                     Minimum="1"
-                                    SpinButtonPlacementMode="Inline"
+                                    SpinButtonPlacementMode="Compact"
                                     Value="{Binding RetentionInterval, Mode=TwoWay}"
-                                    Width="150" />
+                                    Width="120" />
                                 <ComboBox
                                     Header="Unit"
-                                    Width="150"
+                                    Width="120"
                                     ItemsSource="{Binding RetentionIntervalUnits}"
                                     SelectedItem="{Binding RetentionIntervalUnit, Mode=TwoWay}" />
                             </StackPanel>
 
                             <NumberBox
-                                Header="Hourly backup threshold"
+                                Header="Keep hourly backups for (hours)"
                                 Minimum="1"
-                                SpinButtonPlacementMode="Inline"
+                                SpinButtonPlacementMode="Compact"
                                 Value="{Binding AutomaticHourlyBackupThreshold, Mode=TwoWay}"
-                                Width="190" />
+                                Width="220"
+                                Visibility="{x:Bind ViewModel.ShowAutomaticHourlyThreshold, Mode=OneWay}" />
                         </StackPanel>
-                    </Border>
 
-                    <Border
-                        Grid.Column="1"
-                        Padding="18"
-                        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                        BorderThickness="1"
-                        CornerRadius="8">
-                        <StackPanel Spacing="12">
-                            <StackPanel Spacing="2">
-                                <TextBlock FontWeight="SemiBold" Text="Full backups" />
-                                <TextBlock
-                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                    Text="Control scheduled full backups and missed backup handling."
-                                    TextWrapping="WrapWholeWords" />
-                            </StackPanel>
-
-                            <ToggleSwitch Header="Create full backup after an interval" IsOn="{Binding EnableScheduledFullBackups, Mode=TwoWay}" />
-
+                        <StackPanel Grid.Column="1" Spacing="10">
+                            <TextBlock FontWeight="SemiBold" Text="Full backups" />
+                            <ToggleSwitch
+                                Header="Create full backup after an interval"
+                                IsOn="{Binding EnableScheduledFullBackups, Mode=TwoWay}" />
                             <NumberBox
                                 Header="Days between full backups"
                                 Minimum="1"
-                                SpinButtonPlacementMode="Inline"
+                                SpinButtonPlacementMode="Compact"
                                 Value="{Binding ScheduledFullBackupDays, Mode=TwoWay}"
-                                Width="190" />
-
-                            <ToggleSwitch Header="Perform missed scheduled backups later" IsOn="{Binding PerformMissedBackupsLater, Mode=TwoWay}" />
+                                Width="180"
+                                Visibility="{x:Bind ViewModel.ShowFullBackupDays, Mode=OneWay}" />
+                            <ToggleSwitch
+                                Header="Perform missed scheduled backups later"
+                                IsOn="{Binding PerformMissedBackupsLater, Mode=TwoWay}" />
                         </StackPanel>
-                    </Border>
-                </Grid>
+                    </Grid>
+                </Border>
             </Grid>
         </ScrollViewer>
 
@@ -251,15 +281,13 @@
             Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
             BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
             BorderThickness="0,1,0,0">
-            <Grid MaxWidth="980" HorizontalAlignment="Stretch">
-                <StackPanel
-                    HorizontalAlignment="Right"
-                    Orientation="Horizontal"
-                    Spacing="10">
-                    <Button Command="{Binding CancelCommand}">Cancel</Button>
-                    <Button Command="{Binding SaveCommand}" Style="{StaticResource AccentButtonStyle}">Save</Button>
-                </StackPanel>
-            </Grid>
+            <StackPanel
+                HorizontalAlignment="Right"
+                Orientation="Horizontal"
+                Spacing="10">
+                <Button Command="{Binding CancelCommand}" Content="Cancel" />
+                <Button Command="{Binding SaveCommand}" Style="{StaticResource AccentButtonStyle}" Content="Save" />
+            </StackPanel>
         </Grid>
     </Grid>
 </winex:WindowEx>

--- a/src/BSH.MainApp/Windows/StatusWindow.xaml
+++ b/src/BSH.MainApp/Windows/StatusWindow.xaml
@@ -3,45 +3,91 @@
     x:Class="BSH.MainApp.Windows.StatusWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:BSH.MainApp.Windows"
-    xmlns:converters="using:BSH.MainApp.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     Title="{x:Bind ViewModel.StatusTitle, Mode=OneWay}"
-    Height="340" Width="600" IsResizable="False" IsMaximizable="False" IsMinimizable="False" IsAlwaysOnTop="True">
+    Height="300"
+    Width="520"
+    IsResizable="False"
+    IsMaximizable="False"
+    IsMinimizable="False"
+    IsAlwaysOnTop="True">
 
-    <Grid Background="White">
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <Grid.RowDefinitions>
-            <RowDefinition Height="*"></RowDefinition>
-            <RowDefinition Height="Auto"></RowDefinition>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <StackPanel Margin="30" Grid.Row="0" Spacing="12" Orientation="Vertical">
-            <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="{x:Bind ViewModel.StatusTitle, Mode=OneWay}" />
-            <TextBlock Style="{StaticResource BaseTextBlockStyle}" Text="{x:Bind ViewModel.StatusText, Mode=OneWay}" />
 
-            <ProgressBar Maximum="{x:Bind ViewModel.TotalProgress}" Value="{x:Bind ViewModel.CurrentProgress, Mode=OneWay}" />
-            <StackPanel Orientation="Horizontal" Spacing="4">
-                <TextBlock Text="{x:Bind ViewModel.CurrentProgress}" />
-                <TextBlock Text="/" />
-                <TextBlock Text="{x:Bind ViewModel.TotalProgress}" />
-                <TextBlock Text="files processed" />
-            </StackPanel>
-            <TextBlock Text="{x:Bind ViewModel.CurrentFileText, Mode=OneWay}" />
-            <StackPanel Orientation="Horizontal" Spacing="8">
-                <TextBlock VerticalAlignment="Center" Text="After completion" />
-                <ComboBox Width="180" SelectedIndex="{x:Bind ViewModel.SelectedCompletionActionIndex, Mode=TwoWay}">
-                    <ComboBoxItem Content="No action" />
-                    <ComboBoxItem Content="Shutdown" />
-                    <ComboBoxItem Content="Hibernate" />
-                </ComboBox>
-            </StackPanel>
-        </StackPanel>
+        <Grid Grid.Row="0" Padding="24,20" RowSpacing="14">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
 
-        <Grid Grid.Row="1" Background="#fafafa" Padding="30,10" BorderBrush="#f0f0f0" BorderThickness="0,1,0,0">
-            <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Right">
-                <Button Command="{x:Bind ViewModel.CancelCommand}">Cancel</Button>
+            <StackPanel Grid.Row="0" Spacing="4">
+                <TextBlock
+                    FontSize="20"
+                    FontWeight="SemiBold"
+                    Text="{x:Bind ViewModel.StatusTitle, Mode=OneWay}"
+                    TextTrimming="CharacterEllipsis"
+                    TextWrapping="NoWrap" />
+                <TextBlock
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                    Text="{x:Bind ViewModel.StatusText, Mode=OneWay}"
+                    TextTrimming="CharacterEllipsis"
+                    TextWrapping="WrapWholeWords"
+                    MaxLines="2" />
             </StackPanel>
+
+            <StackPanel Grid.Row="1" Spacing="6">
+                <ProgressBar
+                    Height="4"
+                    IsIndeterminate="{x:Bind ViewModel.IsProgressIndeterminate, Mode=OneWay}"
+                    Maximum="{x:Bind ViewModel.ProgressMaximum, Mode=OneWay}"
+                    Value="{x:Bind ViewModel.CurrentProgress, Mode=OneWay}" />
+                <TextBlock
+                    FontSize="12"
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                    Text="{x:Bind ViewModel.ProgressFilesText, Mode=OneWay}" />
+            </StackPanel>
+
+            <TextBlock
+                Grid.Row="2"
+                FontSize="12"
+                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                Text="{x:Bind ViewModel.CurrentFileText, Mode=OneWay}"
+                TextTrimming="CharacterEllipsis"
+                TextWrapping="NoWrap"
+                ToolTipService.ToolTip="{x:Bind ViewModel.CurrentFileText, Mode=OneWay}" />
+
+            <ComboBox
+                Grid.Row="4"
+                Header="After completion"
+                HorizontalAlignment="Left"
+                MinWidth="200"
+                SelectedIndex="{x:Bind ViewModel.SelectedCompletionActionIndex, Mode=TwoWay}">
+                <ComboBoxItem Content="No action" />
+                <ComboBoxItem Content="Shutdown" />
+                <ComboBoxItem Content="Hibernate" />
+            </ComboBox>
+        </Grid>
+
+        <Grid
+            Grid.Row="1"
+            Padding="24,12"
+            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+            BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+            BorderThickness="0,1,0,0">
+            <Button
+                HorizontalAlignment="Right"
+                MinWidth="100"
+                Command="{x:Bind ViewModel.CancelCommand}"
+                Content="Cancel" />
         </Grid>
     </Grid>
 </winex:WindowEx>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Refines the WinUI schedule editor, backup progress window, and settings pages so they feel less crowded while keeping full feature parity with the existing WinForms/WinUI capabilities.

### Schedule editor
- Progressive disclosure for retention interval, hourly threshold, and full-backup days
- Compact add form that hides unused date/day fields
- Empty-state for the schedule list
- Retention + full backups combined into one card
- Delete control simplified (no CommandBar chrome)

### Progress dialog
- Theme-aware backgrounds (no hardcoded white)
- Clearer hierarchy: title → status → progress → current file → completion action
- Path ellipsis + tooltip; throttled UI updates (~100ms, matching WinForms)
- Indeterminate progress while preparing; single “N of M files” line
- ComboBox header instead of a separate label row

### Settings
- Shared `SettingsResources.xaml` for spacing/section styles
- Theme brushes instead of hardcoded white
- Automation: shorter mode copy; “Set schedule” only enabled in Scheduled mode
- Options: compression exclusion editor only when compression is selected
- Sources: flatter expander (list in content, not nested card)
- Target: FTP/UNC fields as settings cards instead of dense label grids
- Behavior: threshold NumberBoxes gated by their parent toggles; expanders auto-open when enabled

## Test plan
- [ ] Open Settings → Automation: switch modes; confirm Set schedule is enabled only for Scheduled
- [ ] Open schedule editor: add Once/Hourly/Daily/Weekly/Monthly entries; verify conditional fields
- [ ] Switch retention modes and full-backup toggle; confirm controls appear/disappear correctly
- [ ] Run a backup; verify progress window layout, file path truncation, cancel, and after-completion actions
- [ ] Settings Sources/Target/Options/Behavior: confirm all prior controls still work (FTP fields, exclusions, notifications)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ff2d45a-db70-42ba-b449-3b0ea44fcaab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ff2d45a-db70-42ba-b449-3b0ea44fcaab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

