### PR TITLE
Fix: WinUI folder restore treated as single-file (#581)

### DIFF
--- a/src/BSH.MainApp/ViewModels/BrowserViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/BrowserViewModel.cs
@@ -312,9 +312,12 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
             return;
         }
 
+        // RestoreJob treats a path as a single file when Path.GetFileName is non-empty.
+        // Browser folder FullPaths are slash-stripped (e.g. "source\docs"), so folder
+        // restores must be normalized to "\source\docs\" like WinForms.
         var path = CurrentItem.IsFile
             ? CurrentItem.FullPath + CurrentItem.Name
-            : CurrentItem.FullPath;
+            : ToFolderRestorePath(CurrentItem.FullPath);
 
         await jobService.RestoreBackupAsync(CurrentVersion.Id, path, destination);
     }
@@ -326,7 +329,25 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
             return;
         }
 
-        await jobService.RestoreBackupAsync(CurrentVersion.Id, CurrentFolderPath[^1].FullPath, destination);
+        await jobService.RestoreBackupAsync(
+            CurrentVersion.Id,
+            ToFolderRestorePath(CurrentFolderPath[^1].FullPath),
+            destination);
+    }
+
+    /// <summary>
+    /// Formats a browser folder path for RestoreJob folder-mode restores.
+    /// </summary>
+    private static string ToFolderRestorePath(string path)
+    {
+        path ??= string.Empty;
+        path = path.Trim('\\');
+        if (string.IsNullOrEmpty(path))
+        {
+            return "\\";
+        }
+
+        return "\\" + path + "\\";
     }
 
     [RelayCommand(CanExecute = nameof(HasFileSelected))]

--- a/src/BSH.Test/BrowserViewModelTests.cs
+++ b/src/BSH.Test/BrowserViewModelTests.cs
@@ -237,11 +237,38 @@ public class BrowserViewModelTests
         var jobService = new BrowserJobService();
         var viewModel = CreateViewModel(jobService: jobService, browserDialogService: dialogService);
         viewModel.CurrentVersion = Version("2");
-        viewModel.CurrentFolderPath.Add(new FileOrFolderItem { Name = "docs", FullPath = @"\source\docs\", IsFile = false });
+        // Production BrowserContentService stores slash-stripped folder paths.
+        viewModel.CurrentFolderPath.Add(new FileOrFolderItem { Name = "docs", FullPath = @"source\docs", IsFile = false });
 
         await viewModel.RestoreAllToCommand.ExecuteAsync(null);
 
         Assert.That(jobService.RestoreCalls.Single(), Is.EqualTo(("2", @"\source\docs\", @"D:\RestoreHere")));
+    }
+
+    [Test]
+    public async Task RestoreFileCommand_NormalizesSelectedFolderPathForRestoreJob()
+    {
+        var jobService = new BrowserJobService();
+        var viewModel = CreateViewModel(jobService: jobService);
+        viewModel.CurrentVersion = Version("2");
+        viewModel.CurrentItem = new FileOrFolderItem { Name = "docs", FullPath = @"source\docs", IsFile = false };
+
+        await viewModel.RestoreFileCommand.ExecuteAsync(null);
+
+        Assert.That(jobService.RestoreCalls.Single(), Is.EqualTo(("2", @"\source\docs\", "")));
+    }
+
+    [Test]
+    public async Task RestoreAllCommand_NormalizesCurrentFolderPathForRestoreJob()
+    {
+        var jobService = new BrowserJobService();
+        var viewModel = CreateViewModel(jobService: jobService);
+        viewModel.CurrentVersion = Version("2");
+        viewModel.CurrentFolderPath.Add(new FileOrFolderItem { Name = "docs", FullPath = @"source\docs", IsFile = false });
+
+        await viewModel.RestoreAllCommand.ExecuteAsync(null);
+
+        Assert.That(jobService.RestoreCalls.Single(), Is.EqualTo(("2", @"\source\docs\", "")));
     }
 
     private static BrowserViewModel CreateViewModel(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Bug and impact

WinUI Backup Browser folder restores (Restore / Restore to… on a selected folder, and Restore all / Restore all to… for the current folder) passed slash-stripped paths such as `source\docs` into `RestoreJob`.

`RestoreJob` decides file vs folder mode with `Path.GetFileName(File)`: a non-empty filename means single-file restore. For `source\docs`, that is `"docs"`, so the job looked up a file named `docs` under `\source\` and either restored nothing or the wrong file. Users who restore a folder get incomplete/wrong recovery.

**Trigger:** Open WinUI Backup Browser, select a subfolder (or stay in one and use Restore all), click Restore or Restore to….

## Root cause

`BrowserContentService` stores folder `FullPath` values without leading/trailing `\` (`GetPathWithoutSlashes` / `BuildFolderPath`). WinForms always passed `\` + folder + `\` (see `frmBrowser`). The WinUI restore wiring from #581/#580-era browser work did not re-apply that convention.

## Fix

- Normalize folder restore paths in `BrowserViewModel` to `\folder\` before calling `IJobService.RestoreBackupAsync`.
- File restores unchanged (`FullPath + Name`).
- Added unit tests that use the production slash-stripped path shape and assert the restore call receives `\source\docs\`.

## Validation

- Logic cross-checked against WinForms `frmBrowser` (`'\\' + selectedFolder + '\\'`) and `RestoreJob` file/folder gate.
- New/updated `BrowserViewModelTests` cover selected-folder restore and Restore all / Restore all to….
- Full `dotnet test` not run here (Linux / `net*-windows`); CI on the PR will build/test on Windows.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c611c3b-df80-4e73-a6a6-9e1f846dad7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c611c3b-df80-4e73-a6a6-9e1f846dad7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

