### PR TITLE
fix: high-value CI analyzer warnings from main build

### DIFF
--- a/src/BSH.Engine/Services/MediaTargetApplier.cs
+++ b/src/BSH.Engine/Services/MediaTargetApplier.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Alexander Seeliger. All Rights Reserved.
 // Licensed under the Apache License, Version 2.0.
 
+#nullable enable
+
 using System;
 using System.IO;
 using System.Security.Cryptography;

--- a/src/BSH.Engine/Services/UncTargetProbe.cs
+++ b/src/BSH.Engine/Services/UncTargetProbe.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Alexander Seeliger. All Rights Reserved.
 // Licensed under the Apache License, Version 2.0.
 
+#nullable enable
+
 using System;
 using System.IO;
 using Brightbits.BSH.Engine.Security;

--- a/src/BSH.Main/Dialogs/SubDialogs/frmChangeMedia.cs
+++ b/src/BSH.Main/Dialogs/SubDialogs/frmChangeMedia.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Alexander Seeliger. All Rights Reserved.
 // Licensed under the Apache License, Version 2.0.
 
+#nullable enable
+
 using System;
 using System.IO;
 using System.Windows.Forms;
@@ -174,7 +176,7 @@ public partial class frmChangeMedia
                 txtFTPUsername.Text,
                 txtFTPPassword.Text,
                 txtFTPPath.Text,
-                cboFtpEncoding.SelectedItem.ToString(),
+                Convert.ToString(cboFtpEncoding.SelectedItem) ?? "",
                 !chkFtpEncryption.Checked,
                 0);
             storage.Open();
@@ -217,7 +219,7 @@ public partial class frmChangeMedia
         {
             txtFTPPath.Text = FtpStorage.GetFtpPath(txtFTPPath.Text);
 
-            var profile = FtpStorage.CheckConnection(txtFTPServer.Text, int.Parse(txtFTPPort.Text), txtFTPUsername.Text, txtFTPPassword.Text, txtFTPPath.Text, cboFtpEncoding.SelectedItem.ToString());
+            var profile = FtpStorage.CheckConnection(txtFTPServer.Text, int.Parse(txtFTPPort.Text), txtFTPUsername.Text, txtFTPPassword.Text, txtFTPPath.Text, Convert.ToString(cboFtpEncoding.SelectedItem));
 
             if (!profile)
             {

--- a/src/BSH.Main/Dialogs/SubDialogs/frmEditVersion.cs
+++ b/src/BSH.Main/Dialogs/SubDialogs/frmEditVersion.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
+using System.Windows.Forms;
 
 namespace Brightbits.BSH.Main;
 
@@ -14,13 +15,20 @@ public partial class frmEditVersion
 
     private void txtTitle_TextChanged(object sender, EventArgs e)
     {
-        txtTitle.Text = txtTitle.Text.Replace("\"", "");
-        txtTitle.Text = txtTitle.Text.Replace("'", "");
+        SanitizeQuotes(txtTitle);
     }
 
     private void txtDescription_TextChanged(object sender, EventArgs e)
     {
-        txtTitle.Text = txtTitle.Text.Replace("\"", "");
-        txtTitle.Text = txtTitle.Text.Replace("'", "");
+        SanitizeQuotes(txtDescription);
+    }
+
+    private static void SanitizeQuotes(TextBox textBox)
+    {
+        var sanitized = textBox.Text.Replace("\"", "").Replace("'", "");
+        if (sanitized != textBox.Text)
+        {
+            textBox.Text = sanitized;
+        }
     }
 }

--- a/src/BSH.Main/Dialogs/frmBrowser.cs
+++ b/src/BSH.Main/Dialogs/frmBrowser.cs
@@ -371,8 +371,7 @@ public partial class frmBrowser : IStatusReport
                 }
 
                 // determine file details
-                var shFi = new SHFILEINFO();
-                SHGetFileInfo(fileInfo.FullName, 0U, out shFi, (uint)System.Runtime.InteropServices.Marshal.SizeOf(shFi), (uint)SHGFI.SHGFI_TYPENAME);
+                SHGetFileInfo(fileInfo.FullName, 0U, out SHFILEINFO shFi, (uint)System.Runtime.InteropServices.Marshal.SizeOf(typeof(SHFILEINFO)), (uint)SHGFI.SHGFI_TYPENAME);
                 listViewItem.SubItems[2].Text = shFi.szTypeName;
 
                 // set icon to ListViewItem

--- a/src/BSH.Main/Dialogs/frmMain.cs
+++ b/src/BSH.Main/Dialogs/frmMain.cs
@@ -293,8 +293,7 @@ public partial class frmMain
 
     private void lblExtras_Click(object sender, EventArgs e)
     {
-        BetaversionenÜberAktualiserungenHerunterladenToolStripMenuItem.Visible = (ModifierKeys & Keys.Control) == Keys.Control;
-        cmsHelp.Show(picHelp, new Point((int)Math.Round(-cmsHelp.Width / 2d + picHelp.Width / 2d), picHelp.Height));
+        picHelp_Click(sender, e);
     }
 
     private void EreignisprotokollAnzeigenToolStripMenuItem_Click(object sender, EventArgs e)

--- a/src/BSH.MainApp/Helpers/RuntimeHelper.cs
+++ b/src/BSH.MainApp/Helpers/RuntimeHelper.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace BSH.MainApp.Helpers;
 
-public class RuntimeHelper
+public static class RuntimeHelper
 {
     [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
     private static extern int GetCurrentPackageFullName(ref int packageFullNameLength, StringBuilder? packageFullName);

--- a/src/BSH.MainApp/Services/BrowserDialogService.cs
+++ b/src/BSH.MainApp/Services/BrowserDialogService.cs
@@ -143,7 +143,7 @@ public class BrowserDialogService : IBrowserDialogService
         }
         catch (Exception ex)
         {
-            if (App.MainWindow?.Content != null)
+            if (App.MainWindow.Content != null)
             {
                 await presentationService.ShowMessageBoxAsync(
                     "Restore destination",

--- a/src/BSH.MainApp/Services/ScheduledBackupService.cs
+++ b/src/BSH.MainApp/Services/ScheduledBackupService.cs
@@ -112,18 +112,17 @@ public class ScheduledBackupService : IScheduledBackupService
         // lower process priority
         Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.BelowNormal;
 
-        // run backup
-        var task = jobService.CreateBackupAsync("Automatisches Backup", "", false);
-
-        await task.ContinueWith(async (x) =>
+        try
         {
-            if (x.Result)
+            if (await jobService.CreateBackupAsync("Automatisches Backup", "", false))
             {
                 await RemoveOldBackups();
             }
-        }, TaskContinuationOptions.OnlyOnRanToCompletion)
-            .ContinueWith((x) => Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.Normal,
-            TaskContinuationOptions.None);
+        }
+        finally
+        {
+            Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.Normal;
+        }
     }
 
     private async Task RemoveOldBackups()
@@ -325,16 +324,17 @@ public class ScheduledBackupService : IScheduledBackupService
         var fullBackupOption = schedulePolicy.ShouldPerformFullBackup(lastFullBackup?.CreationDate, DateTime.Now);
 
         // Backup durchführen
-        var task = jobService.CreateBackupAsync("Automatische Sicherung", "", false, fullBackupOption);
-
-        await task.ContinueWith(async (x) =>
+        try
         {
-            if (x.Result)
+            if (await jobService.CreateBackupAsync("Automatische Sicherung", "", false, fullBackupOption))
             {
                 await RemoveOldBackupsScheduled();
             }
-        }, TaskContinuationOptions.OnlyOnRanToCompletion)
-            .ContinueWith((x) => Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.Normal, TaskContinuationOptions.None);
+        }
+        finally
+        {
+            Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.Normal;
+        }
     }
 
     private async Task RemoveOldBackupsScheduled()

--- a/src/BSH.MainApp/ViewModels/SettingsViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/SettingsViewModel.cs
@@ -38,6 +38,7 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
     private readonly IOrchestrationService orchestrationService;
     private readonly IStartupLaunchAdapter startupLaunchAdapter;
     private readonly IUpdateService updateService;
+    private bool suppressEnhancedSettingsPersistence;
 
     #region Sources Settings
 
@@ -693,18 +694,35 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
         this.EnableNotificationWhenBackupOutdated = !string.IsNullOrEmpty(this.configurationManager.RemindAfterDays);
         this.NotificationWhenBackupOutdated = int.TryParse(this.configurationManager.RemindAfterDays, out var days) ? days : 0;
 
-        // Set backing fields so load does not re-enter the persistence handlers.
-        launchAtWindowsStartup = startupLaunchAdapter.IsEnabled();
-        OnPropertyChanged(nameof(LaunchAtWindowsStartup));
+        // Load without re-entering the persistence handlers.
+        suppressEnhancedSettingsPersistence = true;
+        try
+        {
+            LaunchAtWindowsStartup = startupLaunchAdapter.IsEnabled();
+        }
+        finally
+        {
+            suppressEnhancedSettingsPersistence = false;
+        }
+
         _ = LoadUpdateSettingsAsync();
     }
 
     private async Task LoadUpdateSettingsAsync()
     {
-        automaticallyCheckForUpdates = await updateService.GetAutoSearchEnabledAsync();
-        downloadBetaUpdates = await updateService.GetDownloadBetaAsync();
-        OnPropertyChanged(nameof(AutomaticallyCheckForUpdates));
-        OnPropertyChanged(nameof(DownloadBetaUpdates));
+        var autoSearch = await updateService.GetAutoSearchEnabledAsync();
+        var downloadBeta = await updateService.GetDownloadBetaAsync();
+
+        suppressEnhancedSettingsPersistence = true;
+        try
+        {
+            AutomaticallyCheckForUpdates = autoSearch;
+            DownloadBetaUpdates = downloadBeta;
+        }
+        finally
+        {
+            suppressEnhancedSettingsPersistence = false;
+        }
     }
 
     partial void OnEnableNotificationWhenDiskspaceLowChanged(bool oldValue, bool newValue)
@@ -768,7 +786,7 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
 
     partial void OnLaunchAtWindowsStartupChanged(bool oldValue, bool newValue)
     {
-        if (oldValue == newValue)
+        if (suppressEnhancedSettingsPersistence || oldValue == newValue)
         {
             return;
         }
@@ -778,8 +796,16 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
             return;
         }
 
-        launchAtWindowsStartup = oldValue;
-        OnPropertyChanged(nameof(LaunchAtWindowsStartup));
+        suppressEnhancedSettingsPersistence = true;
+        try
+        {
+            LaunchAtWindowsStartup = oldValue;
+        }
+        finally
+        {
+            suppressEnhancedSettingsPersistence = false;
+        }
+
         _ = presentationController.ShowMessageBoxAsync(
             "Access denied",
             "Windows startup could not be changed. Check your permissions and try again.",
@@ -788,7 +814,7 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
 
     partial void OnAutomaticallyCheckForUpdatesChanged(bool oldValue, bool newValue)
     {
-        if (oldValue == newValue)
+        if (suppressEnhancedSettingsPersistence || oldValue == newValue)
         {
             return;
         }
@@ -798,7 +824,7 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
 
     partial void OnDownloadBetaUpdatesChanged(bool oldValue, bool newValue)
     {
-        if (oldValue == newValue)
+        if (suppressEnhancedSettingsPersistence || oldValue == newValue)
         {
             return;
         }

--- a/src/BSH.Service/Program.cs
+++ b/src/BSH.Service/Program.cs
@@ -28,4 +28,4 @@ LoggerProviderOptions.RegisterProviderOptions<
 builder.Services.AddHostedService<WindowsBackgroundService>();
 
 IHost host = builder.Build();
-host.Run();
+await host.RunAsync();

--- a/src/BSH.Service/VSS/VssBackup.cs
+++ b/src/BSH.Service/VSS/VssBackup.cs
@@ -23,7 +23,7 @@ namespace BSH.Service.VSS
         /// Otherwise, this example code quiesces all VSS-compatible components
         /// before making its shadow copy.
         /// </remarks>
-        bool ComponentMode = false;
+        readonly bool ComponentMode = false;
 
         /// <summary>A reference to the VSS context.</summary>
         IVssBackupComponents _backup = null!;

--- a/src/BSH.Test/Integration/FileSystemRestoreIntegrationTests.cs
+++ b/src/BSH.Test/Integration/FileSystemRestoreIntegrationTests.cs
@@ -112,7 +112,7 @@ public class FileSystemRestoreIntegrationTests
 
         var restoredFile = Path.Combine(restoreDir, Path.GetFileName(sourceFile));
         Assert.That(File.Exists(restoredFile), Is.True);
-        Assert.That(File.ReadAllText(restoredFile), Is.EqualTo(SampleContent));
+        Assert.That(await File.ReadAllTextAsync(restoredFile), Is.EqualTo(SampleContent));
     }
 
     [Test]
@@ -125,7 +125,7 @@ public class FileSystemRestoreIntegrationTests
         await RunRestoreAsync(overwrite: FileOverwrite.Overwrite);
 
         var restoredFile = Path.Combine(restoreDir, "report.txt");
-        Assert.That(File.ReadAllText(restoredFile), Is.EqualTo(SampleContent + "-compressed"));
+        Assert.That(await File.ReadAllTextAsync(restoredFile), Is.EqualTo(SampleContent + "-compressed"));
     }
 
     [Test]

--- a/src/BSH.Test/WinUiOrchestrationParityTests.cs
+++ b/src/BSH.Test/WinUiOrchestrationParityTests.cs
@@ -317,8 +317,7 @@ public class WinUiOrchestrationParityTests
             {
                 Assert.That(waitMode, Is.EqualTo(MediaWaitMode.PromptUser));
                 waitWasRequested = true;
-                cancellationTokenSource.Cancel();
-                await Task.Yield();
+                await cancellationTokenSource.CancelAsync();
                 return false;
             },
             () => Task.FromResult(true));

--- a/src/PreviewHandlerFramework/PreviewHandler.cs
+++ b/src/PreviewHandlerFramework/PreviewHandler.cs
@@ -14,7 +14,7 @@ namespace C4F.DevKit.PreviewHandler.PreviewHandlerFramework
     public abstract class PreviewHandler : IPreviewHandler, IPreviewHandlerVisuals, IOleWindow, IObjectWithSite
     {
         private bool _showPreview;
-        private PreviewHandlerControl _previewControl;
+        private readonly PreviewHandlerControl _previewControl;
         private IntPtr _parentHwnd;
         private Rectangle _windowBounds;
         private object _unkSite;

--- a/src/PreviewHandlerFramework/PreviewHandlerAttribute.cs
+++ b/src/PreviewHandlerFramework/PreviewHandlerAttribute.cs
@@ -9,7 +9,7 @@ namespace C4F.DevKit.PreviewHandler.PreviewHandlerFramework
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
     public sealed class PreviewHandlerAttribute : Attribute
     {
-        private string _name, _extension, _appId;
+        private readonly string _name, _extension, _appId;
 
         public PreviewHandlerAttribute(string name, string extension, string appId)
         {

--- a/src/PreviewHandlerHost/PreviewHandlerRegistryAccessor.cs
+++ b/src/PreviewHandlerHost/PreviewHandlerRegistryAccessor.cs
@@ -10,7 +10,7 @@ namespace C4F.DevKit.PreviewHandler.PreviewHandlerHost
     /// and posted about on his blog.  http://blogs.msdn.com/toub/archive/2006/12/14/preview-handler-association-editor.aspx
     /// We made a few minor tweaks for our purposes, but the core of the logic is his.  Thanks to Stephen for sharing this code.
     /// </summary>
-    internal class PreviewHandlerRegistryAccessor
+    internal static class PreviewHandlerRegistryAccessor
     {
         private const string BaseRegistryKey = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\PreviewHandlers";
         private const string BaseClsIDKey = @"HKEY_CLASSES_ROOT\{0}\shellex\{{8895b1c6-b41f-4c1c-a562-0d564250836f}}";

--- a/src/PreviewHandlerHost/StreamWrapper.cs
+++ b/src/PreviewHandlerHost/StreamWrapper.cs
@@ -125,7 +125,7 @@ namespace C4F.DevKit.PreviewHandler.PreviewHandlerHost
         public void Seek(long dlibMove, int dwOrigin, IntPtr plibNewPosition)
         {
             long newPosition = 0;
-            SeekOrigin seekOrigin = SeekOrigin.Begin;
+            SeekOrigin seekOrigin;
 
             try
             {

--- a/src/SmartPreview/frmSmartPreview.cs
+++ b/src/SmartPreview/frmSmartPreview.cs
@@ -132,7 +132,6 @@ public partial class frmSmartPreview
                         previewItem.SizeMode = PictureBoxSizeMode.Zoom;
                         plContent.Controls.Add(previewItem);
                         previewItem.Dock = DockStyle.Fill;
-                        psd = null;
                         break;
                     }
 
@@ -252,8 +251,7 @@ public partial class frmSmartPreview
                                     picIcon.Image = Icon.ExtractAssociatedIcon(fileName).ToBitmap();
 
                                     // retrieve file type
-                                    var shFi = new SHFILEINFO();
-                                    SHGetFileInfo(fileName, 0, out shFi, (uint)System.Runtime.InteropServices.Marshal.SizeOf(shFi), (uint)SHGFI.SHGFI_TYPENAME);
+                                    SHGetFileInfo(fileName, 0, out SHFILEINFO shFi, (uint)System.Runtime.InteropServices.Marshal.SizeOf(typeof(SHFILEINFO)), (uint)SHGFI.SHGFI_TYPENAME);
 
                                     lblFileType.Text = shFi.szTypeName;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

From the latest successful `main` CI build ([run 29701709877](https://github.com/alexsee/bsh3/actions/runs/29701709877)), fixed the highest-value / quick-win warnings and skipped large or low-value noise (MVVMTK0045 AOT migration across all ViewModels, cognitive complexity, duplicated string literals, WinForms modal `ShowDialog` sync usage, intentional MD5 hashing, etc.).

### Fixes included

- **CS8632** — `#nullable enable` on recent UNC media helpers (`MediaTargetApplier`, `UncTargetProbe`, `frmChangeMedia`)
- **CA1849 / S6966** — replace `Task.ContinueWith` + `.Result` in `ScheduledBackupService` with straight `await`; `await host.RunAsync()` in `BSH.Service`
- **MVVMTK0034** — load settings via generated properties with a suppress flag (no backing-field writes)
- **S4144 + bug** — `frmEditVersion` description handler was sanitizing `txtTitle`; now sanitizes the correct textbox
- Trivial cleanups: static utility classes (S1118), readonly fields (S2933), useless assignments (S1854), unnecessary null check (S2589), duplicate help-click handler

### Intentionally not addressed

- **MVVMTK0045** (~154 unique): field-based `[ObservableProperty]` → partial properties; large mechanical migration
- Cognitive complexity / magic strings / hardcoded URIs / make-static churn
- WinForms `Show`/`ShowDialog` sync warnings (modal UI pattern)
- MD5 / `GetTempFileName` / dispose-pattern refactors

## Test plan

- [ ] CI build on this PR is green
- [ ] Confirm CS8632 / MVVMTK0034 / ScheduledBackupService CA1849 are gone from the PR build log
- [ ] Spot-check WinUI settings load (startup + update toggles) still does not re-persist on open
- [ ] Spot-check edit-version dialog: quotes stripped from title *and* description independently

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ebabf435-cb73-46d5-9fc7-944b81f23456"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ebabf435-cb73-46d5-9fc7-944b81f23456"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

