### PR TITLE
fix: UNC setup/switch probes fail to authenticate with credentials

### DIFF
--- a/src/BSH.Engine/Security/Network.cs
+++ b/src/BSH.Engine/Security/Network.cs
@@ -11,7 +11,12 @@ public class NetworkConnection : IDisposable
 {
     public string RemoteShare { get; set; } = null;
 
-    public NetworkConnection(string remoteHost, string remoteUser, string remotePassword)
+    /// <summary>
+    /// Opens a temporary SMB connection. By default <paramref name="remotePassword"/> is
+    /// treated as DPAPI LocalMachine ciphertext (config <c>UNCPassword</c>). Pass
+    /// <paramref name="passwordIsEncrypted"/> as false for UI plaintext (setup / media-switch probes).
+    /// </summary>
+    public NetworkConnection(string remoteHost, string remoteUser, string remotePassword, bool passwordIsEncrypted = true)
     {
         if (string.IsNullOrEmpty(remoteUser) || string.IsNullOrEmpty(remotePassword) || !Uri.TryCreate(remoteHost, UriKind.Absolute, out var loc) || !loc.IsUnc)
         {
@@ -21,8 +26,10 @@ public class NetworkConnection : IDisposable
         var auth = loc.Host;
         var segments = loc.Segments;
 
-        // decrypt password
-        var pw = Crypto.DecryptString(remotePassword, System.Security.Cryptography.DataProtectionScope.LocalMachine);
+        // Config-stored passwords are DPAPI ciphertext; UI probes pass plaintext.
+        var pw = passwordIsEncrypted
+            ? Crypto.DecryptString(remotePassword, System.Security.Cryptography.DataProtectionScope.LocalMachine)
+            : remotePassword;
 
         if (pw.Length == 0)
         {

--- a/src/BSH.Engine/Services/UncTargetProbe.cs
+++ b/src/BSH.Engine/Services/UncTargetProbe.cs
@@ -40,7 +40,8 @@ public static class UncTargetProbe
 
         try
         {
-            using var networkConnection = new NetworkConnection(path, username ?? "", password ?? "");
+            // NetworkConnection decrypts config-stored DPAPI passwords by default; UI probes pass plaintext.
+            using var networkConnection = new NetworkConnection(path, username ?? "", password ?? "", passwordIsEncrypted: false);
             if (!Directory.Exists(path))
             {
                 return new UncProbeResult(UncProbeStatus.Unreachable, path);

--- a/src/BSH.Test/UncTargetProbeTests.cs
+++ b/src/BSH.Test/UncTargetProbeTests.cs
@@ -1,7 +1,10 @@
 // Copyright (c) Alexander Seeliger. All Rights Reserved.
 // Licensed under the Apache License, Version 2.0.
 
+using System.ComponentModel;
 using System.IO;
+using System.Security.Cryptography;
+using Brightbits.BSH.Engine.Security;
 using Brightbits.BSH.Engine.Services;
 using NUnit.Framework;
 
@@ -45,5 +48,39 @@ public class UncTargetProbeTests
 
         Assert.That(result.Status, Is.EqualTo(UncProbeStatus.Unreachable).Or.EqualTo(UncProbeStatus.ContainsBackupData));
         Assert.That(result.NormalizedPath, Is.EqualTo(@"\\invalid-host-that-does-not-exist-bsh3\share"));
+    }
+
+    [Test]
+    public void NetworkConnection_PlaintextPassword_IsUsedWhenPasswordIsEncryptedFalse()
+    {
+        // Regression: UI UNC probes pass plaintext, but NetworkConnection historically always
+        // DPAPI-decrypted. Decrypting plaintext yields "" and silently skips authentication.
+        const string plaintext = "ShareSecret!42";
+        Assert.That(
+            Crypto.DecryptString(plaintext, DataProtectionScope.LocalMachine),
+            Is.EqualTo(""),
+            "Plaintext must not round-trip through DecryptString (default NetworkConnection path).");
+
+        var encrypted = Crypto.EncryptString(plaintext, DataProtectionScope.LocalMachine);
+        Assert.That(
+            Crypto.DecryptString(encrypted, DataProtectionScope.LocalMachine),
+            Is.EqualTo(plaintext));
+
+        // passwordIsEncrypted: false proceeds past decrypt and attempts WNetAddConnection2.
+        Assert.Throws<Win32Exception>(() =>
+        {
+            using var _ = new NetworkConnection(
+                @"\\invalid-host-that-does-not-exist-bsh3\share",
+                "user",
+                plaintext,
+                passwordIsEncrypted: false);
+        });
+
+        // Default (encrypted) path with plaintext must refuse to connect (pre-fix bug).
+        using var mistypedConnection = new NetworkConnection(
+            @"\\invalid-host-that-does-not-exist-bsh3\share",
+            "user",
+            plaintext);
+        Assert.That(mistypedConnection.RemoteShare, Is.Null);
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Bug and impact

After UNC media-switch/setup support (#557), entering a username/password for a credential-protected `\\server\share` still fails validation (“network unreachable”). Users cannot complete setup or switch storage to password-protected UNC targets, even with correct credentials.

## Root cause

`UncTargetProbe` passes **UI plaintext** passwords into `NetworkConnection`, which always DPAPI-decrypts its password argument (correct for config-stored `UNCPassword`). Decrypting plaintext yields `""`, so `WNetAddConnection2` is never called with the real secret and the probe falls through to an unauthenticated `Directory.Exists` check.

## Fix

- Add `passwordIsEncrypted` to `NetworkConnection` (default `true` for `FileSystemStorage`).
- `UncTargetProbe` passes `passwordIsEncrypted: false`.
- Regression test covering plaintext-vs-ciphertext behavior.

## Validation

- `dotnet build BSH.Engine` with `EnableWindowsTargeting` / `Platform=x64` succeeded on the Linux cloud agent.
- Full NUnit suite requires Windows CI (per AGENTS.md).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ba6445d-ca9c-4236-b29c-e101a6dc58a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ba6445d-ca9c-4236-b29c-e101a6dc58a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

