### PR TITLE
test: expand engine backup/restore/delete/edit coverage

### DIFF
--- a/src/BSH.Test/BackupServiceTests.cs
+++ b/src/BSH.Test/BackupServiceTests.cs
@@ -98,6 +98,9 @@ public class BackupServiceTests
     [TearDown]
     public void Cleanup()
     {
+        storage?.Dispose();
+        storage = null;
+
         DbClientFactory.ClosePool();
 
         try

--- a/src/BSH.Test/BackupServiceTests.cs
+++ b/src/BSH.Test/BackupServiceTests.cs
@@ -1,0 +1,177 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Brightbits.BSH.Engine;
+using Brightbits.BSH.Engine.Contracts;
+using Brightbits.BSH.Engine.Contracts.Database;
+using Brightbits.BSH.Engine.Contracts.Repo;
+using Brightbits.BSH.Engine.Database;
+using Brightbits.BSH.Engine.Exceptions;
+using Brightbits.BSH.Engine.Jobs;
+using Brightbits.BSH.Engine.Models;
+using Brightbits.BSH.Engine.Repo;
+using Brightbits.BSH.Engine.Services;
+using BSH.Test.Helpers;
+using BSH.Test.Mocks;
+using NUnit.Framework;
+
+namespace BSH.Test;
+
+/// <summary>
+/// Black-box tests for <see cref="BackupService"/> orchestration (password gate, job dispatch).
+/// </summary>
+public class BackupServiceTests
+{
+    private string dbPath;
+    private IDbClientFactory dbClientFactory;
+    private IConfigurationManager configurationManager;
+    private IQueryManager queryManager;
+    private IVersionQueryRepository versionQueryRepository;
+    private IBackupMutationRepository backupMutationRepository;
+    private StorageMock storage;
+    private StorageFactoryMock storageFactory;
+    private FileCollectorServiceFactoryMock fileCollectorFactory;
+    private VssClientMock vssClient;
+    private BackupService backupService;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        if (dbClientFactory != null)
+        {
+            DbClientFactory.ClosePool();
+            dbClientFactory = null;
+        }
+
+        dbPath = Path.Combine(Path.GetTempPath(), "BSH.Test", "backup-service-" + Guid.NewGuid().ToString("N") + ".db");
+        Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);
+
+        if (File.Exists(dbPath))
+        {
+            File.Delete(dbPath);
+        }
+
+        dbClientFactory = new DbClientFactory();
+        await dbClientFactory.InitializeAsync(dbPath);
+
+        configurationManager = new ConfigurationManager(dbClientFactory);
+        await configurationManager.InitializeAsync();
+        configurationManager.SourceFolder = @"D:\Meine Dokumente";
+        configurationManager.OldBackupPrevent = "0";
+
+        versionQueryRepository = new VersionQueryRepository();
+        backupMutationRepository = new BackupMutationRepository(dbClientFactory);
+        storage = new StorageMock();
+        storageFactory = new StorageFactoryMock(storage);
+        vssClient = new VssClientMock();
+
+        fileCollectorFactory = new FileCollectorServiceFactoryMock(
+            [],
+            [
+                new FileTableRow
+                {
+                    FileName = "test.txt",
+                    FilePath = "",
+                    FileRoot = @"D:\Meine Dokumente",
+                    FileSize = 128,
+                    FileDateCreated = DateTime.Now,
+                    FileDateModified = DateTime.Now,
+                }
+            ]);
+
+        queryManager = new QueryManager(dbClientFactory, configurationManager, storageFactory);
+        backupService = new BackupService(
+            configurationManager,
+            queryManager,
+            dbClientFactory,
+            storageFactory,
+            vssClient,
+            fileCollectorFactory,
+            versionQueryRepository,
+            backupMutationRepository);
+    }
+
+    [TearDown]
+    public void Cleanup()
+    {
+        DbClientFactory.ClosePool();
+
+        try
+        {
+            if (!string.IsNullOrEmpty(dbPath) && File.Exists(dbPath))
+            {
+                File.Delete(dbPath);
+            }
+        }
+        catch
+        {
+            // ignore
+        }
+    }
+
+    [Test]
+    public void StartBackup_RequiresPasswordWhenEncryptionEnabled()
+    {
+        configurationManager.Encrypt = 1;
+        configurationManager.EncryptPassMD5 = "hash";
+
+        Assert.Throws<PasswordRequiredException>(() =>
+            backupService.StartBackup("t", "", new JobReportStub(), CancellationToken.None));
+    }
+
+    [Test]
+    public async Task StartBackup_RunsWhenPasswordProvided()
+    {
+        configurationManager.Encrypt = 1;
+        configurationManager.EncryptPassMD5 = "cc03e747a6afbbcbf8be7668acfebee5";
+        backupService.SetPassword("test123");
+
+        var observer = new JobReportStub();
+        await backupService.StartBackup("encrypted", "", observer, CancellationToken.None);
+
+        Assert.That(observer.ReportedStates, Does.Contain(JobState.FINISHED));
+        Assert.That(storage.CopyFileToStorageEncryptedCalls, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task StartDelete_DispatchesDeleteJob()
+    {
+        await JobSeedHelper.SeedVersionAsync(dbClientFactory, 1, "01-01-2021 00-00-00");
+        await JobSeedHelper.SeedFileForVersionAsync(dbClientFactory, 1, 1, 1, "a.txt", @"\docs\", 1, "");
+
+        var observer = new JobReportStub();
+        await backupService.StartDelete("1", observer, CancellationToken.None);
+
+        Assert.That(storage.DeletedPlain, Has.Count.EqualTo(1));
+        Assert.That(observer.ReportedStates, Does.Contain(JobState.FINISHED));
+    }
+
+    [Test]
+    public async Task SetStableAsync_PersistsStableFlag()
+    {
+        await JobSeedHelper.SeedVersionAsync(dbClientFactory, 1, "01-01-2021 00-00-00");
+        await backupService.SetStableAsync("1", stable: false);
+
+        using var dbClient = dbClientFactory.CreateDbClient();
+        Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT versionStable FROM versiontable WHERE versionID = 1")), Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task UpdateVersionAsync_UpdatesTitleAndDescription()
+    {
+        await JobSeedHelper.SeedVersionAsync(dbClientFactory, 1, "01-01-2021 00-00-00");
+        await backupService.UpdateVersionAsync("1", new VersionDetails
+        {
+            Title = "Renamed",
+            Description = "Updated description",
+        });
+
+        using var dbClient = dbClientFactory.CreateDbClient();
+        Assert.That(await dbClient.ExecuteScalarAsync("SELECT versionTitle FROM versiontable WHERE versionID = 1"), Is.EqualTo("Renamed"));
+        Assert.That(await dbClient.ExecuteScalarAsync("SELECT versionDescription FROM versiontable WHERE versionID = 1"), Is.EqualTo("Updated description"));
+    }
+}

--- a/src/BSH.Test/BackupTests.cs
+++ b/src/BSH.Test/BackupTests.cs
@@ -364,6 +364,232 @@ public class BackupTests
         Assert.That(version, Is.Null);
     }
 
+    [Test]
+    public async Task FullBackup_ForcesNewPackagesForUnchangedFiles()
+    {
+        var modified = new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Local);
+        var created = new DateTime(2024, 1, 2, 3, 0, 0, DateTimeKind.Local);
+
+        fileCollectorServiceFactory = new FileCollectorServiceFactoryMock(
+            [],
+            [
+                new FileTableRow
+                {
+                    FileName = "stable.txt",
+                    FilePath = "",
+                    FileRoot = @"D:\Meine Dokumente",
+                    FileSize = 2048,
+                    FileDateCreated = created,
+                    FileDateModified = modified,
+                }
+            ]);
+
+        var storage = new StorageMock();
+        var first = new BackupJob(storage, dbClientFactory, queryManager, configurationManager, fileCollectorServiceFactory, vssClient, versionQueryRepository, backupMutationRepository)
+        {
+            SourceFolder = @"D:\Meine Dokumente",
+            Title = "first",
+            Description = "",
+        };
+        await first.BackupAsync(CancellationToken.None);
+
+        var second = new BackupJob(storage, dbClientFactory, queryManager, configurationManager, fileCollectorServiceFactory, vssClient, versionQueryRepository, backupMutationRepository)
+        {
+            SourceFolder = @"D:\Meine Dokumente",
+            Title = "full",
+            Description = "",
+            FullBackup = true,
+        };
+        await second.BackupAsync(CancellationToken.None);
+
+        Assert.That(storage.CopyFileToStorageCalls, Is.EqualTo(2));
+
+        using var dbClient = dbClientFactory.CreateDbClient();
+        Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT COUNT(*) FROM fileversiontable")), Is.EqualTo(2));
+        Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT COUNT(*) FROM filelink")), Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task Backup_PersistsEmptyFolders()
+    {
+        fileCollectorServiceFactory = new FileCollectorServiceFactoryMock(
+            [new FolderTableRow(@"D:\Meine Dokumente\empty", @"D:\Meine Dokumente")],
+            [
+                new FileTableRow
+                {
+                    FileName = "keep.txt",
+                    FilePath = "",
+                    FileRoot = @"D:\Meine Dokumente",
+                    FileSize = 10,
+                    FileDateCreated = DateTime.Now,
+                    FileDateModified = DateTime.Now,
+                }
+            ]);
+
+        var storage = new StorageMock();
+        var backupJob = new BackupJob(storage, dbClientFactory, queryManager, configurationManager, fileCollectorServiceFactory, vssClient, versionQueryRepository, backupMutationRepository)
+        {
+            SourceFolder = @"D:\Meine Dokumente",
+            Title = "folders",
+            Description = "",
+        };
+        await backupJob.BackupAsync(CancellationToken.None);
+
+        using var dbClient = dbClientFactory.CreateDbClient();
+        Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT COUNT(*) FROM foldertable")), Is.EqualTo(1));
+        Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT COUNT(*) FROM folderlink")), Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Backup_NoChanges_RefreshesVersionDirectoryViaRename()
+    {
+        var modified = new DateTime(2024, 5, 1, 12, 0, 0, DateTimeKind.Local);
+        fileCollectorServiceFactory = new FileCollectorServiceFactoryMock(
+            [],
+            [
+                new FileTableRow
+                {
+                    FileName = "same.txt",
+                    FilePath = "",
+                    FileRoot = @"D:\Meine Dokumente",
+                    FileSize = 100,
+                    FileDateCreated = modified,
+                    FileDateModified = modified,
+                }
+            ]);
+
+        var storage = new StorageMock();
+        var first = new BackupJob(storage, dbClientFactory, queryManager, configurationManager, fileCollectorServiceFactory, vssClient, versionQueryRepository, backupMutationRepository)
+        {
+            SourceFolder = @"D:\Meine Dokumente",
+            Title = "first",
+            Description = "",
+        };
+        await first.BackupAsync(CancellationToken.None);
+        var version1 = await queryManager.GetLastBackupAsync();
+        Assert.That(version1, Is.Not.Null);
+
+        // Second run with identical file metadata → link-only, then refresh rename path.
+        await Task.Delay(1100);
+        var second = new BackupJob(storage, dbClientFactory, queryManager, configurationManager, fileCollectorServiceFactory, vssClient, versionQueryRepository, backupMutationRepository)
+        {
+            SourceFolder = @"D:\Meine Dokumente",
+            Title = "refresh",
+            Description = "",
+        };
+        await second.BackupAsync(CancellationToken.None);
+
+        Assert.That(storage.CopyFileToStorageCalls, Is.EqualTo(1), "Unchanged file must not be recopied.");
+        Assert.That(storage.RenamedDirectories, Has.Count.EqualTo(1));
+
+        using var dbClient = dbClientFactory.CreateDbClient();
+        Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT COUNT(*) FROM versiontable WHERE versionStatus = 0")), Is.EqualTo(1));
+        Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT COUNT(*) FROM fileversiontable")), Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Backup_AbortsWhenFreeSpaceClearlyInsufficient()
+    {
+        fileCollectorServiceFactory = new FileCollectorServiceFactoryMock(
+            [],
+            [
+                new FileTableRow
+                {
+                    FileName = "big.bin",
+                    FilePath = "",
+                    FileRoot = @"D:\Meine Dokumente",
+                    FileSize = 5_000_000,
+                    FileDateCreated = DateTime.Now,
+                    FileDateModified = DateTime.Now,
+                }
+            ]);
+
+        var storage = new StorageMock(freeSpaceBytes: 1000);
+        var observer = new Helpers.JobReportStub();
+        var backupJob = new BackupJob(storage, dbClientFactory, queryManager, configurationManager, fileCollectorServiceFactory, vssClient, versionQueryRepository, backupMutationRepository)
+        {
+            SourceFolder = @"D:\Meine Dokumente",
+            Title = "disk",
+            Description = "",
+        };
+        backupJob.AddObserver(observer);
+
+        await backupJob.BackupAsync(CancellationToken.None);
+
+        Assert.That(observer.ReportedStates, Does.Contain(JobState.ERROR));
+        Assert.That(observer.InsufficientDiskSpaceCalls, Is.EqualTo(1));
+        Assert.That(storage.CopyFileToStorageCalls, Is.EqualTo(0));
+        Assert.That(await queryManager.GetLastBackupAsync(), Is.Null);
+    }
+
+    [Test]
+    public async Task Backup_UnchangedFile_LinksExistingPackageOnIncremental()
+    {
+        var modified = new DateTime(2024, 6, 1, 8, 0, 0, DateTimeKind.Local);
+        fileCollectorServiceFactory = new FileCollectorServiceFactoryMock(
+            [],
+            [
+                new FileTableRow
+                {
+                    FileName = "link.txt",
+                    FilePath = "",
+                    FileRoot = @"D:\Meine Dokumente",
+                    FileSize = 512,
+                    FileDateCreated = modified,
+                    FileDateModified = modified,
+                }
+            ]);
+
+        var storage = new StorageMock();
+        var first = new BackupJob(storage, dbClientFactory, queryManager, configurationManager, fileCollectorServiceFactory, vssClient, versionQueryRepository, backupMutationRepository)
+        {
+            SourceFolder = @"D:\Meine Dokumente",
+            Title = "v1",
+            Description = "",
+        };
+        await first.BackupAsync(CancellationToken.None);
+
+        // Force a distinct version date so we get a real second version with a new file (plus the unchanged one).
+        await Task.Delay(1100);
+        fileCollectorServiceFactory = new FileCollectorServiceFactoryMock(
+            [],
+            [
+                new FileTableRow
+                {
+                    FileName = "link.txt",
+                    FilePath = "",
+                    FileRoot = @"D:\Meine Dokumente",
+                    FileSize = 512,
+                    FileDateCreated = modified,
+                    FileDateModified = modified,
+                },
+                new FileTableRow
+                {
+                    FileName = "new.txt",
+                    FilePath = "",
+                    FileRoot = @"D:\Meine Dokumente",
+                    FileSize = 64,
+                    FileDateCreated = DateTime.Now,
+                    FileDateModified = DateTime.Now,
+                }
+            ]);
+
+        var second = new BackupJob(storage, dbClientFactory, queryManager, configurationManager, fileCollectorServiceFactory, vssClient, versionQueryRepository, backupMutationRepository)
+        {
+            SourceFolder = @"D:\Meine Dokumente",
+            Title = "v2",
+            Description = "",
+        };
+        await second.BackupAsync(CancellationToken.None);
+
+        Assert.That(storage.CopyFileToStorageCalls, Is.EqualTo(2), "Only the new file should be copied on the second run.");
+
+        using var dbClient = dbClientFactory.CreateDbClient();
+        Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT COUNT(*) FROM fileversiontable")), Is.EqualTo(2));
+        Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync(
+            "SELECT COUNT(*) FROM filelink WHERE fileversionID = 1 AND versionID = 2")), Is.EqualTo(1));
+    }
+
     private BackupJob CreateBackupJobForSingleTempFile(StorageMock storage, VssClientMock vss, string extension)
     {
         var filePath = CreateTempFile(extension);

--- a/src/BSH.Test/BackupTests.cs
+++ b/src/BSH.Test/BackupTests.cs
@@ -444,19 +444,17 @@ public class BackupTests
     public async Task Backup_NoChanges_RefreshesVersionDirectoryViaRename()
     {
         var modified = new DateTime(2024, 5, 1, 12, 0, 0, DateTimeKind.Local);
-        fileCollectorServiceFactory = new FileCollectorServiceFactoryMock(
-            [],
-            [
-                new FileTableRow
-                {
-                    FileName = "same.txt",
-                    FilePath = "",
-                    FileRoot = @"D:\Meine Dokumente",
-                    FileSize = 100,
-                    FileDateCreated = modified,
-                    FileDateModified = modified,
-                }
-            ]);
+        FileTableRow UnchangedFile() => new()
+        {
+            FileName = "same.txt",
+            FilePath = "",
+            FileRoot = @"D:\Meine Dokumente",
+            FileSize = 100,
+            FileDateCreated = modified,
+            FileDateModified = modified,
+        };
+
+        fileCollectorServiceFactory = new FileCollectorServiceFactoryMock([], [UnchangedFile()]);
 
         var storage = new StorageMock();
         var first = new BackupJob(storage, dbClientFactory, queryManager, configurationManager, fileCollectorServiceFactory, vssClient, versionQueryRepository, backupMutationRepository)
@@ -469,8 +467,9 @@ public class BackupTests
         var version1 = await queryManager.GetLastBackupAsync();
         Assert.That(version1, Is.Not.Null);
 
-        // Second run with identical file metadata → link-only, then refresh rename path.
+        // Fresh row instances: BackupJob mutates FilePath on the collected rows.
         await Task.Delay(1100);
+        fileCollectorServiceFactory = new FileCollectorServiceFactoryMock([], [UnchangedFile()]);
         var second = new BackupJob(storage, dbClientFactory, queryManager, configurationManager, fileCollectorServiceFactory, vssClient, versionQueryRepository, backupMutationRepository)
         {
             SourceFolder = @"D:\Meine Dokumente",

--- a/src/BSH.Test/DeleteTests.cs
+++ b/src/BSH.Test/DeleteTests.cs
@@ -15,6 +15,8 @@ using Brightbits.BSH.Engine.Jobs;
 using Brightbits.BSH.Engine.Providers.Ports;
 using Brightbits.BSH.Engine.Repo;
 using Brightbits.BSH.Engine.Storage;
+using BSH.Test.Helpers;
+using BSH.Test.Mocks;
 using NUnit.Framework;
 
 namespace BSH.Test;
@@ -132,6 +134,145 @@ public class DeleteTests
         using var dbClient = dbClientFactory.CreateDbClient();
         Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT COUNT(*) FROM fileversiontable")), Is.EqualTo(0));
         Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT COUNT(*) FROM filetable")), Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task DeleteVersion_DoesNotRemovePackagesStillLinkedByLaterVersions()
+    {
+        const string versionDate1 = "01-01-2021 00-00-00";
+        const string versionDate2 = "02-01-2021 00-00-00";
+
+        await JobSeedHelper.SeedVersionAsync(dbClientFactory, 1, versionDate1);
+        await JobSeedHelper.SeedVersionAsync(dbClientFactory, 2, versionDate2);
+
+        // Unchanged file shared across both versions (filePackage stays on version 1).
+        await JobSeedHelper.SeedFileForVersionAsync(dbClientFactory, 1, 1, 1, "shared.txt", @"\docs\", 1, "");
+        await dbClientFactory.ExecuteNonQueryAsync("INSERT INTO filelink (fileversionID, versionID) VALUES (1, 2)");
+
+        // File unique to version 2.
+        await JobSeedHelper.SeedFileForVersionAsync(dbClientFactory, 2, 2, 2, "only-v2.txt", @"\docs\", 1, "");
+
+        var storage = new StorageMock();
+        var deleteJob = CreateDeleteJob(storage, "1");
+        await deleteJob.DeleteAsync();
+
+        Assert.That(storage.DeletedPlain, Is.Empty, "Shared package must remain for version 2 restores.");
+
+        using var dbClient = dbClientFactory.CreateDbClient();
+        Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT COUNT(*) FROM fileversiontable WHERE fileversionID = 1")), Is.EqualTo(1));
+        Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT COUNT(*) FROM filelink WHERE versionID = 1")), Is.EqualTo(0));
+        Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT COUNT(*) FROM filelink WHERE versionID = 2")), Is.EqualTo(2));
+        Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT versionStatus FROM versiontable WHERE versionID = 1")), Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task DeleteVersion_RemovesOnlyPackagesUniqueToThatVersion()
+    {
+        const string versionDate1 = "01-01-2021 00-00-00";
+        const string versionDate2 = "02-01-2021 00-00-00";
+
+        await JobSeedHelper.SeedVersionAsync(dbClientFactory, 1, versionDate1);
+        await JobSeedHelper.SeedVersionAsync(dbClientFactory, 2, versionDate2);
+
+        await JobSeedHelper.SeedFileForVersionAsync(dbClientFactory, 1, 1, 1, "shared.txt", @"\docs\", 1, "");
+        await dbClientFactory.ExecuteNonQueryAsync("INSERT INTO filelink (fileversionID, versionID) VALUES (1, 2)");
+        await JobSeedHelper.SeedFileForVersionAsync(dbClientFactory, 2, 2, 2, "only-v2.txt", @"\docs\", 1, "");
+
+        var storage = new StorageMock();
+        var deleteJob = CreateDeleteJob(storage, "2");
+        await deleteJob.DeleteAsync();
+
+        Assert.That(storage.DeletedPlain, Has.Count.EqualTo(1));
+        Assert.That(storage.DeletedPlain[0], Does.Contain("only-v2.txt"));
+        Assert.That(storage.DeletedPlain[0], Does.Not.Contain("shared.txt"));
+
+        using var dbClient = dbClientFactory.CreateDbClient();
+        Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT COUNT(*) FROM fileversiontable")), Is.EqualTo(1));
+        Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT COUNT(*) FROM filelink WHERE versionID = 1")), Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task DeleteVersion_CleansOrphanedStorageDirectory()
+    {
+        const string versionDate = "01-01-2021 00-00-00";
+        await JobSeedHelper.SeedVersionAsync(dbClientFactory, 1, versionDate);
+        await JobSeedHelper.SeedFileForVersionAsync(dbClientFactory, 1, 1, 1, "plain.txt", @"\docs\", 1, "");
+
+        var storage = new StorageMock();
+        await CreateDeleteJob(storage, "1").DeleteAsync();
+
+        Assert.That(storage.DeletedDirectories, Does.Contain(versionDate));
+        Assert.That(storage.UploadDatabaseFileCalls, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void DeleteSingle_FailsWhenMediumUnavailable()
+    {
+        var storage = new StorageMock(failCheckMedium: true);
+        var deleteJob = CreateDeleteSingleJob(storage);
+
+        Assert.ThrowsAsync<DeviceNotReadyException>(async () => await deleteJob.DeleteSingleAsync("a.txt", @"\docs\"));
+    }
+
+    [Test]
+    public async Task DeleteSingle_PathFilterDeletesAllFilesUnderPath()
+    {
+        const string versionDate = "01-01-2021 00-00-00";
+        await JobSeedHelper.SeedVersionAsync(dbClientFactory, 1, versionDate);
+        await JobSeedHelper.SeedFileForVersionAsync(dbClientFactory, 1, 1, 1, "a.txt", @"\docs\", 1, "");
+        await JobSeedHelper.SeedFileForVersionAsync(dbClientFactory, 2, 2, 1, "b.txt", @"\docs\", 2, "");
+        await JobSeedHelper.SeedFileForVersionAsync(dbClientFactory, 3, 3, 1, "keep.txt", @"\other\", 1, "");
+
+        var storage = new StorageMock();
+        await CreateDeleteSingleJob(storage).DeleteSingleAsync(fileFilter: "", pathFilter: @"\docs\%");
+
+        Assert.That(storage.DeletedPlain, Has.Count.EqualTo(1));
+        Assert.That(storage.DeletedCompressed, Has.Count.EqualTo(1));
+        Assert.That(storage.DeletedPlain[0], Does.Contain("a.txt"));
+        Assert.That(storage.DeletedCompressed[0], Does.Contain("b.txt"));
+
+        using var dbClient = dbClientFactory.CreateDbClient();
+        Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT COUNT(*) FROM filetable")), Is.EqualTo(1));
+        Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT COUNT(*) FROM filetable WHERE fileName = 'keep.txt'")), Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task DeleteSingle_PlainAndCompressedRouting()
+    {
+        const string versionDate = "01-01-2021 00-00-00";
+        await JobSeedHelper.SeedVersionAsync(dbClientFactory, 1, versionDate);
+        await JobSeedHelper.SeedFileForVersionAsync(dbClientFactory, 1, 1, 1, "plain.txt", @"\docs\", 1, "");
+        await JobSeedHelper.SeedFileForVersionAsync(dbClientFactory, 2, 2, 1, "zip.txt", @"\docs\", 2, "");
+
+        var storage = new StorageMock();
+        await CreateDeleteSingleJob(storage).DeleteSingleAsync("plain.txt", @"\docs\");
+
+        Assert.That(storage.DeletedPlain, Has.Count.EqualTo(1));
+        Assert.That(storage.DeletedCompressed, Is.Empty);
+
+        await CreateDeleteSingleJob(storage).DeleteSingleAsync("zip.txt", @"\docs\");
+        Assert.That(storage.DeletedCompressed, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public async Task DeleteVersion_RemovesFolderMetadataForDeletedVersionOnly()
+    {
+        const string versionDate1 = "01-01-2021 00-00-00";
+        const string versionDate2 = "02-01-2021 00-00-00";
+
+        await JobSeedHelper.SeedVersionAsync(dbClientFactory, 1, versionDate1);
+        await JobSeedHelper.SeedVersionAsync(dbClientFactory, 2, versionDate2);
+        await JobSeedHelper.SeedFileForVersionAsync(dbClientFactory, 1, 1, 1, "a.txt", @"\docs\", 1, "");
+        await JobSeedHelper.SeedEmptyFolderAsync(dbClientFactory, 1, 1, @"\docs\empty\");
+        await JobSeedHelper.SeedEmptyFolderAsync(dbClientFactory, 1, 2, @"\docs\empty\");
+
+        var storage = new StorageMock();
+        await CreateDeleteJob(storage, "1").DeleteAsync();
+
+        using var dbClient = dbClientFactory.CreateDbClient();
+        Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT COUNT(*) FROM folderlink WHERE versionid = 1")), Is.EqualTo(0));
+        Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT COUNT(*) FROM folderlink WHERE versionid = 2")), Is.EqualTo(1));
+        Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT COUNT(*) FROM foldertable")), Is.EqualTo(1));
     }
 
     private DeleteJob CreateDeleteJob(IStorageProvider storage, string version)

--- a/src/BSH.Test/EditTests.cs
+++ b/src/BSH.Test/EditTests.cs
@@ -160,7 +160,7 @@ public class EditTests
     }
 
     [Test]
-    public async Task Edit_SharedEncryptedPackageLinkedToMultipleVersions_SurfacesSecondDecryptError()
+    public async Task Edit_SharedEncryptedPackageLinkedToMultipleVersions_DecryptsOnceSuccessfully()
     {
         configurationManager.Encrypt = 1;
         configurationManager.EncryptPassMD5 = "existing-hash";
@@ -172,14 +172,16 @@ public class EditTests
         await JobSeedHelper.SeedFileForVersionAsync(dbClientFactory, 1, 1, 1, "secret.txt", @"\docs\", 6, "");
         await dbClientFactory.ExecuteNonQueryAsync("INSERT INTO filelink (fileversionID, versionID) VALUES (1, 2)");
 
+        // EditJob writes fileType updates on the same SQLite connection while the
+        // editable-files reader is still open, so a shared package is processed once.
         var storage = new StorageMock(failSecondDecryptOfSameFile: true);
         var editJob = CreateEditJob(storage);
         editJob.Password = "test123";
         await editJob.EditAsync();
 
         Assert.That(storage.DecryptedFiles, Has.Count.EqualTo(1));
-        Assert.That(editJob.FileErrorList.Count, Is.EqualTo(1));
-        Assert.That(configurationManager.Encrypt, Is.EqualTo(1), "Partial edit must keep encryption flags.");
+        Assert.That(editJob.FileErrorList, Is.Empty);
+        Assert.That(configurationManager.Encrypt, Is.EqualTo(0));
 
         using var dbClient = dbClientFactory.CreateDbClient();
         Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT fileType FROM fileversiontable WHERE fileversionID = 1")), Is.EqualTo(1));

--- a/src/BSH.Test/EditTests.cs
+++ b/src/BSH.Test/EditTests.cs
@@ -15,6 +15,8 @@ using Brightbits.BSH.Engine.Jobs;
 using Brightbits.BSH.Engine.Providers.Ports;
 using Brightbits.BSH.Engine.Repo;
 using Brightbits.BSH.Engine.Storage;
+using BSH.Test.Helpers;
+using BSH.Test.Mocks;
 using NUnit.Framework;
 
 namespace BSH.Test;
@@ -121,6 +123,85 @@ public class EditTests
         using var dbClient = dbClientFactory.CreateDbClient();
         Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT fileType FROM fileversiontable WHERE fileversionID = 1")), Is.EqualTo(5));
         Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT fileType FROM fileversiontable WHERE fileversionID = 2")), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Edit_FailsWhenMediumUnavailable()
+    {
+        var storage = new StorageMock(failCheckMedium: true);
+        var editJob = CreateEditJob(storage);
+
+        Assert.ThrowsAsync<DeviceNotReadyException>(async () => await editJob.EditAsync());
+    }
+
+    [Test]
+    public async Task Edit_SkipsNonEncryptedFileTypes()
+    {
+        configurationManager.Encrypt = 1;
+        configurationManager.EncryptPassMD5 = "existing-hash";
+
+        const string versionDate = "01-01-2021 00-00-00";
+        await JobSeedHelper.SeedVersionAsync(dbClientFactory, 1, versionDate);
+        await JobSeedHelper.SeedFileForVersionAsync(dbClientFactory, 1, 1, 1, "plain.txt", @"\docs\", 1, "");
+        await JobSeedHelper.SeedFileForVersionAsync(dbClientFactory, 2, 2, 1, "compressed.txt", @"\docs\", 2, "");
+
+        var storage = new StorageMock();
+        var editJob = CreateEditJob(storage);
+        editJob.Password = "test123";
+        await editJob.EditAsync();
+
+        Assert.That(editJob.FileErrorList, Is.Empty);
+        Assert.That(storage.DecryptedFiles, Is.Empty);
+        Assert.That(configurationManager.Encrypt, Is.EqualTo(0));
+
+        using var dbClient = dbClientFactory.CreateDbClient();
+        Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT fileType FROM fileversiontable WHERE fileversionID = 1")), Is.EqualTo(1));
+        Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT fileType FROM fileversiontable WHERE fileversionID = 2")), Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task Edit_SharedEncryptedPackageLinkedToMultipleVersions_SurfacesSecondDecryptError()
+    {
+        configurationManager.Encrypt = 1;
+        configurationManager.EncryptPassMD5 = "existing-hash";
+
+        const string versionDate1 = "01-01-2021 00-00-00";
+        const string versionDate2 = "02-01-2021 00-00-00";
+        await JobSeedHelper.SeedVersionAsync(dbClientFactory, 1, versionDate1);
+        await JobSeedHelper.SeedVersionAsync(dbClientFactory, 2, versionDate2);
+        await JobSeedHelper.SeedFileForVersionAsync(dbClientFactory, 1, 1, 1, "secret.txt", @"\docs\", 6, "");
+        await dbClientFactory.ExecuteNonQueryAsync("INSERT INTO filelink (fileversionID, versionID) VALUES (1, 2)");
+
+        var storage = new StorageMock(failSecondDecryptOfSameFile: true);
+        var editJob = CreateEditJob(storage);
+        editJob.Password = "test123";
+        await editJob.EditAsync();
+
+        Assert.That(storage.DecryptedFiles, Has.Count.EqualTo(1));
+        Assert.That(editJob.FileErrorList.Count, Is.EqualTo(1));
+        Assert.That(configurationManager.Encrypt, Is.EqualTo(1), "Partial edit must keep encryption flags.");
+
+        using var dbClient = dbClientFactory.CreateDbClient();
+        Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT fileType FROM fileversiontable WHERE fileversionID = 1")), Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Edit_UsesLongFilesDirectoryForEncryptedLongNames()
+    {
+        configurationManager.Encrypt = 1;
+        configurationManager.EncryptPassMD5 = "existing-hash";
+
+        const string versionDate = "01-01-2021 00-00-00";
+        await JobSeedHelper.SeedVersionAsync(dbClientFactory, 1, versionDate);
+        await JobSeedHelper.SeedFileForVersionAsync(dbClientFactory, 1, 1, 1, "long.txt", @"\docs\", 6, "stored-long-name");
+
+        var storage = new StorageMock();
+        var editJob = CreateEditJob(storage);
+        editJob.Password = "test123";
+        await editJob.EditAsync();
+
+        Assert.That(storage.DecryptedFiles, Has.Count.EqualTo(1));
+        Assert.That(storage.DecryptedFiles[0], Is.EqualTo(versionDate + "\\_LONGFILES_\\stored-long-name"));
     }
 
     private EditJob CreateEditJob(IStorageProvider storage)

--- a/src/BSH.Test/Helpers/EngineJobTestContext.cs
+++ b/src/BSH.Test/Helpers/EngineJobTestContext.cs
@@ -23,7 +23,7 @@ public sealed class EngineJobTestContext : IAsyncDisposable
 
     public string DbPath { get; }
 
-    public IDbClientFactory DbClientFactory { get; private set; }
+    public IDbClientFactory DbFactory { get; private set; }
 
     public IConfigurationManager ConfigurationManager { get; private set; }
 
@@ -54,19 +54,19 @@ public sealed class EngineJobTestContext : IAsyncDisposable
     {
         DbClientFactory.ClosePool();
 
-        DbClientFactory = new DbClientFactory();
-        await DbClientFactory.InitializeAsync(DbPath);
+        DbFactory = new DbClientFactory();
+        await DbFactory.InitializeAsync(DbPath);
 
-        ConfigurationManager = new ConfigurationManager(DbClientFactory);
+        ConfigurationManager = new ConfigurationManager(DbFactory);
         await ConfigurationManager.InitializeAsync();
         ConfigurationManager.OldBackupPrevent = "0";
         ConfigurationManager.MediaVolumeSerial = "";
 
         VersionQueryRepository = new VersionQueryRepository();
-        BackupMutationRepository = new BackupMutationRepository(DbClientFactory);
+        BackupMutationRepository = new BackupMutationRepository(DbFactory);
 
         var storageFactory = new StorageFactory(ConfigurationManager);
-        QueryManager = new QueryManager(DbClientFactory, ConfigurationManager, storageFactory);
+        QueryManager = new QueryManager(DbFactory, ConfigurationManager, storageFactory);
     }
 
     public async ValueTask DisposeAsync()

--- a/src/BSH.Test/Helpers/EngineJobTestContext.cs
+++ b/src/BSH.Test/Helpers/EngineJobTestContext.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Brightbits.BSH.Engine;
+using Brightbits.BSH.Engine.Contracts;
+using Brightbits.BSH.Engine.Contracts.Database;
+using Brightbits.BSH.Engine.Contracts.Repo;
+using Brightbits.BSH.Engine.Database;
+using Brightbits.BSH.Engine.Repo;
+using Brightbits.BSH.Engine.Storage;
+
+namespace BSH.Test.Helpers;
+
+/// <summary>
+/// Owns a unique temporary SQLite database and wired engine collaborators for job tests.
+/// </summary>
+public sealed class EngineJobTestContext : IAsyncDisposable
+{
+    public string RootDir { get; }
+
+    public string DbPath { get; }
+
+    public IDbClientFactory DbClientFactory { get; private set; }
+
+    public IConfigurationManager ConfigurationManager { get; private set; }
+
+    public IQueryManager QueryManager { get; private set; }
+
+    public IVersionQueryRepository VersionQueryRepository { get; private set; }
+
+    public IBackupMutationRepository BackupMutationRepository { get; private set; }
+
+    private EngineJobTestContext(string rootDir, string dbPath)
+    {
+        RootDir = rootDir;
+        DbPath = dbPath;
+    }
+
+    public static async Task<EngineJobTestContext> CreateAsync(string namePrefix = "engine")
+    {
+        var rootDir = Path.Combine(Path.GetTempPath(), "BSH.Test", $"{namePrefix}-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(rootDir);
+        var dbPath = Path.Combine(rootDir, "testdb.db");
+
+        var context = new EngineJobTestContext(rootDir, dbPath);
+        await context.InitializeAsync();
+        return context;
+    }
+
+    private async Task InitializeAsync()
+    {
+        DbClientFactory.ClosePool();
+
+        DbClientFactory = new DbClientFactory();
+        await DbClientFactory.InitializeAsync(DbPath);
+
+        ConfigurationManager = new ConfigurationManager(DbClientFactory);
+        await ConfigurationManager.InitializeAsync();
+        ConfigurationManager.OldBackupPrevent = "0";
+        ConfigurationManager.MediaVolumeSerial = "";
+
+        VersionQueryRepository = new VersionQueryRepository();
+        BackupMutationRepository = new BackupMutationRepository(DbClientFactory);
+
+        var storageFactory = new StorageFactory(ConfigurationManager);
+        QueryManager = new QueryManager(DbClientFactory, ConfigurationManager, storageFactory);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        DbClientFactory.ClosePool();
+
+        try
+        {
+            if (Directory.Exists(RootDir))
+            {
+                Directory.Delete(RootDir, recursive: true);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup when Windows still holds file locks.
+        }
+
+        await Task.CompletedTask;
+    }
+}

--- a/src/BSH.Test/Helpers/JobReportStub.cs
+++ b/src/BSH.Test/Helpers/JobReportStub.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using Brightbits.BSH.Engine;
+using Brightbits.BSH.Engine.Jobs;
+using Brightbits.BSH.Engine.Models;
+
+namespace BSH.Test.Helpers;
+
+/// <summary>
+/// Lightweight <see cref="IJobReport"/> for asserting job state and overwrite prompts.
+/// </summary>
+public sealed class JobReportStub : IJobReport
+{
+    public RequestOverwriteResult OverwriteResult { get; set; } = RequestOverwriteResult.Overwrite;
+
+    public int RequestOverwriteCalls { get; private set; }
+
+    public int InsufficientDiskSpaceCalls { get; private set; }
+
+    public List<JobState> ReportedStates { get; } = [];
+
+    public List<(string Title, string Text)> ReportedStatuses { get; } = [];
+
+    public void ReportAction(ActionType action, bool silent) { }
+
+    public void ReportState(JobState jobState) => ReportedStates.Add(jobState);
+
+    public void ReportStatus(string title, string text) => ReportedStatuses.Add((title, text));
+
+    public void ReportProgress(int total, int current) { }
+
+    public void ReportFileProgress(string file) { }
+
+    public void ReportExceptions(Collection<FileExceptionEntry> files, bool silent) { }
+
+    public Task RequestShowErrorInsufficientDiskSpaceAsync()
+    {
+        InsufficientDiskSpaceCalls++;
+        return Task.CompletedTask;
+    }
+
+    public Task<RequestOverwriteResult> RequestOverwrite(FileTableRow localFile, FileTableRow remoteFile)
+    {
+        RequestOverwriteCalls++;
+        return Task.FromResult(OverwriteResult);
+    }
+}

--- a/src/BSH.Test/Helpers/JobSeedHelper.cs
+++ b/src/BSH.Test/Helpers/JobSeedHelper.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Threading.Tasks;
+using Brightbits.BSH.Engine.Contracts.Database;
+
+namespace BSH.Test.Helpers;
+
+/// <summary>
+/// SQL seed helpers for black-box job tests that inject metadata without a prior backup.
+/// </summary>
+public static class JobSeedHelper
+{
+    public static async Task SeedVersionAsync(
+        IDbClientFactory dbClientFactory,
+        int versionId,
+        string versionDate,
+        string sources = @"D:\Source",
+        int versionStatus = 0)
+    {
+        var escapedSources = sources.Replace("'", "''");
+        await dbClientFactory.ExecuteNonQueryAsync(
+            $"INSERT INTO versiontable (versionID, versionDate, versionTitle, versionDescription, versionType, versionStatus, versionStable, versionSources) " +
+            $"VALUES ({versionId}, '{versionDate}', 'v{versionId}', '', 2, {versionStatus}, 1, '{escapedSources}')");
+    }
+
+    public static async Task SeedFileForVersionAsync(
+        IDbClientFactory dbClientFactory,
+        int fileId,
+        int fileVersionId,
+        int versionId,
+        string fileName,
+        string filePath,
+        int fileType,
+        string longFileName,
+        int filePackage = -1,
+        long fileSize = 123,
+        string dateModified = "2021-01-01 00:00:00",
+        string dateCreated = "2021-01-01 00:00:00")
+    {
+        var package = filePackage < 0 ? versionId : filePackage;
+        var escapedName = fileName.Replace("'", "''");
+        var escapedPath = filePath.Replace("'", "''");
+        var escapedLong = (longFileName ?? "").Replace("'", "''");
+
+        // Insert filetable row only when this fileId is new.
+        using (var dbClient = dbClientFactory.CreateDbClient())
+        {
+            var existing = await dbClient.ExecuteScalarAsync($"SELECT COUNT(*) FROM filetable WHERE fileID = {fileId}");
+            if (existing == null || System.Convert.ToInt32(existing) == 0)
+            {
+                await dbClientFactory.ExecuteNonQueryAsync(
+                    $"INSERT INTO filetable (fileID, fileName, filePath) VALUES ({fileId}, '{escapedName}', '{escapedPath}')");
+            }
+        }
+
+        using (var dbClient = dbClientFactory.CreateDbClient())
+        {
+            var existingVersion = await dbClient.ExecuteScalarAsync(
+                $"SELECT COUNT(*) FROM fileversiontable WHERE fileversionID = {fileVersionId}");
+            if (existingVersion == null || System.Convert.ToInt32(existingVersion) == 0)
+            {
+                await dbClientFactory.ExecuteNonQueryAsync(
+                    "INSERT INTO fileversiontable (fileversionID, fileStatus, fileType, fileHash, fileDateModified, fileDateCreated, fileSize, filePackage, fileID, longfilename) VALUES " +
+                    $"({fileVersionId}, 1, {fileType}, '', '{dateModified}', '{dateCreated}', {fileSize}, {package}, {fileId}, '{escapedLong}')");
+            }
+        }
+
+        await dbClientFactory.ExecuteNonQueryAsync(
+            $"INSERT INTO filelink (fileversionID, versionID) VALUES ({fileVersionId}, {versionId})");
+    }
+
+    public static async Task SeedEmptyFolderAsync(
+        IDbClientFactory dbClientFactory,
+        int folderId,
+        int versionId,
+        string folderPath)
+    {
+        var escaped = folderPath.Replace("'", "''");
+
+        using (var dbClient = dbClientFactory.CreateDbClient())
+        {
+            var existing = await dbClient.ExecuteScalarAsync($"SELECT COUNT(*) FROM foldertable WHERE id = {folderId}");
+            if (existing == null || System.Convert.ToInt32(existing) == 0)
+            {
+                await dbClientFactory.ExecuteNonQueryAsync(
+                    $"INSERT INTO foldertable (id, folder) VALUES ({folderId}, '{escaped}')");
+            }
+        }
+
+        await dbClientFactory.ExecuteNonQueryAsync(
+            $"INSERT INTO folderlink (folderid, versionid) VALUES ({folderId}, {versionId})");
+    }
+}

--- a/src/BSH.Test/Integration/FileSystemEngineLifecycleTests.cs
+++ b/src/BSH.Test/Integration/FileSystemEngineLifecycleTests.cs
@@ -1,0 +1,452 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Brightbits.BSH.Engine;
+using Brightbits.BSH.Engine.Contracts;
+using Brightbits.BSH.Engine.Contracts.Database;
+using Brightbits.BSH.Engine.Contracts.Repo;
+using Brightbits.BSH.Engine.Contracts.Services;
+using Brightbits.BSH.Engine.Database;
+using Brightbits.BSH.Engine.Jobs;
+using Brightbits.BSH.Engine.Providers.Ports;
+using Brightbits.BSH.Engine.Repo;
+using Brightbits.BSH.Engine.Security;
+using Brightbits.BSH.Engine.Services.FileCollector;
+using Brightbits.BSH.Engine.Storage;
+using BSH.Test.Mocks;
+using NUnit.Framework;
+
+namespace BSH.Test.Integration;
+
+/// <summary>
+/// Real filesystem lifecycle coverage for backup → restore → delete → edit via
+/// <see cref="FileSystemStorage"/>. Treats the engine jobs as a black box.
+/// </summary>
+[Category("Integration")]
+public class FileSystemEngineLifecycleTests
+{
+    private const string Password = "test123";
+
+    private string rootDir;
+    private string sourceDir;
+    private string backupDir;
+    private string restoreDir;
+    private string dbPath;
+
+    private IDbClientFactory dbClientFactory;
+    private IConfigurationManager configurationManager;
+    private IQueryManager queryManager;
+    private IVersionQueryRepository versionQueryRepository;
+    private IBackupMutationRepository backupMutationRepository;
+    private IFileCollectorServiceFactory fileCollectorServiceFactory;
+    private VssClientMock vssClient;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        if (dbClientFactory != null)
+        {
+            DbClientFactory.ClosePool();
+            dbClientFactory = null;
+        }
+
+        rootDir = Path.Combine(Path.GetTempPath(), "BSH.Test", "lifecycle-" + Guid.NewGuid().ToString("N"));
+        sourceDir = Path.Combine(rootDir, "source");
+        backupDir = Path.Combine(rootDir, "backup");
+        restoreDir = Path.Combine(rootDir, "restore");
+        dbPath = Path.Combine(rootDir, "testdb_lifecycle.db");
+
+        Directory.CreateDirectory(sourceDir);
+        Directory.CreateDirectory(backupDir);
+        Directory.CreateDirectory(restoreDir);
+
+        dbClientFactory = new DbClientFactory();
+        await dbClientFactory.InitializeAsync(dbPath);
+
+        configurationManager = new ConfigurationManager(dbClientFactory);
+        await configurationManager.InitializeAsync();
+        configurationManager.BackupFolder = backupDir;
+        configurationManager.SourceFolder = sourceDir;
+        configurationManager.MediaVolumeSerial = "";
+        configurationManager.OldBackupPrevent = "0";
+
+        versionQueryRepository = new VersionQueryRepository();
+        backupMutationRepository = new BackupMutationRepository(dbClientFactory);
+        fileCollectorServiceFactory = new FileCollectorServiceFactory();
+        vssClient = new VssClientMock();
+
+        var storageFactory = new StorageFactory(configurationManager);
+        queryManager = new QueryManager(dbClientFactory, configurationManager, storageFactory);
+    }
+
+    [TearDown]
+    public void Cleanup()
+    {
+        DbClientFactory.ClosePool();
+
+        try
+        {
+            if (!string.IsNullOrEmpty(rootDir) && Directory.Exists(rootDir))
+            {
+                Directory.Delete(rootDir, recursive: true);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup on Windows file locks.
+        }
+    }
+
+    [Test]
+    public async Task DeleteOlderVersion_RemainingVersionStillRestores()
+    {
+        WriteSourceFile("doc.txt", "version-one");
+        await RunBackupAsync();
+        var version1 = await queryManager.GetLastBackupAsync();
+
+        await Task.Delay(1100);
+        File.WriteAllText(Path.Combine(sourceDir, "doc.txt"), "version-two");
+        File.SetLastWriteTimeUtc(Path.Combine(sourceDir, "doc.txt"), DateTime.UtcNow.AddMinutes(1));
+        await RunBackupAsync();
+        var version2 = await queryManager.GetLastBackupAsync();
+        Assert.That(version2.Id, Is.Not.EqualTo(version1.Id));
+
+        await RunDeleteAsync(version1.Id);
+
+        var dest = Path.Combine(restoreDir, "after-delete");
+        Directory.CreateDirectory(dest);
+        await RunRestoreAsync(int.Parse(version2.Id), dest);
+
+        Assert.That(File.ReadAllText(Path.Combine(dest, "doc.txt")), Is.EqualTo("version-two"));
+        Assert.That(await queryManager.GetLastBackupAsync(), Is.Not.Null);
+    }
+
+    [Test]
+    public async Task DeleteNewerVersion_OlderSharedContentStillRestores()
+    {
+        WriteSourceFile("stable.txt", "unchanged-content");
+        WriteSourceFile("gone-later.txt", "only-in-v1");
+        await RunBackupAsync();
+        var version1 = await queryManager.GetLastBackupAsync();
+
+        await Task.Delay(1100);
+        File.Delete(Path.Combine(sourceDir, "gone-later.txt"));
+        WriteSourceFile("new-in-v2.txt", "only-in-v2");
+        await RunBackupAsync();
+        var version2 = await queryManager.GetLastBackupAsync();
+
+        await RunDeleteAsync(version2.Id);
+
+        var dest = Path.Combine(restoreDir, "v1-after-v2-delete");
+        Directory.CreateDirectory(dest);
+        await RunRestoreAsync(int.Parse(version1.Id), dest);
+
+        Assert.That(File.ReadAllText(Path.Combine(dest, "stable.txt")), Is.EqualTo("unchanged-content"));
+        Assert.That(File.ReadAllText(Path.Combine(dest, "gone-later.txt")), Is.EqualTo("only-in-v1"));
+        Assert.That(File.Exists(Path.Combine(dest, "new-in-v2.txt")), Is.False);
+    }
+
+    [Test]
+    public async Task SharedUnchangedFile_SurvivesDeleteOfFirstVersion()
+    {
+        WriteSourceFile("shared.txt", "shared-bytes");
+        await RunBackupAsync();
+        var version1 = await queryManager.GetLastBackupAsync();
+
+        await Task.Delay(1100);
+        WriteSourceFile("extra.txt", "second-version-only");
+        await RunBackupAsync();
+        var version2 = await queryManager.GetLastBackupAsync();
+
+        await RunDeleteAsync(version1.Id);
+
+        var dest = Path.Combine(restoreDir, "shared");
+        Directory.CreateDirectory(dest);
+        await RunRestoreAsync(int.Parse(version2.Id), dest);
+
+        Assert.That(File.ReadAllText(Path.Combine(dest, "shared.txt")), Is.EqualTo("shared-bytes"));
+        Assert.That(File.ReadAllText(Path.Combine(dest, "extra.txt")), Is.EqualTo("second-version-only"));
+    }
+
+    [Test]
+    public async Task EditDecrypt_ThenRestoreWithoutPassword()
+    {
+        configurationManager.Encrypt = 1;
+        configurationManager.EncryptPassMD5 = Hash.GetMD5Hash(Password);
+        WriteSourceFile("secret.txt", "encrypted-payload");
+
+        await RunBackupAsync(password: Password);
+
+        var editJob = new EditJob(
+            CreateStorage(),
+            dbClientFactory,
+            queryManager,
+            configurationManager,
+            versionQueryRepository,
+            backupMutationRepository)
+        {
+            Password = Password,
+        };
+        await editJob.EditAsync();
+        Assert.That(editJob.FileErrorList, Is.Empty);
+        Assert.That(configurationManager.Encrypt, Is.EqualTo(0));
+
+        var dest = Path.Combine(restoreDir, "decrypted");
+        Directory.CreateDirectory(dest);
+        var restoreJob = CreateRestoreJob(CreateStorage(), version: 1, destination: dest, password: null);
+        await restoreJob.RestoreAsync(CancellationToken.None);
+
+        Assert.That(restoreJob.FileErrorList, Is.Empty);
+        Assert.That(File.ReadAllText(Path.Combine(dest, "secret.txt")), Is.EqualTo("encrypted-payload"));
+    }
+
+    [Test]
+    public async Task EmptyFolder_IsRestored()
+    {
+        var emptyDir = Path.Combine(sourceDir, "hollow");
+        Directory.CreateDirectory(emptyDir);
+        WriteSourceFile("anchor.txt", "keep");
+
+        await RunBackupAsync();
+
+        var dest = Path.Combine(restoreDir, "with-empty");
+        Directory.CreateDirectory(dest);
+        await RunRestoreAsync(1, dest);
+
+        Assert.That(Directory.Exists(Path.Combine(dest, "hollow")), Is.True);
+        Assert.That(File.ReadAllText(Path.Combine(dest, "anchor.txt")), Is.EqualTo("keep"));
+    }
+
+    [Test]
+    public async Task NestedAndUnicodePaths_RoundTrip()
+    {
+        var nested = Path.Combine(sourceDir, "äöü", "深层");
+        Directory.CreateDirectory(nested);
+        File.WriteAllText(Path.Combine(nested, "файл.txt"), "unicode-content");
+
+        await RunBackupAsync();
+
+        var dest = Path.Combine(restoreDir, "unicode");
+        Directory.CreateDirectory(dest);
+        await RunRestoreAsync(1, dest);
+
+        var restored = Directory.GetFiles(dest, "файл.txt", SearchOption.AllDirectories).SingleOrDefault();
+        Assert.That(restored, Is.Not.Null);
+        Assert.That(File.ReadAllText(restored), Is.EqualTo("unicode-content"));
+    }
+
+    [Test]
+    public async Task DeleteSingleFile_RemovesItFromAllVersions()
+    {
+        WriteSourceFile("keep.txt", "keep-me");
+        WriteSourceFile("drop.txt", "drop-me");
+        await RunBackupAsync();
+
+        await Task.Delay(1100);
+        File.WriteAllText(Path.Combine(sourceDir, "drop.txt"), "drop-me-v2");
+        File.SetLastWriteTimeUtc(Path.Combine(sourceDir, "drop.txt"), DateTime.UtcNow.AddMinutes(1));
+        await RunBackupAsync();
+
+        var sourceLeaf = Path.GetFileName(sourceDir);
+        var deleteJob = new DeleteSingleJob(
+            CreateStorage(),
+            dbClientFactory,
+            queryManager,
+            configurationManager,
+            versionQueryRepository,
+            backupMutationRepository);
+        await deleteJob.DeleteSingleAsync("drop.txt", $@"\{sourceLeaf}\");
+
+        Assert.That(deleteJob.FileErrorList, Is.Empty);
+
+        var dest = Path.Combine(restoreDir, "after-single-delete");
+        Directory.CreateDirectory(dest);
+        var version2 = await queryManager.GetLastBackupAsync();
+        await RunRestoreAsync(int.Parse(version2.Id), dest);
+
+        Assert.That(File.Exists(Path.Combine(dest, "keep.txt")), Is.True);
+        Assert.That(File.Exists(Path.Combine(dest, "drop.txt")), Is.False);
+    }
+
+    [Test]
+    public async Task CompressedBackup_DeleteVersion_AndRestoreSibling()
+    {
+        configurationManager.Compression = 1;
+        WriteSourceFile("a.txt", "alpha");
+        await RunBackupAsync();
+        var version1 = await queryManager.GetLastBackupAsync();
+
+        await Task.Delay(1100);
+        WriteSourceFile("b.txt", "beta");
+        await RunBackupAsync();
+        var version2 = await queryManager.GetLastBackupAsync();
+
+        await RunDeleteAsync(version1.Id);
+
+        var dest = Path.Combine(restoreDir, "compressed");
+        Directory.CreateDirectory(dest);
+        await RunRestoreAsync(int.Parse(version2.Id), dest);
+
+        Assert.That(File.ReadAllText(Path.Combine(dest, "a.txt")), Is.EqualTo("alpha"));
+        Assert.That(File.ReadAllText(Path.Combine(dest, "b.txt")), Is.EqualTo("beta"));
+    }
+
+    [Test]
+    public async Task CancelledBackup_LeavesNoVersion()
+    {
+        WriteSourceFile("one.txt", "content");
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var backupJob = CreateBackupJob(CreateStorage());
+        await backupJob.BackupAsync(cts.Token);
+
+        Assert.That(await queryManager.GetLastBackupAsync(), Is.Null);
+    }
+
+    [Test]
+    public async Task FullBackupFlag_CopiesUnchangedFileAgain()
+    {
+        WriteSourceFile("same.txt", "payload");
+        await RunBackupAsync();
+
+        await Task.Delay(1100);
+        var before = CountFilesRecursive(backupDir);
+
+        var backupJob = CreateBackupJob(CreateStorage());
+        backupJob.FullBackup = true;
+        await backupJob.BackupAsync(CancellationToken.None);
+        Assert.That(backupJob.FileErrorList, Is.Empty);
+
+        var after = CountFilesRecursive(backupDir);
+        Assert.That(after, Is.GreaterThan(before));
+
+        using var dbClient = dbClientFactory.CreateDbClient();
+        Assert.That(Convert.ToInt32(await dbClient.ExecuteScalarAsync("SELECT COUNT(*) FROM fileversiontable")), Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task AddedAndRemovedFiles_AcrossIncrementals()
+    {
+        WriteSourceFile("stay.txt", "stay");
+        WriteSourceFile("leave.txt", "leave");
+        await RunBackupAsync();
+        var version1 = await queryManager.GetLastBackupAsync();
+
+        await Task.Delay(1100);
+        File.Delete(Path.Combine(sourceDir, "leave.txt"));
+        WriteSourceFile("arrive.txt", "arrive");
+        await RunBackupAsync();
+        var version2 = await queryManager.GetLastBackupAsync();
+
+        var dest1 = Path.Combine(restoreDir, "v1");
+        var dest2 = Path.Combine(restoreDir, "v2");
+        Directory.CreateDirectory(dest1);
+        Directory.CreateDirectory(dest2);
+
+        await RunRestoreAsync(int.Parse(version1.Id), dest1);
+        await RunRestoreAsync(int.Parse(version2.Id), dest2);
+
+        Assert.That(File.Exists(Path.Combine(dest1, "leave.txt")), Is.True);
+        Assert.That(File.Exists(Path.Combine(dest1, "arrive.txt")), Is.False);
+        Assert.That(File.Exists(Path.Combine(dest2, "leave.txt")), Is.False);
+        Assert.That(File.Exists(Path.Combine(dest2, "arrive.txt")), Is.True);
+        Assert.That(File.ReadAllText(Path.Combine(dest2, "stay.txt")), Is.EqualTo("stay"));
+    }
+
+    private async Task RunBackupAsync(string password = null)
+    {
+        var backupJob = CreateBackupJob(CreateStorage());
+        backupJob.Password = password;
+        await backupJob.BackupAsync(CancellationToken.None);
+        Assert.That(backupJob.FileErrorList, Is.Empty, "Backup reported file errors.");
+        Assert.That(await queryManager.GetLastBackupAsync(), Is.Not.Null, "Backup did not create a version.");
+    }
+
+    private async Task RunRestoreAsync(int version, string destination)
+    {
+        var restoreJob = CreateRestoreJob(CreateStorage(), version, destination);
+        await restoreJob.RestoreAsync(CancellationToken.None);
+        Assert.That(restoreJob.FileErrorList, Is.Empty, "Restore reported file errors.");
+    }
+
+    private async Task RunDeleteAsync(string versionId)
+    {
+        var deleteJob = new DeleteJob(
+            CreateStorage(),
+            dbClientFactory,
+            queryManager,
+            configurationManager,
+            versionQueryRepository,
+            backupMutationRepository)
+        {
+            Version = versionId,
+        };
+        await deleteJob.DeleteAsync();
+        Assert.That(deleteJob.FileErrorList, Is.Empty, "Delete reported file errors.");
+    }
+
+    private BackupJob CreateBackupJob(IStorageProvider storage)
+    {
+        return new BackupJob(
+            storage,
+            dbClientFactory,
+            queryManager,
+            configurationManager,
+            fileCollectorServiceFactory,
+            vssClient,
+            versionQueryRepository,
+            backupMutationRepository)
+        {
+            SourceFolder = sourceDir,
+            Title = "Lifecycle",
+            Description = "",
+        };
+    }
+
+    private RestoreJob CreateRestoreJob(
+        IStorageProvider storage,
+        int version,
+        string destination,
+        string password = null)
+    {
+        return new RestoreJob(
+            storage,
+            dbClientFactory,
+            queryManager,
+            configurationManager,
+            versionQueryRepository)
+        {
+            Version = version,
+            File = @"\",
+            Destination = destination,
+            FileOverwrite = FileOverwrite.Overwrite,
+            Password = password,
+        };
+    }
+
+    private IStorageProvider CreateStorage() => new FileSystemStorage(configurationManager);
+
+    private string WriteSourceFile(string fileName, string content)
+    {
+        var path = Path.Combine(sourceDir, fileName);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    private static int CountFilesRecursive(string directory)
+    {
+        if (!Directory.Exists(directory))
+        {
+            return 0;
+        }
+
+        return Directory.GetFiles(directory, "*", SearchOption.AllDirectories).Length;
+    }
+}

--- a/src/BSH.Test/Mocks/StorageFactoryMock.cs
+++ b/src/BSH.Test/Mocks/StorageFactoryMock.cs
@@ -3,10 +3,17 @@
 
 using Brightbits.BSH.Engine.Contracts.Storage;
 using Brightbits.BSH.Engine.Providers.Ports;
-using Brightbits.BSH.Engine.Storage;
 
 namespace BSH.Test.Mocks;
+
 public class StorageFactoryMock : IStorageFactory
 {
-    public IStorageProvider GetCurrentStorageProvider() => new StorageMock();
+    private readonly IStorageProvider storageProvider;
+
+    public StorageFactoryMock(IStorageProvider storageProvider = null)
+    {
+        this.storageProvider = storageProvider ?? new StorageMock();
+    }
+
+    public IStorageProvider GetCurrentStorageProvider() => storageProvider;
 }

--- a/src/BSH.Test/Mocks/StorageMock.cs
+++ b/src/BSH.Test/Mocks/StorageMock.cs
@@ -16,8 +16,12 @@ namespace BSH.Test.Mocks
         private readonly bool failAllCopies;
         private readonly bool pathTooLong;
         private readonly bool throwIoOnFirstRegularCopy;
+        private readonly bool throwOnDelete;
         private readonly string throwOnRemoteContaining;
         private readonly CancellationTokenSource cancelOnCopy;
+        private readonly HashSet<string> decryptFailFiles;
+        private readonly HashSet<string> decryptedOnce = new(StringComparer.OrdinalIgnoreCase);
+        private readonly bool failSecondDecryptOfSameFile;
         private int regularCopyAttempts;
 
         public StorageMock(
@@ -26,7 +30,12 @@ namespace BSH.Test.Mocks
             bool pathTooLong = false,
             bool throwIoOnFirstRegularCopy = false,
             string throwOnRemoteContaining = null,
-            CancellationTokenSource cancelOnCopy = null)
+            CancellationTokenSource cancelOnCopy = null,
+            bool throwOnDelete = false,
+            IEnumerable<string> decryptFailFiles = null,
+            bool failSecondDecryptOfSameFile = false,
+            long freeSpaceBytes = 0,
+            bool canWrite = true)
         {
             this.failCheckMedium = failCheckMedium;
             this.failAllCopies = failAllCopies;
@@ -34,6 +43,13 @@ namespace BSH.Test.Mocks
             this.throwIoOnFirstRegularCopy = throwIoOnFirstRegularCopy;
             this.throwOnRemoteContaining = throwOnRemoteContaining;
             this.cancelOnCopy = cancelOnCopy;
+            this.throwOnDelete = throwOnDelete;
+            this.decryptFailFiles = decryptFailFiles == null
+                ? []
+                : new HashSet<string>(decryptFailFiles, StringComparer.OrdinalIgnoreCase);
+            this.failSecondDecryptOfSameFile = failSecondDecryptOfSameFile;
+            FreeSpaceBytes = freeSpaceBytes;
+            CanWrite = canWrite;
         }
 
         public StorageProviderKind Kind => StorageProviderKind.LocalFileSystem;
@@ -47,10 +63,19 @@ namespace BSH.Test.Mocks
         public List<string> CopiedFromStorageRemoteFiles { get; } = [];
         public List<string> CopiedFromStorageCompressedRemoteFiles { get; } = [];
         public List<string> CopiedFromStorageEncryptedRemoteFiles { get; } = [];
+        public List<string> DeletedPlain { get; } = [];
+        public List<string> DeletedCompressed { get; } = [];
+        public List<string> DeletedEncrypted { get; } = [];
+        public List<string> DeletedDirectories { get; } = [];
+        public List<(string Source, string Target)> RenamedDirectories { get; } = [];
+        public List<string> DecryptedFiles { get; } = [];
+        public int UploadDatabaseFileCalls { get; private set; }
+        public long FreeSpaceBytes { get; set; }
+        public bool CanWrite { get; set; }
 
         public bool CanWriteToStorage()
         {
-            return true;
+            return CanWrite;
         }
 
         public async Task<bool> CheckMedium(bool quickCheck = false)
@@ -112,26 +137,56 @@ namespace BSH.Test.Mocks
 
         public bool DecryptOnStorage(string remoteFile, string password)
         {
+            if (decryptFailFiles.Contains(remoteFile))
+            {
+                throw new IOException("Decrypt failed.");
+            }
+
+            if (failSecondDecryptOfSameFile && !decryptedOnce.Add(remoteFile))
+            {
+                throw new IOException("File already decrypted.");
+            }
+
+            DecryptedFiles.Add(remoteFile);
             return !failAllCopies;
         }
 
         public bool DeleteDirectory(string remoteDirectory)
         {
+            DeletedDirectories.Add(remoteDirectory);
             return !failAllCopies;
         }
 
         public bool DeleteFileFromStorage(string remoteFile)
         {
+            if (throwOnDelete)
+            {
+                throw new IOException("Delete failed.");
+            }
+
+            DeletedPlain.Add(remoteFile);
             return !failAllCopies;
         }
 
         public bool DeleteFileFromStorageCompressed(string remoteFile)
         {
+            if (throwOnDelete)
+            {
+                throw new IOException("Delete failed.");
+            }
+
+            DeletedCompressed.Add(remoteFile);
             return !failAllCopies;
         }
 
         public bool DeleteFileFromStorageEncrypted(string remoteFile)
         {
+            if (throwOnDelete)
+            {
+                throw new IOException("Delete failed.");
+            }
+
+            DeletedEncrypted.Add(remoteFile);
             return !failAllCopies;
         }
 
@@ -141,7 +196,7 @@ namespace BSH.Test.Mocks
 
         public long GetFreeSpace()
         {
-            return 0;
+            return FreeSpaceBytes;
         }
 
         public bool IsPathTooLong(string path, bool compression, bool encryption)
@@ -155,6 +210,7 @@ namespace BSH.Test.Mocks
 
         public bool RenameDirectory(string remoteDirectorySource, string remoteDirectoryTarget)
         {
+            RenamedDirectories.Add((remoteDirectorySource, remoteDirectoryTarget));
             return true;
         }
 
@@ -164,6 +220,7 @@ namespace BSH.Test.Mocks
 
         public bool UploadDatabaseFile(string databaseFile)
         {
+            UploadDatabaseFileCalls++;
             return true;
         }
 

--- a/src/BSH.Test/RestoreTests.cs
+++ b/src/BSH.Test/RestoreTests.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,10 +12,10 @@ using Brightbits.BSH.Engine.Contracts.Repo;
 using Brightbits.BSH.Engine.Database;
 using Brightbits.BSH.Engine.Exceptions;
 using Brightbits.BSH.Engine.Jobs;
-using Brightbits.BSH.Engine.Models;
 using Brightbits.BSH.Engine.Providers.Ports;
 using Brightbits.BSH.Engine.Repo;
 using Brightbits.BSH.Engine.Storage;
+using BSH.Test.Helpers;
 using BSH.Test.Mocks;
 using NUnit.Framework;
 
@@ -257,6 +255,131 @@ public class RestoreTests
         Assert.That(storage.CopiedFromStorageRemoteFiles[1], Is.EqualTo(versionDate2 + @"\docs\" + "doc.txt"));
     }
 
+    [Test]
+    public async Task Restore_EmptyFoldersAreCreatedAtDestination()
+    {
+        const string versionDate = "01-01-2021 00-00-00";
+        await JobSeedHelper.SeedVersionAsync(dbClientFactory, 1, versionDate);
+        await JobSeedHelper.SeedEmptyFolderAsync(dbClientFactory, 1, 1, @"\docs\empty\");
+
+        var destination = Path.Combine(Path.GetTempPath(), "BSH.Test", "restore-empty-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(destination);
+
+        try
+        {
+            var storage = new StorageMock();
+            var restoreJob = CreateRestoreJob(storage, destination: destination, file: @"\");
+            await restoreJob.RestoreAsync(CancellationToken.None);
+
+            Assert.That(Directory.Exists(Path.Combine(destination, "empty")), Is.True);
+        }
+        finally
+        {
+            try { Directory.Delete(destination, true); } catch { /* ignore */ }
+        }
+    }
+
+    [Test]
+    public async Task Restore_FtpFileTypesRouteToCorrectCopyApis()
+    {
+        const string versionDate = "01-01-2021 00-00-00";
+        await JobSeedHelper.SeedVersionAsync(dbClientFactory, 1, versionDate);
+        await JobSeedHelper.SeedFileForVersionAsync(dbClientFactory, 1, 1, 1, "plain.txt", @"\docs\", 3, "");
+        await JobSeedHelper.SeedFileForVersionAsync(dbClientFactory, 2, 2, 1, "zip.txt", @"\docs\", 4, "");
+        await JobSeedHelper.SeedFileForVersionAsync(dbClientFactory, 3, 3, 1, "enc.txt", @"\docs\", 5, "");
+
+        var storage = new StorageMock();
+        var restoreJob = CreateRestoreJob(storage, file: @"\");
+        restoreJob.Password = "test123";
+        await restoreJob.RestoreAsync(CancellationToken.None);
+
+        Assert.That(storage.CopyFileFromStorageCalls, Is.EqualTo(1));
+        Assert.That(storage.CopyFileFromStorageCompressedCalls, Is.EqualTo(1));
+        Assert.That(storage.CopyFileFromStorageEncryptedCalls, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Restore_FolderPathFilterRestoresOnlyMatchingSubtree()
+    {
+        const string versionDate = "01-01-2021 00-00-00";
+        await JobSeedHelper.SeedVersionAsync(dbClientFactory, 1, versionDate);
+        await JobSeedHelper.SeedFileForVersionAsync(dbClientFactory, 1, 1, 1, "in.txt", @"\docs\sub\", 1, "");
+        await JobSeedHelper.SeedFileForVersionAsync(dbClientFactory, 2, 2, 1, "out.txt", @"\other\", 1, "");
+
+        var storage = new StorageMock();
+        var restoreJob = CreateRestoreJob(storage, file: @"\docs\");
+        await restoreJob.RestoreAsync(CancellationToken.None);
+
+        Assert.That(storage.CopyFileFromStorageCalls, Is.EqualTo(1));
+        Assert.That(storage.CopiedFromStorageRemoteFiles[0], Does.Contain("in.txt"));
+        Assert.That(storage.CopiedFromStorageRemoteFiles[0], Does.Not.Contain("out.txt"));
+    }
+
+    [Test]
+    public async Task Restore_OverwriteAsk_OverwriteAllAppliesToSubsequentFiles()
+    {
+        const string versionDate = "01-01-2021 00-00-00";
+        await JobSeedHelper.SeedVersionAsync(dbClientFactory, 1, versionDate);
+        await JobSeedHelper.SeedFileForVersionAsync(dbClientFactory, 1, 1, 1, "a.txt", @"\docs\", 1, "");
+        await JobSeedHelper.SeedFileForVersionAsync(dbClientFactory, 2, 2, 1, "b.txt", @"\docs\", 1, "");
+
+        var destination = Path.Combine(Path.GetTempPath(), "BSH.Test", "restore-ask-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(destination);
+        File.WriteAllText(Path.Combine(destination, "a.txt"), "existing-a");
+        File.WriteAllText(Path.Combine(destination, "b.txt"), "existing-b");
+
+        try
+        {
+            var storage = new StorageMock();
+            var restoreJob = CreateRestoreJob(storage, destination: destination, file: @"\", overwrite: FileOverwrite.Ask);
+            var observer = new JobReportStub { OverwriteResult = RequestOverwriteResult.OverwriteAll };
+            restoreJob.AddObserver(observer);
+
+            await restoreJob.RestoreAsync(CancellationToken.None);
+
+            Assert.That(observer.RequestOverwriteCalls, Is.EqualTo(1), "OverwriteAll should not re-prompt.");
+            Assert.That(storage.CopyFileFromStorageCalls, Is.EqualTo(2));
+        }
+        finally
+        {
+            try { Directory.Delete(destination, true); } catch { /* ignore */ }
+        }
+    }
+
+    [Test]
+    public async Task Restore_SharedPackageFromEarlierVersionUsesOriginalPackageDate()
+    {
+        const string versionDate1 = "01-01-2021 00-00-00";
+        const string versionDate2 = "02-01-2021 00-00-00";
+
+        await JobSeedHelper.SeedVersionAsync(dbClientFactory, 1, versionDate1);
+        await JobSeedHelper.SeedVersionAsync(dbClientFactory, 2, versionDate2);
+        await JobSeedHelper.SeedFileForVersionAsync(dbClientFactory, 1, 1, 1, "shared.txt", @"\docs\", 1, "");
+        await dbClientFactory.ExecuteNonQueryAsync("INSERT INTO filelink (fileversionID, versionID) VALUES (1, 2)");
+
+        var storage = new StorageMock();
+        var restoreJob = CreateRestoreJob(storage, version: 2, file: @"\");
+        await restoreJob.RestoreAsync(CancellationToken.None);
+
+        Assert.That(storage.CopyFileFromStorageCalls, Is.EqualTo(1));
+        Assert.That(storage.CopiedFromStorageRemoteFiles[0], Is.EqualTo(versionDate1 + @"\docs\" + "shared.txt"));
+    }
+
+    [Test]
+    public async Task Restore_LongFileNameUsesLongFilesDirectory()
+    {
+        const string versionDate = "01-01-2021 00-00-00";
+        await JobSeedHelper.SeedVersionAsync(dbClientFactory, 1, versionDate);
+        await JobSeedHelper.SeedFileForVersionAsync(dbClientFactory, 1, 1, 1, "very-long-name.txt", @"\docs\", 1, "stored-long-id");
+
+        var storage = new StorageMock();
+        var restoreJob = CreateRestoreJob(storage, file: @"\");
+        await restoreJob.RestoreAsync(CancellationToken.None);
+
+        Assert.That(storage.CopyFileFromStorageCalls, Is.EqualTo(1));
+        Assert.That(storage.CopiedFromStorageRemoteFiles[0], Is.EqualTo(versionDate + "\\_LONGFILES_\\stored-long-id"));
+    }
+
     private RestoreJob CreateRestoreJob(
         IStorageProvider storage,
         int version = 1,
@@ -311,26 +434,5 @@ public class RestoreTests
         Directory.CreateDirectory(destination);
         File.WriteAllText(Path.Combine(destination, fileName), "existing");
         return destination;
-    }
-
-    private sealed class JobReportStub : IJobReport
-    {
-        public RequestOverwriteResult OverwriteResult { get; set; } = RequestOverwriteResult.Overwrite;
-        public int RequestOverwriteCalls { get; private set; }
-        public List<JobState> ReportedStates { get; } = [];
-
-        public void ReportAction(ActionType action, bool silent) { }
-        public void ReportState(JobState jobState) => ReportedStates.Add(jobState);
-        public void ReportStatus(string title, string text) { }
-        public void ReportProgress(int total, int current) { }
-        public void ReportFileProgress(string file) { }
-        public void ReportExceptions(Collection<FileExceptionEntry> files, bool silent) { }
-        public Task RequestShowErrorInsufficientDiskSpaceAsync() => Task.CompletedTask;
-
-        public Task<RequestOverwriteResult> RequestOverwrite(FileTableRow localFile, FileTableRow remoteFile)
-        {
-            RequestOverwriteCalls++;
-            return Task.FromResult(OverwriteResult);
-        }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Expands the engine test suite as a black-box around `BackupJob`, `RestoreJob`, `DeleteJob`, `DeleteSingleJob`, `EditJob`, and `BackupService`. Aligns with remaining P1 items from the WinUI beta testing plan (#568): delete-then-restore, shared incremental packages, empty folders, long-path restore, disk-space abort, and deeper `FileSystemStorage` lifecycle coverage.

No production engine code changes.

## What’s added

### Shared infrastructure
- `Helpers/EngineJobTestContext`, `JobSeedHelper`, `JobReportStub`
- `StorageMock` extended for delete/decrypt/rename/free-space recording
- Injectable `StorageFactoryMock`

### Unit coverage
- **Backup:** `FullBackup` forces new packages, empty-folder persistence, no-change refresh rename, disk-space abort, incremental linking of unchanged files
- **Restore:** empty folders, FTP `fileType` 3/4/5 routing, folder path filter, `OverwriteAll`, shared package path from earlier version, long-file restore path
- **Delete:** shared packages preserved when still linked, unique packages removed, orphan directory cleanup, folder metadata cleanup, `DeleteSingle` medium fail / path filter / plain+compressed routing
- **Edit:** medium fail, non-encrypted skip, shared encrypted package double-decrypt edge case, long-file decrypt path
- **BackupService:** password gate, encrypted backup dispatch, delete dispatch, `SetStableAsync` / `UpdateVersionAsync`

### Integration (`[Category("Integration")]`)
New `FileSystemEngineLifecycleTests` with real `FileSystemStorage`:
- Delete older/newer version then restore remaining
- Shared unchanged file survives first-version delete
- Edit decrypt → restore without password
- Empty folder restore
- Nested + Unicode paths
- `DeleteSingle` across versions
- Compressed delete + restore sibling
- Cancelled backup leaves no version
- `FullBackup` recopies unchanged files
- Added/removed files across incrementals

## Notes
- Suite still requires Windows CI (`net*-windows` / WinUI reference); not runnable on this Linux Cloud VM.
- Existing restore integration suite left intact; lifecycle suite complements it.

## Test plan
- [ ] `dotnet test BSH.Test\BSH.Test.csproj -c Release -p:Platform=x64` on Windows
- [ ] Optional: `--filter "FullyQualifiedName~Delete|FullyQualifiedName~Edit|FullyQualifiedName~Backup|Category=Integration"`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8b93-15fd-74fc-b6f6-7be5d8723e1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8b93-15fd-74fc-b6f6-7be5d8723e1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

