### PR TITLE
fix: use theme-aware colors in the WinUI shell

### DIFF
--- a/src/BSH.MainApp/App.xaml
+++ b/src/BSH.MainApp/App.xaml
@@ -18,10 +18,20 @@
             <SolidColorBrush x:Key="WarningTextBrush" Color="#C45A00" />
             <winex:Icon x:Key="AppIcon">Assets\app_ico.ico</winex:Icon>
 
-            <SolidColorBrush x:Key="ButtonBottomPanelBackgroundColor">#fafafa</SolidColorBrush>
-            <SolidColorBrush x:Key="ButtonBottomPanelBorderBrush">#f0f0f0</SolidColorBrush>
-
-            <Color x:Key="App.Theme.IconBaseColor">#DB202020</Color>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Default">
+                    <SolidColorBrush x:Key="AppPageBackgroundBrush" Color="White" />
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="Light">
+                    <SolidColorBrush x:Key="AppPageBackgroundBrush" Color="White" />
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="Dark">
+                    <SolidColorBrush x:Key="AppPageBackgroundBrush" Color="{StaticResource SolidBackgroundFillColorBase}" />
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="HighContrast">
+                    <SolidColorBrush x:Key="AppPageBackgroundBrush" Color="{StaticResource SystemColorWindowColor}" />
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/src/BSH.MainApp/Controls/SetupOptionCard.xaml
+++ b/src/BSH.MainApp/Controls/SetupOptionCard.xaml
@@ -15,7 +15,7 @@
                     <VisualState.Setters>
                         <Setter Target="CardBorder.BorderThickness" Value="2" />
                         <Setter Target="CardBorder.BorderBrush" Value="{ThemeResource AccentFillColorDefaultBrush}" />
-                        <Setter Target="CardBorder.Background" Value="#F3F8FF" />
+                        <Setter Target="CardBorder.Background" Value="{ThemeResource AccentFillColorTertiaryBrush}" />
                         <Setter Target="GlyphIcon.Foreground" Value="{ThemeResource AccentTextFillColorPrimaryBrush}" />
                     </VisualState.Setters>
                 </VisualState>

--- a/src/BSH.MainApp/MainWindow.xaml
+++ b/src/BSH.MainApp/MainWindow.xaml
@@ -12,7 +12,7 @@
     TaskBarIcon="{StaticResource AppIcon}"
     Width="1200" Height="800" Closed="WindowEx_Closed">
 
-    <Grid>
+    <Grid Background="{ThemeResource AppPageBackgroundBrush}">
         <Border
             Canvas.ZIndex="0"
             IsHitTestVisible="False">

--- a/src/BSH.MainApp/Views/BrowserPage.xaml
+++ b/src/BSH.MainApp/Views/BrowserPage.xaml
@@ -67,7 +67,7 @@
             <Setter Property="BorderBrush" Value="Transparent" />
             <Setter Property="Width" Value="36" />
             <Setter Property="Height" Value="32" />
-            <Setter Property="Foreground" Value="{StaticResource App.Theme.IconBaseColor}"/>
+            <Setter Property="Foreground" Value="{ThemeResource TextFillColorPrimaryBrush}"/>
         </Style>
 
         <Style
@@ -89,7 +89,7 @@
         </Style>
     </Page.Resources>
 
-    <Grid Background="White">
+    <Grid Background="{ThemeResource AppPageBackgroundBrush}">
         <Grid Visibility="{x:Bind ViewModel.HasVersions, Mode=OneWay, Converter={StaticResource VisibilityInvertConverter}}">
             <StackPanel Orientation="Vertical" VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="12">
                 <TextBlock HorizontalTextAlignment="Center" Style="{StaticResource HeaderTextBlockStyle}" Text="{helpers:ResourceString Name=Browser_Empty_Title}" />
@@ -134,7 +134,7 @@
                 Padding="6,0,12,0"
 				CornerRadius="{StaticResource ControlCornerRadius}">
                     <BreadcrumbBar
-                    Background="White"
+                    Background="Transparent"
                     ItemsSource="{x:Bind ViewModel.CurrentFolderPath, Mode=OneWay}"
                     ItemClicked="BreadcrumbBar_ItemClicked"
                     VerticalAlignment="Center">
@@ -194,7 +194,7 @@
                     </Grid>
                 </SplitView.Pane>
 
-                <Grid BorderBrush="#f0f0f0" BorderThickness="0,1,0,0">
+                <Grid BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" BorderThickness="0,1,0,0">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="*" />
@@ -335,7 +335,7 @@
                     ColumnSpacing="15" 
                     RowSpacing="10" 
                     Padding="20" 
-                    BorderBrush="#f0f0f0" 
+                    BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" 
                     BorderThickness="1,0,0,0" 
                     Visibility="{x:Bind ViewModel.ToggleInfoPane, Mode=OneWay}"
                     Width="300">

--- a/src/BSH.MainApp/Views/MainPage.xaml
+++ b/src/BSH.MainApp/Views/MainPage.xaml
@@ -8,10 +8,10 @@
     xmlns:converters="using:BSH.MainApp.Converters"
     xmlns:helpers="using:BSH.MainApp.Helpers"
     d:DataContext="{d:DesignInstance Type=viewmodels:MainViewModel}"
-    Background="{ThemeResource SolidBackgroundFillColorBaseBrush}"
+    Background="{ThemeResource AppPageBackgroundBrush}"
     mc:Ignorable="d">
 
-    <Grid Background="White">
+    <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="*"></RowDefinition>
             <RowDefinition Height="Auto"></RowDefinition>
@@ -96,7 +96,7 @@
                     <TextBlock Grid.Row="1" Text="{helpers:ResourceString Name=MainView_Files}" />
                 </Grid>
 
-                <Border Grid.Column="1" BorderBrush="LightGray" BorderThickness="1,0,0,0" Padding="20,0,20,0">
+                <Border Grid.Column="1" BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" BorderThickness="1,0,0,0" Padding="20,0,20,0">
                     <Grid>
                         <Grid.RowDefinitions>
                             <RowDefinition />
@@ -107,7 +107,7 @@
                     </Grid>
                 </Border>
 
-                <Border Grid.Column="2" BorderBrush="LightGray" BorderThickness="1,0,0,0" Padding="20,0,20,0">
+                <Border Grid.Column="2" BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" BorderThickness="1,0,0,0" Padding="20,0,20,0">
                     <Grid>
                         <Grid.RowDefinitions>
                             <RowDefinition />
@@ -120,7 +120,7 @@
             </Grid>
         </Grid>
 
-        <Grid Grid.Row="1" Visibility="{x:Bind ViewModel.NextBackupGridVisibility, Mode=OneWay}" Background="#fafafa" Padding="30,20" BorderBrush="#f0f0f0" BorderThickness="0,1,0,0">
+        <Grid Grid.Row="1" Visibility="{x:Bind ViewModel.NextBackupGridVisibility, Mode=OneWay}" Background="{ThemeResource SolidBackgroundFillColorSecondaryBrush}" Padding="30,20" BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" BorderThickness="0,1,0,0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition></ColumnDefinition>
                 <ColumnDefinition Width="Auto"></ColumnDefinition>
@@ -140,7 +140,7 @@
             </Button>
         </Grid>
 
-        <Grid Grid.Row="1" Visibility="{x:Bind ViewModel.ProgressGridVisibility, Mode=OneWay}" Background="#fafafa" ColumnSpacing="20" Padding="30,20" BorderBrush="#f0f0f0" BorderThickness="0,1,0,0">
+        <Grid Grid.Row="1" Visibility="{x:Bind ViewModel.ProgressGridVisibility, Mode=OneWay}" Background="{ThemeResource SolidBackgroundFillColorSecondaryBrush}" ColumnSpacing="20" Padding="30,20" BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" BorderThickness="0,1,0,0">
             <Grid.RowDefinitions>
                 <RowDefinition />
             </Grid.RowDefinitions>

--- a/src/BSH.MainApp/Views/SettingsPage.xaml
+++ b/src/BSH.MainApp/Views/SettingsPage.xaml
@@ -6,7 +6,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:helpers="using:BSH.MainApp.Helpers"
     mc:Ignorable="d"
-    Background="White">
+    Background="{ThemeResource AppPageBackgroundBrush}">
 
     <Grid Margin="30">
         <Grid.RowDefinitions>

--- a/src/BSH.MainApp/Views/SettingsPages/EnhancedSettingsPage.xaml
+++ b/src/BSH.MainApp/Views/SettingsPages/EnhancedSettingsPage.xaml
@@ -9,7 +9,7 @@
     d:DataContext="{d:DesignInstance Type=viewmodels:SettingsViewModel}"
     mc:Ignorable="d"
     xmlns:toolkit="using:CommunityToolkit.WinUI.Controls"
-    Background="White">
+    Background="{ThemeResource AppPageBackgroundBrush}">
 
     <Page.Resources>
         <x:Double x:Key="SettingsCardSpacing">3</x:Double>

--- a/src/BSH.MainApp/Views/SettingsPages/ModeSettingsPage.xaml
+++ b/src/BSH.MainApp/Views/SettingsPages/ModeSettingsPage.xaml
@@ -11,7 +11,7 @@
     d:DataContext="{d:DesignInstance Type=viewmodels:SettingsViewModel}"
     mc:Ignorable="d"
     xmlns:toolkit="using:CommunityToolkit.WinUI.Controls"
-    Background="White">
+    Background="{ThemeResource AppPageBackgroundBrush}">
 
     <Page.Resources>
         <x:Double x:Key="SettingsCardSpacing">3</x:Double>

--- a/src/BSH.MainApp/Views/SettingsPages/OptionsSettingsPage.xaml
+++ b/src/BSH.MainApp/Views/SettingsPages/OptionsSettingsPage.xaml
@@ -10,7 +10,7 @@
     d:DataContext="{d:DesignInstance Type=viewmodels:SettingsViewModel}"
     mc:Ignorable="d"
     xmlns:toolkit="using:CommunityToolkit.WinUI.Controls"
-    Background="White">
+    Background="{ThemeResource AppPageBackgroundBrush}">
 
     <Page.Resources>
         <x:Double x:Key="SettingsCardSpacing">3</x:Double>

--- a/src/BSH.MainApp/Views/SettingsPages/SourcesSettingsPage.xaml
+++ b/src/BSH.MainApp/Views/SettingsPages/SourcesSettingsPage.xaml
@@ -9,7 +9,7 @@
     d:DataContext="{d:DesignInstance Type=viewmodels:SettingsViewModel}"
     mc:Ignorable="d"
     xmlns:toolkit="using:CommunityToolkit.WinUI.Controls"
-    Background="White">
+    Background="{ThemeResource AppPageBackgroundBrush}">
 
     <Page.Resources>
         <x:Double x:Key="SettingsCardSpacing">3</x:Double>
@@ -65,7 +65,7 @@
                                 </ListView>
 
                                 <TextBlock Grid.Row="1"
-                                           Foreground="Red"
+                                           Foreground="{ThemeResource SystemFillColorCriticalBrush}"
                                            Text="{Binding SourceValidationErrorMessage}"
                                            TextWrapping="Wrap" />
 

--- a/src/BSH.MainApp/Views/SettingsPages/TargetSettingsPage.xaml
+++ b/src/BSH.MainApp/Views/SettingsPages/TargetSettingsPage.xaml
@@ -9,7 +9,7 @@
     d:DataContext="{d:DesignInstance Type=viewmodels:SettingsViewModel}"
     mc:Ignorable="d"
     xmlns:toolkit="using:CommunityToolkit.WinUI.Controls" xmlns:engine="using:Brightbits.BSH.Engine"
-    Background="White">
+    Background="{ThemeResource AppPageBackgroundBrush}">
 
     <Page.Resources>
         <x:Double x:Key="SettingsCardSpacing">3</x:Double>

--- a/src/BSH.MainApp/Views/SetupPage.xaml
+++ b/src/BSH.MainApp/Views/SetupPage.xaml
@@ -12,7 +12,7 @@
     xmlns:engine="using:Brightbits.BSH.Engine"
     xmlns:helpers="using:BSH.MainApp.Helpers"
     d:DataContext="{d:DesignInstance Type=viewmodels:SetupViewModel}"
-    Background="White"
+    Background="{ThemeResource AppPageBackgroundBrush}"
     mc:Ignorable="d">
 
     <Page.Resources>
@@ -27,7 +27,7 @@
         <models:SetupImportSourceKind x:Key="Import_Path">ExplicitPath</models:SetupImportSourceKind>
     </Page.Resources>
 
-    <Grid Background="White">
+    <Grid>
         <Grid
             Width="800"
             HorizontalAlignment="Center"
@@ -52,7 +52,7 @@
             </StackPanel>
 
             <ScrollViewer Grid.Row="1" Margin="0,28,0,0" VerticalScrollBarVisibility="Auto">
-                <Grid Background="White">
+                <Grid>
                     <!-- Welcome -->
                     <StackPanel
                         Visibility="{x:Bind ViewModel.WelcomeVisibility, Mode=OneWay}"
@@ -73,7 +73,7 @@
 
                         <Border
                             Padding="20,18"
-                            Background="#F3F8FF"
+                            Background="{ThemeResource AccentFillColorTertiaryBrush}"
                             BorderBrush="{ThemeResource AccentFillColorDefaultBrush}"
                             BorderThickness="2"
                             CornerRadius="8">

--- a/src/BSH.MainApp/Windows/CompressionExclusionsWindow.xaml
+++ b/src/BSH.MainApp/Windows/CompressionExclusionsWindow.xaml
@@ -19,7 +19,7 @@
     IsMaximizable="False"
     IsMinimizable="False">
 
-    <Grid Background="White"
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
           d:DataContext="{d:DesignInstance Type=viewmodels:CompressionExclusionsViewModel}">
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
@@ -46,7 +46,7 @@
         </Grid>
 
         <Grid Grid.Row="1"
-              Background="{StaticResource ButtonBottomPanelBackgroundColor}" Padding="30,10" BorderBrush="{StaticResource ButtonBottomPanelBorderBrush}" BorderThickness="0,1,0,0">
+              Background="{ThemeResource SolidBackgroundFillColorSecondaryBrush}" Padding="30,10" BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" BorderThickness="0,1,0,0">
             <StackPanel HorizontalAlignment="Right" Orientation="Horizontal" Spacing="10">
                 <Button Command="{x:Bind ViewModel.CancelCommand}"
                         Content="{helpers:ResourceString Name=MainView_Cancel}" />

--- a/src/BSH.MainApp/Windows/EditBackupWindow.xaml
+++ b/src/BSH.MainApp/Windows/EditBackupWindow.xaml
@@ -12,7 +12,7 @@
     TaskBarIcon="{StaticResource AppIcon}"
     Height="500" Width="600" IsResizable="False" IsMaximizable="False" IsMinimizable="False" IsAlwaysOnTop="True">
 
-    <Grid Background="White">
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <Grid.RowDefinitions>
             <RowDefinition Height="*"></RowDefinition>
             <RowDefinition Height="Auto"></RowDefinition>
@@ -50,7 +50,7 @@
             </StackPanel>
         </Grid>
 
-        <Grid Grid.Row="1" Background="{StaticResource ButtonBottomPanelBackgroundColor}" Padding="30,10" BorderBrush="{StaticResource ButtonBottomPanelBorderBrush}" BorderThickness="0,1,0,0">
+        <Grid Grid.Row="1" Background="{ThemeResource SolidBackgroundFillColorSecondaryBrush}" Padding="30,10" BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" BorderThickness="0,1,0,0">
             <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Right">
                 <Button Command="{x:Bind ViewModel.CancelCommand}" Content="{helpers:ResourceString Name=MainView_Cancel}" />
                 <Button Command="{x:Bind ViewModel.SaveCommand}" Style="{StaticResource AccentButtonStyle}" Content="{helpers:ResourceString Name=MsgBox_Save}" />

--- a/src/BSH.MainApp/Windows/FilterWindow.xaml
+++ b/src/BSH.MainApp/Windows/FilterWindow.xaml
@@ -19,7 +19,7 @@
     IsMinimizable="False"
     IsAlwaysOnTop="True">
 
-    <Grid Background="White"
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
           d:DataContext="{d:DesignInstance Type=viewmodels:FilterViewModel}">
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
@@ -75,7 +75,7 @@
         </Grid>
 
         <Grid Grid.Row="1"
-              Background="{StaticResource ButtonBottomPanelBackgroundColor}" Padding="30,10" BorderBrush="{StaticResource ButtonBottomPanelBorderBrush}" BorderThickness="0,1,0,0">
+              Background="{ThemeResource SolidBackgroundFillColorSecondaryBrush}" Padding="30,10" BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" BorderThickness="0,1,0,0">
             <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Right">
                 <Button Command="{x:Bind ViewModel.CancelCommand}" Content="{helpers:ResourceString Name=MainView_Cancel}" />
                 <Button Command="{x:Bind ViewModel.SaveCommand}" Style="{StaticResource AccentButtonStyle}" Content="{helpers:ResourceString Name=MsgBox_Save}" />

--- a/src/BSH.MainApp/Windows/NewBackupWindow.xaml
+++ b/src/BSH.MainApp/Windows/NewBackupWindow.xaml
@@ -12,7 +12,7 @@
     TaskBarIcon="{StaticResource AppIcon}"
     Height="500" Width="600" IsResizable="False" IsMaximizable="False" IsMinimizable="False" IsAlwaysOnTop="True">
 
-    <Grid Background="White">
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <Grid.RowDefinitions>
             <RowDefinition Height="*"></RowDefinition>
             <RowDefinition Height="Auto"></RowDefinition>
@@ -41,7 +41,7 @@
             </StackPanel>
         </Grid>
 
-        <Grid Grid.Row="1" Background="{StaticResource ButtonBottomPanelBackgroundColor}" Padding="30,10" BorderBrush="{StaticResource ButtonBottomPanelBorderBrush}" BorderThickness="0,1,0,0">
+        <Grid Grid.Row="1" Background="{ThemeResource SolidBackgroundFillColorSecondaryBrush}" Padding="30,10" BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" BorderThickness="0,1,0,0">
             <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Right">
                 <Button Command="{x:Bind ViewModel.CancelCommand}" Content="{helpers:ResourceString Name=MainView_Cancel}" />
                 <Button Command="{x:Bind ViewModel.StartBackupCommand}" Style="{StaticResource AccentButtonStyle}" Content="{helpers:ResourceString Name=CreateBackup_CreateButton}" />

--- a/src/BSH.MainApp/Windows/RequestFileOverwriteWindow.xaml
+++ b/src/BSH.MainApp/Windows/RequestFileOverwriteWindow.xaml
@@ -18,7 +18,7 @@
     Width="700"
     Height="450">
 
-    <Grid Background="White">
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <Grid.RowDefinitions>
             <RowDefinition Height="*"></RowDefinition>
             <RowDefinition Height="Auto"></RowDefinition>
@@ -28,7 +28,7 @@
             <TextBlock Style="{StaticResource SubtitleTextBlockStyle}" Text="{helpers:ResourceString Name=Overwrite_AlreadyExists}" />
             <toolkit:SettingsCard IsClickEnabled="True" Header="{helpers:ResourceString Name=Overwrite_ReplaceHeader}" Command="{x:Bind ViewModel.OverwriteFileCommand}">
                 <toolkit:SettingsCard.HeaderIcon>
-                    <FontIcon Foreground="Green" Glyph="&#xE8FB;" />
+                    <FontIcon Foreground="{ThemeResource SystemFillColorSuccessBrush}" Glyph="&#xE8FB;" />
                 </toolkit:SettingsCard.HeaderIcon>
                 <toolkit:SettingsCard.Description>
                     <StackPanel Orientation="Vertical">
@@ -72,11 +72,11 @@
             </toolkit:SettingsCard>
             <toolkit:SettingsCard IsClickEnabled="True" Header="{helpers:ResourceString Name=Overwrite_SkipHeader}" Command="{x:Bind ViewModel.SkipFileCommand}">
                 <toolkit:SettingsCard.HeaderIcon>
-                    <FontIcon Foreground="DarkBlue" Glyph="&#xE7A7;" />
+                    <FontIcon Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" Glyph="&#xE7A7;" />
                 </toolkit:SettingsCard.HeaderIcon>
             </toolkit:SettingsCard>
         </StackPanel>
-        <Grid Grid.Row="1" Background="{StaticResource ButtonBottomPanelBackgroundColor}" Padding="30,10" BorderBrush="{StaticResource ButtonBottomPanelBorderBrush}" BorderThickness="0,1,0,0">
+        <Grid Grid.Row="1" Background="{ThemeResource SolidBackgroundFillColorSecondaryBrush}" Padding="30,10" BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" BorderThickness="0,1,0,0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"></ColumnDefinition>
                 <ColumnDefinition Width="Auto"></ColumnDefinition>

--- a/src/BSH.MainApp/Windows/RequestPasswordWindow.xaml
+++ b/src/BSH.MainApp/Windows/RequestPasswordWindow.xaml
@@ -13,8 +13,7 @@
     Title="{helpers:ResourceString Name=Password_Title}"
     Height="300" Width="500"
     PrimaryButtonText="{helpers:ResourceString Name=MsgBox_OK}"
-    SecondaryButtonText="{helpers:ResourceString Name=MainView_Cancel}"
-    Background="White">
+    SecondaryButtonText="{helpers:ResourceString Name=MainView_Cancel}">
 
     <Grid>
         <StackPanel Orientation="Vertical" Spacing="30">

--- a/src/BSH.MainApp/Windows/ScheduleEditorWindow.xaml
+++ b/src/BSH.MainApp/Windows/ScheduleEditorWindow.xaml
@@ -20,7 +20,7 @@
     IsResizable="True"
     mc:Ignorable="d">
 
-    <Grid Background="White" d:DataContext="{d:DesignInstance Type=viewmodels:ScheduleEditorViewModel}">
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" d:DataContext="{d:DesignInstance Type=viewmodels:ScheduleEditorViewModel}">
         <Grid.Resources>
             <converters:ScheduleOptionDisplayConverter x:Key="ScheduleOptionDisplayConverter" />
             <DataTemplate x:Key="ScheduleOptionTemplate">
@@ -158,7 +158,7 @@
                     <Border
                         Grid.Row="0" Grid.Column="1"
                         Padding="16,16"
-                        Background="#f1f1f1"
+                        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                         CornerRadius="8">
                         <StackPanel Spacing="8">
                             <StackPanel Orientation="Vertical" VerticalAlignment="Center" Spacing="10">
@@ -303,7 +303,7 @@
 
         <Grid
             Grid.Row="1"
-            Background="{StaticResource ButtonBottomPanelBackgroundColor}" Padding="30,10" BorderBrush="{StaticResource ButtonBottomPanelBorderBrush}" BorderThickness="0,1,0,0">
+            Background="{ThemeResource SolidBackgroundFillColorSecondaryBrush}" Padding="30,10" BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" BorderThickness="0,1,0,0">
             <StackPanel HorizontalAlignment="Right" Orientation="Horizontal" Spacing="10">
                 <Button Command="{Binding CancelCommand}" Content="{helpers:ResourceString Name=MainView_Cancel}" />
                 <Button

--- a/src/BSH.MainApp/Windows/StatusWindow.xaml
+++ b/src/BSH.MainApp/Windows/StatusWindow.xaml
@@ -13,7 +13,7 @@
     TaskBarIcon="{StaticResource AppIcon}"
     Height="340" Width="600" IsResizable="False" IsMaximizable="False" IsMinimizable="False" IsAlwaysOnTop="True">
 
-    <Grid Background="White">
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <Grid.RowDefinitions>
             <RowDefinition Height="*"></RowDefinition>
             <RowDefinition Height="Auto"></RowDefinition>
@@ -40,7 +40,7 @@
             </StackPanel>
         </StackPanel>
 
-        <Grid Grid.Row="1" Background="{StaticResource ButtonBottomPanelBackgroundColor}" Padding="30,10" BorderBrush="{StaticResource ButtonBottomPanelBorderBrush}" BorderThickness="0,1,0,0">
+        <Grid Grid.Row="1" Background="{ThemeResource SolidBackgroundFillColorSecondaryBrush}" Padding="30,10" BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" BorderThickness="0,1,0,0">
             <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Right">
                 <Button Command="{x:Bind ViewModel.CancelCommand}" Content="{helpers:ResourceString Name=Status_Cancel}" />
             </StackPanel>

--- a/src/BSH.MainApp/Windows/SwitchStorageWindow.xaml
+++ b/src/BSH.MainApp/Windows/SwitchStorageWindow.xaml
@@ -84,7 +84,7 @@
 
         <Grid
             Grid.Row="1"
-            Background="{StaticResource ButtonBottomPanelBackgroundColor}" Padding="30,10" BorderBrush="{StaticResource ButtonBottomPanelBorderBrush}" BorderThickness="0,1,0,0">
+            Background="{ThemeResource SolidBackgroundFillColorSecondaryBrush}" Padding="30,10" BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" BorderThickness="0,1,0,0">
             <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Right">
                 <Button Command="{x:Bind ViewModel.CancelCommand}" Content="{helpers:ResourceString Name=SwitchStorage_Cancel}" />
                 <Button Command="{x:Bind ViewModel.ConfirmCommand}" Content="{helpers:ResourceString Name=SwitchStorage_Confirm}" Style="{StaticResource AccentButtonStyle}" />

--- a/src/BSH.MainApp/Windows/WaitForMediumWindow.xaml
+++ b/src/BSH.MainApp/Windows/WaitForMediumWindow.xaml
@@ -18,7 +18,7 @@
     IsAlwaysOnTop="True"
     Closed="WindowEx_Closed">
 
-    <Grid>
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
@@ -39,7 +39,7 @@
                    Margin="30,0,30,0" />
 
         <!-- Cancel Button -->
-        <Grid Grid.Row="2" Background="{StaticResource ButtonBottomPanelBackgroundColor}" Padding="30,10" BorderBrush="{StaticResource ButtonBottomPanelBorderBrush}" BorderThickness="0,1,0,0">
+        <Grid Grid.Row="2" Background="{ThemeResource SolidBackgroundFillColorSecondaryBrush}" Padding="30,10" BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" BorderThickness="0,1,0,0">
             <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Right">
                 <Button Command="{x:Bind ViewModel.CancelCommand}" Content="{helpers:ResourceString Name=WaitForMedium_Cancel}" />
             </StackPanel>


### PR DESCRIPTION
Replace hardcoded light backgrounds so dark mode stays readable while the main window remains white in light mode.