### PR TITLE
feat: write a collectable WinUI event log (#600)

### DIFF
--- a/src/BSH.MainApp/App.xaml.cs
+++ b/src/BSH.MainApp/App.xaml.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Alexander Seeliger. All Rights Reserved.
 // Licensed under the Apache License, Version 2.0.
 
+using System.Reflection;
 using Brightbits.BSH.Engine;
 using Brightbits.BSH.Engine.Contracts;
 using Brightbits.BSH.Engine.Contracts.Database;
@@ -32,6 +33,7 @@ using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
+using Serilog;
 using Windows.UI.Popups;
 
 namespace BSH.MainApp;
@@ -77,6 +79,9 @@ public partial class App : Application
         var germanCulture = new System.Globalization.CultureInfo("de-DE");
         System.Globalization.CultureInfo.DefaultThreadCurrentCulture = germanCulture;
         System.Globalization.CultureInfo.DefaultThreadCurrentUICulture = germanCulture;
+
+        var version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown";
+        AppEventLog.Initialize(AppEventLog.GetDirectory(DatabaseFile), "Backup Service Home", version);
 
         InitializeComponent();
 
@@ -317,6 +322,15 @@ public partial class App : Application
 
     private static void ExitApplication()
     {
+        try
+        {
+            Log.CloseAndFlush();
+        }
+        catch
+        {
+            // Best-effort flush so the dated event log is complete on exit.
+        }
+
         if (Current is App app)
         {
             app.TrayIcon?.Dispose();

--- a/src/BSH.MainApp/BSH.MainApp.csproj
+++ b/src/BSH.MainApp/BSH.MainApp.csproj
@@ -39,6 +39,7 @@
 		<PackageReference Include="Microsoft.WindowsAppSDK" Version="2.3.1" />
 		<PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="3.0.1" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+		<PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
 		<PackageReference Include="WinUIEx" Version="2.9.2" />
 		<PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.2.251219" />
 	</ItemGroup>

--- a/src/BSH.MainApp/Services/AppEventLog.cs
+++ b/src/BSH.MainApp/Services/AppEventLog.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Serilog;
+using Serilog.Events;
+
+namespace BSH.MainApp.Services;
+
+/// <summary>
+/// Configures the dated AppData event log that Show Event Logs opens, matching the WinForms file sink.
+/// </summary>
+public static class AppEventLog
+{
+    public static string GetDirectory(string databaseFile)
+    {
+        var directory = Path.GetDirectoryName(databaseFile);
+        if (string.IsNullOrEmpty(directory))
+        {
+            throw new ArgumentException("Database path has no directory.", nameof(databaseFile));
+        }
+
+        return directory;
+    }
+
+    public static string GetFilePath(string directory, DateTime date) =>
+        Path.Combine(directory, $"log{date:yyyyMMdd}.txt");
+
+    public static string GetCurrentFilePath(string databaseFile, DateTime date) =>
+        GetFilePath(GetDirectory(databaseFile), date);
+
+    public static void Initialize(string directory, string appTitle, string version)
+    {
+        Directory.CreateDirectory(directory);
+
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Information()
+            .MinimumLevel.Override("FtpClient", LogEventLevel.Warning)
+            .WriteTo.File(
+                path: Path.Combine(directory, "log.txt"),
+                rollingInterval: RollingInterval.Day,
+                retainedFileCountLimit: 14)
+            .CreateLogger();
+
+        Log.Information("{AppTitle} {Version} started.", appTitle, version);
+    }
+}

--- a/src/BSH.MainApp/Services/PresentationService.cs
+++ b/src/BSH.MainApp/Services/PresentationService.cs
@@ -93,14 +93,7 @@ public class PresentationService : IPresentationService
 
     public Task OpenCurrentEventLogAsync()
     {
-        var date = DateTime.Now.ToString("yyyyMMdd");
-        var logFile = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-            "Alexosoft",
-            "Backup Service Home 3",
-            $"log{date}.txt");
-
-        OpenShellTarget(logFile);
+        OpenShellTarget(AppEventLog.GetCurrentFilePath(App.DatabaseFile, DateTime.Now));
         return Task.CompletedTask;
     }
 

--- a/src/BSH.MainApp/packages.lock.json
+++ b/src/BSH.MainApp/packages.lock.json
@@ -115,6 +115,15 @@
         "resolved": "13.0.4",
         "contentHash": "pdgNNMai3zv51W5aq268sujXUyx7SNdE2bj1wZcWjAQrKMFZV260lbqYop1d2GM67JI1huLRwxo9ZqnfF/lC6A=="
       },
+      "Serilog.Sinks.File": {
+        "type": "Direct",
+        "requested": "[7.0.0, )",
+        "resolved": "7.0.0",
+        "contentHash": "fKL7mXv7qaiNBUC71ssvn/dU0k9t0o45+qm2XgKAlSt19xF+ijjxyA3R6HmCgfKEKwfcfkwWjayuQtRueZFkYw==",
+        "dependencies": {
+          "Serilog": "4.2.0"
+        }
+      },
       "WinUIEx": {
         "type": "Direct",
         "requested": "[2.9.2, )",

--- a/src/BSH.Test/AppEventLogTests.cs
+++ b/src/BSH.Test/AppEventLogTests.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using BSH.MainApp.Services;
+using NUnit.Framework;
+using Serilog;
+
+namespace BSH.Test;
+
+public class AppEventLogTests
+{
+    [Test]
+    public void InitializeWritesDatedLogLineToDisk()
+    {
+        var directory = CreateTempDirectory();
+        var previous = Log.Logger;
+
+        try
+        {
+            AppEventLog.Initialize(directory, "Backup Service Home", "3.9.0.3");
+            Log.CloseAndFlush();
+
+            var logFile = AppEventLog.GetFilePath(directory, DateTime.Now);
+            Assert.That(File.Exists(logFile), Is.True, $"Expected event log at {logFile}");
+
+            var contents = File.ReadAllText(logFile);
+            Assert.That(contents, Does.Contain("Backup Service Home"));
+            Assert.That(contents, Does.Contain("3.9.0.3"));
+            Assert.That(contents, Does.Contain("started"));
+        }
+        finally
+        {
+            Log.CloseAndFlush();
+            Log.Logger = previous;
+            DeleteDirectory(directory);
+        }
+    }
+
+    [Test]
+    public async Task UnhandledExceptionIsWrittenToTheSameEventLogFile()
+    {
+        var directory = CreateTempDirectory();
+        var previous = Log.Logger;
+
+        try
+        {
+            AppEventLog.Initialize(directory, "Backup Service Home", "3.9.0.3");
+
+            var handler = new UnhandledExceptionHandler(
+                askContinueAsync: (_, _) => Task.FromResult(true),
+                exitApplication: () => { });
+
+            await handler.HandleAsync(new InvalidOperationException("collectable crash for support"));
+            await Log.CloseAndFlushAsync();
+
+            var contents = await File.ReadAllTextAsync(AppEventLog.GetFilePath(directory, DateTime.Now));
+            Assert.That(contents, Does.Contain("collectable crash for support"));
+        }
+        finally
+        {
+            await Log.CloseAndFlushAsync();
+            Log.Logger = previous;
+            DeleteDirectory(directory);
+        }
+    }
+
+    [Test]
+    public void GetFilePathUsesLegacyDatedEventLogName()
+    {
+        var path = AppEventLog.GetFilePath(@"C:\Alexosoft\Backup Service Home 3", new DateTime(2026, 8, 16));
+        Assert.That(path, Is.EqualTo(@"C:\Alexosoft\Backup Service Home 3\log20260816.txt"));
+    }
+
+    [Test]
+    public void GetCurrentFilePathUsesTheDatabaseFolder()
+    {
+        var path = AppEventLog.GetCurrentFilePath(
+            @"C:\Alexosoft\Backup Service Home 3\backupservicehome.bshdb",
+            new DateTime(2026, 8, 16));
+
+        Assert.That(path, Is.EqualTo(@"C:\Alexosoft\Backup Service Home 3\log20260816.txt"));
+    }
+
+    private static string CreateTempDirectory()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "BSH.Test", $"eventlog-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private static void DeleteDirectory(string directory)
+    {
+        try
+        {
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+        catch
+        {
+            // Temp cleanup is best-effort; locked log files should not fail the test.
+        }
+    }
+}

--- a/src/BSH.Test/packages.lock.json
+++ b/src/BSH.Test/packages.lock.json
@@ -641,6 +641,14 @@
           "Serilog": "4.2.0"
         }
       },
+      "Serilog.Sinks.File": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "fKL7mXv7qaiNBUC71ssvn/dU0k9t0o45+qm2XgKAlSt19xF+ijjxyA3R6HmCgfKEKwfcfkwWjayuQtRueZFkYw==",
+        "dependencies": {
+          "Serilog": "4.2.0"
+        }
+      },
       "ServiceWire": {
         "type": "Transitive",
         "resolved": "5.6.0",
@@ -743,6 +751,7 @@
           "Microsoft.WindowsAppSDK": "[2.3.1, )",
           "Microsoft.Xaml.Behaviors.WinUI.Managed": "[3.0.1, )",
           "Newtonsoft.Json": "[13.0.4, )",
+          "Serilog.Sinks.File": "[7.0.0, )",
           "WinUIEx": "[2.9.2, )"
         }
       },


### PR DESCRIPTION
The WinUI shell now appends a dated AppData log so testers can collect startup and crash-dialog errors without a debugger.