### PR TITLE
fix: browser empty sources fallback and version navigation

### DIFF
--- a/src/BSH.MainApp/Services/BrowserContentService.cs
+++ b/src/BSH.MainApp/Services/BrowserContentService.cs
@@ -13,16 +13,27 @@ public class BrowserContentService : IBrowserContentService
 {
     private readonly IQueryManager queryManager;
     private readonly IBrowserFavoritesService favoritesService;
+    private readonly IConfigurationManager configurationManager;
 
-    public BrowserContentService(IQueryManager queryManager, IBrowserFavoritesService favoritesService)
+    public BrowserContentService(
+        IQueryManager queryManager,
+        IBrowserFavoritesService favoritesService,
+        IConfigurationManager configurationManager)
     {
         this.queryManager = queryManager;
         this.favoritesService = favoritesService;
+        this.configurationManager = configurationManager;
     }
 
     public async Task<IReadOnlyList<BrowserFavoriteItem>> GetFavoritesAsync(VersionDetails version)
     {
-        var sourceFavorites = version.Sources.Split("|", StringSplitOptions.RemoveEmptyEntries)
+        var sources = version.Sources;
+        if (string.IsNullOrEmpty(sources))
+        {
+            sources = configurationManager.SourceFolder;
+        }
+
+        var sourceFavorites = (sources ?? string.Empty).Split("|", StringSplitOptions.RemoveEmptyEntries)
             .Select(NormalizeBrowserPath)
             .Where(x => !string.IsNullOrWhiteSpace(x))
             .Select(x => new BrowserFavoriteItem

--- a/src/BSH.MainApp/Strings/de-de/Resources.resw
+++ b/src/BSH.MainApp/Strings/de-de/Resources.resw
@@ -192,11 +192,23 @@ Diese Funktion ist derzeit nicht verfügbar, weil die Schnellvorschau nicht gefu
   <data name="Browser_LockUnlockBackup" xml:space="preserve">
     <value>Sicherung sperren/entsperren</value>
   </data>
+  <data name="Browser_NextVersion" xml:space="preserve">
+    <value>Neuer</value>
+  </data>
+  <data name="Browser_NextVersion_Tooltip" xml:space="preserve">
+    <value>Eine neuere Version anzeigen</value>
+  </data>
   <data name="Browser_Organize" xml:space="preserve">
     <value>Organisieren</value>
   </data>
   <data name="Browser_PreviewPane" xml:space="preserve">
     <value>Vorschaufenster</value>
+  </data>
+  <data name="Browser_PreviousVersion" xml:space="preserve">
+    <value>Älter</value>
+  </data>
+  <data name="Browser_PreviousVersion_Tooltip" xml:space="preserve">
+    <value>Eine frühere Version anzeigen</value>
   </data>
   <data name="Browser_Properties" xml:space="preserve">
     <value>Eigenschaften</value>

--- a/src/BSH.MainApp/Strings/en-us/Resources.resw
+++ b/src/BSH.MainApp/Strings/en-us/Resources.resw
@@ -192,11 +192,23 @@ This feature is currently not available because the quick preview could not be f
   <data name="Browser_LockUnlockBackup" xml:space="preserve">
     <value>Lock/unlock backup</value>
   </data>
+  <data name="Browser_NextVersion" xml:space="preserve">
+    <value>Newer</value>
+  </data>
+  <data name="Browser_NextVersion_Tooltip" xml:space="preserve">
+    <value>Jump to a newer backup</value>
+  </data>
   <data name="Browser_Organize" xml:space="preserve">
     <value>Organize</value>
   </data>
   <data name="Browser_PreviewPane" xml:space="preserve">
     <value>Preview pane</value>
+  </data>
+  <data name="Browser_PreviousVersion" xml:space="preserve">
+    <value>Older</value>
+  </data>
+  <data name="Browser_PreviousVersion_Tooltip" xml:space="preserve">
+    <value>Jump to an older backup</value>
   </data>
   <data name="Browser_Properties" xml:space="preserve">
     <value>Properties</value>

--- a/src/BSH.MainApp/ViewModels/BrowserViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/BrowserViewModel.cs
@@ -29,6 +29,7 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
     private long contentRequestId;
     private bool suppressSearchTermsChanged;
     private bool suppressInfoPaneChanged;
+    private bool suppressFavoriteChanged;
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(RestoreFileCommand))]
@@ -178,22 +179,33 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
             return;
         }
 
+        var preservedItem = CurrentItem;
+        var preservedPath = GetPathToPreserve();
+
         await LoadFavoritesAsync();
         if (Favorites.Count == 0)
         {
             return;
         }
 
-        CurrentFavorite = Favorites[0];
+        var pathToLoad = preservedPath;
+        if (string.IsNullOrEmpty(pathToLoad))
+        {
+            pathToLoad = Favorites[0].Path;
+            preservedItem = null;
+        }
+
+        SelectFavoriteForPath(pathToLoad);
 
         ClearSearchTerms();
-        await LoadFolderAsync(CurrentVersion.Id, CurrentFavorite.Path, BeginContentRequest());
+        await LoadFolderAsync(CurrentVersion.Id, pathToLoad, BeginContentRequest());
+        RestorePreservedItem(preservedItem);
     }
 
     [RelayCommand]
     private async Task LoadFavorite()
     {
-        if (CurrentVersion == null || CurrentFavorite == null)
+        if (suppressFavoriteChanged || CurrentVersion == null || CurrentFavorite == null)
         {
             return;
         }
@@ -605,6 +617,60 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
         {
             Favorites.Add(favorite);
         }
+    }
+
+    private string? GetPathToPreserve()
+    {
+        if (CurrentItem != null)
+        {
+            return CurrentItem.FullPath?.Trim('\\');
+        }
+
+        if (CurrentFolderPath.Count > 0)
+        {
+            return CurrentFolderPath[^1].FullPath;
+        }
+
+        return null;
+    }
+
+    private void SelectFavoriteForPath(string path)
+    {
+        var match = Favorites.FirstOrDefault(x => browserContentService.PathsMatch(x.Path, path))
+            ?? Favorites
+                .Where(x => path.StartsWith(x.Path + "\\", StringComparison.OrdinalIgnoreCase))
+                .OrderByDescending(x => x.Path.Length)
+                .FirstOrDefault()
+            ?? Favorites[0];
+
+        suppressFavoriteChanged = true;
+        try
+        {
+            CurrentFavorite = match;
+        }
+        finally
+        {
+            suppressFavoriteChanged = false;
+        }
+    }
+
+    private void RestorePreservedItem(FileOrFolderItem? preservedItem)
+    {
+        if (preservedItem == null)
+        {
+            return;
+        }
+
+        if (preservedItem.IsFile)
+        {
+            CurrentItem = Items.FirstOrDefault(x => x.IsFile
+                && string.Equals(x.Name, preservedItem.Name, StringComparison.OrdinalIgnoreCase)
+                && browserContentService.PathsMatch(x.FullPath, preservedItem.FullPath));
+            return;
+        }
+
+        CurrentItem = CurrentFolderPath.LastOrDefault(x => browserContentService.PathsMatch(x.FullPath, preservedItem.FullPath))
+            ?? preservedItem;
     }
 
     private async Task NavigateToContainingVersionAsync(bool previous)

--- a/src/BSH.MainApp/Views/BrowserPage.xaml
+++ b/src/BSH.MainApp/Views/BrowserPage.xaml
@@ -259,6 +259,17 @@
                             Icon="Folder" 
                             Label="{helpers:ResourceString Name=Browser_RestoreTo}" />
                             <AppBarSeparator />
+                            <AppBarButton
+                            Command="{x:Bind ViewModel.NavigateToPreviousVersionCommand}"
+                            Icon="Previous"
+                            Label="{helpers:ResourceString Name=Browser_PreviousVersion}"
+                            ToolTipService.ToolTip="{helpers:ResourceString Name=Browser_PreviousVersion_Tooltip}" />
+                            <AppBarButton
+                            Command="{x:Bind ViewModel.NavigateToNextVersionCommand}"
+                            Icon="Next"
+                            Label="{helpers:ResourceString Name=Browser_NextVersion}"
+                            ToolTipService.ToolTip="{helpers:ResourceString Name=Browser_NextVersion_Tooltip}" />
+                            <AppBarSeparator />
                             <AppBarButton 
                             Command="{x:Bind ViewModel.ShowFilePreviewCommand}" 
                             Icon="Preview"

--- a/src/BSH.Test/BrowserContentServiceTests.cs
+++ b/src/BSH.Test/BrowserContentServiceTests.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Brightbits.BSH.Engine.Contracts;
+using Brightbits.BSH.Engine.Models;
+using BSH.MainApp.Contracts.Services;
+using BSH.MainApp.Models;
+using BSH.MainApp.Services;
+using BSH.Test.Fakes;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace BSH.Test;
+
+public class BrowserContentServiceTests
+{
+    [Test]
+    public async Task GetFavoritesAsync_WhenVersionSourcesAreEmpty_FallsBackToConfiguredSourceFolders()
+    {
+        var service = CreateService(sourceFolder: @"Y:\MyFiles\source_1|Y:\MyFiles\source_2\");
+        var version = new VersionDetails { Id = "2", Sources = "" };
+
+        var favorites = await service.GetFavoritesAsync(version);
+
+        Assert.That(favorites.Select(x => (x.Name, x.Path, x.IsUserFavorite)), Is.EqualTo(new[]
+        {
+            ("source_1", "source_1", false),
+            ("source_2", "source_2", false)
+        }));
+    }
+
+    [Test]
+    public async Task GetFavoritesAsync_WhenVersionSourcesAreNull_FallsBackToConfiguredSourceFolders()
+    {
+        var service = CreateService(sourceFolder: @"D:\Documents|D:\Pictures");
+        var version = new VersionDetails { Id = "1", Sources = null };
+
+        var favorites = await service.GetFavoritesAsync(version);
+
+        Assert.That(favorites.Select(x => x.Path), Is.EqualTo(new[] { "Documents", "Pictures" }));
+    }
+
+    [Test]
+    public async Task GetFavoritesAsync_WhenVersionSourcesArePresent_DoesNotUseConfiguredFolders()
+    {
+        var service = CreateService(sourceFolder: @"D:\Configured");
+        var version = new VersionDetails { Id = "1", Sources = @"E:\BackupSource\photos" };
+
+        var favorites = await service.GetFavoritesAsync(version);
+
+        Assert.That(favorites.Select(x => x.Path), Is.EqualTo(new[] { "photos" }));
+    }
+
+    private static BrowserContentService CreateService(string sourceFolder)
+    {
+        return new BrowserContentService(
+            new UnusedQueryManager(),
+            new BrowserFavoritesService(new MemoryLocalSettingsService()),
+            new FakeConfigurationManager { SourceFolder = sourceFolder });
+    }
+
+    private sealed class MemoryLocalSettingsService : ILocalSettingsService
+    {
+        private readonly Dictionary<string, object?> settings = [];
+
+        public Task<T?> ReadSettingAsync<T>(string key)
+        {
+            if (!settings.TryGetValue(key, out var value))
+            {
+                return Task.FromResult(default(T));
+            }
+
+            return Task.FromResult((T?)value);
+        }
+
+        public Task SaveSettingAsync<T>(string key, T value)
+        {
+            settings[key] = value;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class UnusedQueryManager : IQueryManager
+    {
+        public Task<string> GetBackVersionWhereFileAsync(string startVersion, string searchString) => Task.FromResult<string>(null);
+        public Task<string> GetBackVersionWhereFilesInFolderAsync(string startVersion, string path) => Task.FromResult<string>(null);
+        public string GetFileNameFromDrive(FileTableRow file) => file.FileName;
+        public Task<(string, bool)> GetFileNameFromDriveAsync(int versionId, string fileName, string filePath, string password) => Task.FromResult((fileName, false));
+        public Task<FileDetails> GetFileDetailsAsync(string version, string fileName, string filePath) => Task.FromResult<FileDetails>(null);
+        public Task<List<FileTableRow>> GetFilesByVersionAsync(string version, string path) => Task.FromResult(new List<FileTableRow>());
+        public Task<List<string>> GetFolderListAsync(string version, string path) => Task.FromResult(new List<string>());
+        public Task<string> GetFullRestoreFolderAsync(string folder, string version) => Task.FromResult(folder);
+        public Task<VersionDetails> GetLastBackupAsync() => Task.FromResult(new VersionDetails());
+        public Task<VersionDetails> GetLastFullBackupAsync() => Task.FromResult(new VersionDetails());
+        public Task<string> GetLocalizedPathAsync(string path) => Task.FromResult(path);
+        public Task<string> GetNextVersionWhereFileAsync(string startVersion, string searchString) => Task.FromResult<string>(null);
+        public Task<string> GetNextVersionWhereFilesInFolderAsync(string startVersion, string path) => Task.FromResult<string>(null);
+        public Task<int> GetNumberOfVersionsAsync() => Task.FromResult(0);
+        public Task<int> GetNumberOfFilesAsync() => Task.FromResult(0);
+        public Task<double> GetTotalFileSizeAsync() => Task.FromResult(0d);
+        public Task<VersionDetails> GetOldestBackupAsync() => Task.FromResult(new VersionDetails());
+        public Task<VersionDetails> GetVersionByIdAsync(string id) => Task.FromResult(new VersionDetails { Id = id });
+        public List<VersionDetails> GetVersions(bool desc = true) => [];
+        public Task<List<FileTableRow>> GetVersionsByFileAsync(string fileName, string filePath) => Task.FromResult(new List<FileTableRow>());
+        public Task<List<FileTableRow>> SearchFilesByVersionAsync(string version, string searchTerm, int limit = 500) => Task.FromResult(new List<FileTableRow>());
+        public Task<bool> HasChangesOrNewAsync(string path, string versionId) => Task.FromResult(false);
+    }
+}

--- a/src/BSH.Test/BrowserViewModelTests.cs
+++ b/src/BSH.Test/BrowserViewModelTests.cs
@@ -11,6 +11,7 @@ using BSH.MainApp.Models;
 using BSH.MainApp.Services;
 using BSH.MainApp.ViewModels;
 using BSH.MainApp.ViewModels.Windows;
+using BSH.Test.Fakes;
 using Microsoft.UI.Xaml.Controls;
 using NUnit.Framework;
 using System;
@@ -57,6 +58,24 @@ public class BrowserViewModelTests
     }
 
     [Test]
+    public void PreviousAndNextVersionCommandsAreEnabledWhenFileOrFolderIsSelected()
+    {
+        var viewModel = CreateViewModel();
+        viewModel.CurrentVersion = Version("2");
+
+        Assert.That(viewModel.NavigateToPreviousVersionCommand.CanExecute(null), Is.False);
+        Assert.That(viewModel.NavigateToNextVersionCommand.CanExecute(null), Is.False);
+
+        viewModel.CurrentItem = new FileOrFolderItem { Name = "docs", FullPath = "source\\docs", IsFile = false };
+        Assert.That(viewModel.NavigateToPreviousVersionCommand.CanExecute(null), Is.True);
+        Assert.That(viewModel.NavigateToNextVersionCommand.CanExecute(null), Is.True);
+
+        viewModel.CurrentItem = new FileOrFolderItem { Name = "report.txt", FullPath = @"source\docs", IsFile = true };
+        Assert.That(viewModel.NavigateToPreviousVersionCommand.CanExecute(null), Is.True);
+        Assert.That(viewModel.NavigateToNextVersionCommand.CanExecute(null), Is.True);
+    }
+
+    [Test]
     public async Task NavigateToPreviousVersionContainingSelectedFolderLoadsMatchingVersion()
     {
         var queryManager = new BrowserQueryManager
@@ -71,6 +90,47 @@ public class BrowserViewModelTests
 
         Assert.That(queryManager.PreviousFolderLookup, Is.EqualTo(("2", "source\\docs")));
         Assert.That(viewModel.CurrentVersion?.Id, Is.EqualTo("1"));
+        Assert.That(viewModel.CurrentFolderPath.Select(x => x.FullPath), Is.EqualTo(new[] { "source", "source\\docs" }));
+    }
+
+    [Test]
+    public async Task NavigateToNextVersionContainingSelectedFileKeepsCurrentFile()
+    {
+        var queryManager = new BrowserQueryManager
+        {
+            NextFileVersion = "3",
+            Files =
+            [
+                new FileTableRow { FileName = "report.txt", FilePath = @"\source\docs\", VersionId = "3" }
+            ]
+        };
+        var viewModel = CreateViewModel(queryManager);
+        viewModel.CurrentVersion = Version("2");
+        viewModel.CurrentItem = new FileOrFolderItem { Name = "report.txt", FullPath = @"\source\docs\", IsFile = true };
+
+        await viewModel.NavigateToNextVersionCommand.ExecuteAsync(null);
+
+        Assert.That(queryManager.NextFileLookup, Is.EqualTo(("2", "report.txt")));
+        Assert.That(viewModel.CurrentVersion?.Id, Is.EqualTo("3"));
+        Assert.That(viewModel.CurrentFolderPath[^1].FullPath, Is.EqualTo(@"source\docs"));
+        Assert.That(viewModel.CurrentItem?.Name, Is.EqualTo("report.txt"));
+        Assert.That(viewModel.CurrentItem?.IsFile, Is.True);
+    }
+
+    [Test]
+    public async Task LoadVersionKeepsCurrentFolderInsteadOfResettingToFirstFavorite()
+    {
+        var viewModel = CreateViewModel();
+        viewModel.CurrentVersion = Version("2");
+        viewModel.CurrentItem = new FileOrFolderItem { Name = "docs", FullPath = @"source\docs", IsFile = false };
+        viewModel.CurrentFolderPath.Add(new FileOrFolderItem { Name = "source", FullPath = "source", IsFile = false });
+        viewModel.CurrentFolderPath.Add(new FileOrFolderItem { Name = "docs", FullPath = @"source\docs", IsFile = false });
+
+        viewModel.CurrentVersion = Version("1");
+        await viewModel.LoadVersionCommand.ExecuteAsync(null);
+
+        Assert.That(viewModel.CurrentVersion?.Id, Is.EqualTo("1"));
+        Assert.That(viewModel.CurrentFolderPath.Select(x => x.FullPath), Is.EqualTo(new[] { "source", @"source\docs" }));
     }
 
     [Test]
@@ -308,7 +368,7 @@ public class BrowserViewModelTests
             jobService ?? new BrowserJobService(),
             new BrowserBackupService(),
             new BrowserPresentationService(),
-            new BrowserContentService(queryManager, favoritesService),
+            new BrowserContentService(queryManager, favoritesService, new FakeConfigurationManager()),
             browserDialogService ?? new BrowserDialogService(),
             previewService ?? new BrowserPreviewServiceFake(),
             viewPreferencesService);
@@ -326,7 +386,10 @@ public class BrowserViewModelTests
     private sealed class BrowserQueryManager : IQueryManager
     {
         public string? PreviousFolderVersion { get; set; }
+        public string? NextFileVersion { get; set; }
         public (string Version, string Path)? PreviousFolderLookup { get; private set; }
+        public (string Version, string Search)? NextFileLookup { get; private set; }
+        public List<FileTableRow> Files { get; set; } = [];
         public int GetVersionsCallCount { get; private set; }
 
         public Task<string> GetBackVersionWhereFileAsync(string startVersion, string searchString) => Task.FromResult<string>(null);
@@ -340,13 +403,19 @@ public class BrowserViewModelTests
         public string GetFileNameFromDrive(FileTableRow file) => file.FileName;
         public Task<(string, bool)> GetFileNameFromDriveAsync(int versionId, string fileName, string filePath, string password) => Task.FromResult((fileName, false));
         public Task<FileDetails> GetFileDetailsAsync(string version, string fileName, string filePath) => Task.FromResult<FileDetails>(null);
-        public Task<List<FileTableRow>> GetFilesByVersionAsync(string version, string path) => Task.FromResult(new List<FileTableRow>());
+        public Task<List<FileTableRow>> GetFilesByVersionAsync(string version, string path) => Task.FromResult(Files);
         public Task<List<string>> GetFolderListAsync(string version, string path) => Task.FromResult(new List<string>());
         public Task<string> GetFullRestoreFolderAsync(string folder, string version) => Task.FromResult(folder);
         public Task<VersionDetails> GetLastBackupAsync() => Task.FromResult(Version("3"));
         public Task<VersionDetails> GetLastFullBackupAsync() => Task.FromResult(Version("3"));
         public Task<string> GetLocalizedPathAsync(string path) => Task.FromResult(path);
-        public Task<string> GetNextVersionWhereFileAsync(string startVersion, string searchString) => Task.FromResult<string>(null);
+
+        public Task<string> GetNextVersionWhereFileAsync(string startVersion, string searchString)
+        {
+            NextFileLookup = (startVersion, searchString);
+            return Task.FromResult(NextFileVersion);
+        }
+
         public Task<string> GetNextVersionWhereFilesInFolderAsync(string startVersion, string path) => Task.FromResult<string>(null);
         public Task<int> GetNumberOfVersionsAsync() => Task.FromResult(3);
         public Task<int> GetNumberOfFilesAsync() => Task.FromResult(0);

--- a/tools/localization/winui-strings.json
+++ b/tools/localization/winui-strings.json
@@ -391,6 +391,22 @@
     "en": "Lock/unlock backup",
     "de": "Sicherung sperren/entsperren"
   },
+  "Browser_PreviousVersion": {
+    "en": "Older",
+    "de": "Älter"
+  },
+  "Browser_PreviousVersion_Tooltip": {
+    "en": "Jump to an older backup",
+    "de": "Eine frühere Version anzeigen"
+  },
+  "Browser_NextVersion": {
+    "en": "Newer",
+    "de": "Neuer"
+  },
+  "Browser_NextVersion_Tooltip": {
+    "en": "Jump to a newer backup",
+    "de": "Eine neuere Version anzeigen"
+  },
   "Browser_Column_Name": {
     "en": "Name",
     "de": "Name"


### PR DESCRIPTION
Imported and legacy backups often store empty or null Sources, which left the WinUI browser blank or crashed it. The browser now falls back to configured source folders the same way restore and WinForms already do. Older and Newer actions are on the command bar and keep the current folder or file when that version contains it, instead of jumping back to the first favorite.

Closes #612

## Test plan
- [ ] Open an imported or legacy version with empty/null Sources and confirm source folders appear
- [ ] Select a file or folder and confirm Older/Newer are visible and enabled
- [ ] Jump to another version and confirm the current folder or file stays selected when that version contains it
- [ ] `dotnet test -p:Platform=x64 --filter "FullyQualifiedName~BrowserViewModelTests|FullyQualifiedName~BrowserContentServiceTests"`

Made with [Cursor](https://cursor.com)