### PR TITLE
fix: start due backup when USB target arrives

### DIFF
--- a/src/BSH.Engine/Services/MediaArrivalBackupWatch.cs
+++ b/src/BSH.Engine/Services/MediaArrivalBackupWatch.cs
@@ -59,6 +59,19 @@ public sealed class MediaArrivalBackupWatch
         }
     }
 
+    public async Task StartIfMediaMissing(Func<Task> runBackup, Func<Task<bool>> isMediaAvailable)
+    {
+        ArgumentNullException.ThrowIfNull(runBackup);
+        ArgumentNullException.ThrowIfNull(isMediaAvailable);
+
+        if (await isMediaAvailable())
+        {
+            return;
+        }
+
+        Start(runBackup, isMediaAvailable);
+    }
+
     public void Stop()
     {
         IMediaWatcher current;

--- a/src/BSH.Engine/Services/MediaArrivalBackupWatch.cs
+++ b/src/BSH.Engine/Services/MediaArrivalBackupWatch.cs
@@ -1,0 +1,132 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Threading.Tasks;
+using Brightbits.BSH.Engine.Contracts;
+using Brightbits.BSH.Engine.Providers.Ports;
+using Serilog;
+
+namespace Brightbits.BSH.Engine.Services;
+
+/// <summary>
+/// Starts a local-volume media watcher and runs a pending backup when the
+/// configured target drive arrives. FTP targets are ignored.
+/// </summary>
+public sealed class MediaArrivalBackupWatch
+{
+    private readonly IConfigurationManager configurationManager;
+    private readonly IMediaWatcherFactory mediaWatcherFactory;
+    private readonly object sync = new();
+
+    private IMediaWatcher watcher;
+    private Func<Task> runBackup;
+    private Func<Task<bool>> isMediaAvailable;
+
+    public MediaArrivalBackupWatch(
+        IConfigurationManager configurationManager,
+        IMediaWatcherFactory mediaWatcherFactory)
+    {
+        ArgumentNullException.ThrowIfNull(configurationManager);
+        ArgumentNullException.ThrowIfNull(mediaWatcherFactory);
+
+        this.configurationManager = configurationManager;
+        this.mediaWatcherFactory = mediaWatcherFactory;
+    }
+
+    public void Start(Func<Task> runBackup, Func<Task<bool>> isMediaAvailable = null)
+    {
+        ArgumentNullException.ThrowIfNull(runBackup);
+
+        lock (sync)
+        {
+            if (watcher != null)
+            {
+                return;
+            }
+
+            if (configurationManager.MediumType == MediaType.FileTransferServer)
+            {
+                return;
+            }
+
+            this.runBackup = runBackup;
+            this.isMediaAvailable = isMediaAvailable;
+
+            watcher = mediaWatcherFactory.Create();
+            watcher.DeviceAdded += OnDeviceAdded;
+            watcher.StartWatching();
+        }
+    }
+
+    public void Stop()
+    {
+        IMediaWatcher current;
+        lock (sync)
+        {
+            current = watcher;
+            watcher = null;
+            runBackup = null;
+            isMediaAvailable = null;
+        }
+
+        if (current == null)
+        {
+            return;
+        }
+
+        try
+        {
+            current.DeviceAdded -= OnDeviceAdded;
+            current.StopWatching();
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "USB device watcher could not be stopped.");
+        }
+    }
+
+    private async void OnDeviceAdded(object sender, string driveLetter)
+    {
+        try
+        {
+            Func<Task> pending;
+            Func<Task<bool>> mediaCheck;
+            lock (sync)
+            {
+                pending = runBackup;
+                mediaCheck = isMediaAvailable;
+            }
+
+            if (mediaCheck != null && !await mediaCheck())
+            {
+                return;
+            }
+
+            if (!IsTargetDrive(configurationManager.BackupFolder, driveLetter))
+            {
+                return;
+            }
+
+            Stop();
+            if (pending != null)
+            {
+                await pending();
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "USB arrival backup could not be started.");
+        }
+    }
+
+    internal static bool IsTargetDrive(string backupFolder, string driveLetter)
+    {
+        if (string.IsNullOrEmpty(backupFolder) || string.IsNullOrEmpty(driveLetter))
+        {
+            return false;
+        }
+
+        return backupFolder.StartsWith(driveLetter, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/BSH.Main/Modules/BackupLogic.cs
+++ b/src/BSH.Main/Modules/BackupLogic.cs
@@ -408,6 +408,10 @@ static class BackupLogic
             {
                 await RemoveOldBackups();
             }
+            else
+            {
+                DoBackupWhenDriveIsAvailable(RunBackupMethod.Auto);
+            }
         }
         finally
         {
@@ -654,6 +658,10 @@ static class BackupLogic
             if (succeeded)
             {
                 await RemoveOldBackupsScheduled();
+            }
+            else
+            {
+                DoBackupWhenDriveIsAvailable(RunBackupMethod.Schedule);
             }
         }
         finally

--- a/src/BSH.Main/Modules/BackupLogic.cs
+++ b/src/BSH.Main/Modules/BackupLogic.cs
@@ -77,8 +77,7 @@ static class BackupLogic
 
     public static string DatabaseFile = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + @"\Alexosoft\Backup Service Home 3\backupservicehome.bshdb";
 
-    private static IMediaWatcher dCWatcher;
-    private static IMediaWatcherFactory mediaWatcherFactory;
+    private static MediaArrivalBackupWatch mediaArrivalWatch;
     private static IFileCollectorServiceFactory fileCollectorServiceFactory;
 
     private static ISchedulerAdapter schedulerService;
@@ -98,7 +97,8 @@ static class BackupLogic
         BackupService = null;
         BackupController = null;
         fileCollectorServiceFactory = null;
-        mediaWatcherFactory = null;
+        mediaArrivalWatch?.Stop();
+        mediaArrivalWatch = null;
         schedulerAdapterFactory = null;
     }
 
@@ -149,7 +149,7 @@ static class BackupLogic
         VersionQueryRepository = new VersionQueryRepository();
         BackupMutationRepository = new BackupMutationRepository(DbClientFactory);
         fileCollectorServiceFactory = new FileCollectorServiceFactory();
-        mediaWatcherFactory = new MediaWatcherFactory();
+        mediaArrivalWatch = new MediaArrivalBackupWatch(ConfigurationManager, new MediaWatcherFactory());
         schedulerAdapterFactory = new SchedulerAdapterFactory();
 
         BackupService = new BackupService(
@@ -410,7 +410,7 @@ static class BackupLogic
             }
             else
             {
-                DoBackupWhenDriveIsAvailable(RunBackupMethod.Auto);
+                await WatchIfMediaMissing(RunBackupMethod.Auto);
             }
         }
         finally
@@ -661,7 +661,7 @@ static class BackupLogic
             }
             else
             {
-                DoBackupWhenDriveIsAvailable(RunBackupMethod.Schedule);
+                await WatchIfMediaMissing(RunBackupMethod.Schedule);
             }
         }
         finally
@@ -705,8 +705,6 @@ static class BackupLogic
 
     #endregion
 
-    private static RunBackupMethod _RunBackupDelegate;
-
     public enum RunBackupMethod
     {
         Schedule,
@@ -716,71 +714,42 @@ static class BackupLogic
 
     public static void DoBackupWhenDriveIsAvailable(RunBackupMethod RunBackupDelegate)
     {
-        if (dCWatcher != null)
-        {
-            return;
-        }
-
-        // only start, if local device
-        if (ConfigurationManager.MediumType != MediaType.FileTransferServer)
-        {
-            dCWatcher = mediaWatcherFactory.Create();
-            dCWatcher.StartWatching();
-
-            // observe devices
-            dCWatcher.DeviceAdded += DriveArrived;
-            _RunBackupDelegate = RunBackupDelegate;
-        }
+        mediaArrivalWatch?.Start(GetRunBackup(RunBackupDelegate), CheckBackupMediaAsync);
     }
 
     public static void StopDoBackupWhenDriveIsAvailable()
     {
-        try
-        {
-            if (dCWatcher != null)
-            {
-                dCWatcher.DeviceAdded -= DriveArrived;
-                dCWatcher.StopWatching();
-                dCWatcher = null;
-            }
-        }
-        catch
-        {
-            // ignore error
-        }
+        mediaArrivalWatch?.Stop();
     }
 
-    private static async void DriveArrived(object sender, string driveLetter)
+    private static Task WatchIfMediaMissing(RunBackupMethod runBackupDelegate)
     {
-        if (!await BackupController.CheckMediaAsync(ActionType.Backup, true))
+        if (mediaArrivalWatch == null)
         {
-            return;
+            return Task.CompletedTask;
         }
 
-        // check is backup device is connected
-        if (ConfigurationManager.BackupFolder.ToLower().StartsWith(driveLetter.ToLower()))
-        {
-            try
-            {
-                dCWatcher.DeviceAdded -= DriveArrived;
-                dCWatcher.StopWatching();
-                dCWatcher = null;
-            }
-            catch
-            {
-                // ignore error
-            }
+        return mediaArrivalWatch.StartIfMediaMissing(GetRunBackup(runBackupDelegate), CheckBackupMediaAsync);
+    }
 
-            // start backup
-            if (_RunBackupDelegate == RunBackupMethod.Auto)
-            {
-                await RunAutoBackup();
-            }
-            else if (_RunBackupDelegate == RunBackupMethod.Schedule)
-            {
-                await thScheduleSysRunBackup();
-            }
+    private static Func<Task> GetRunBackup(RunBackupMethod runBackupDelegate)
+    {
+        if (runBackupDelegate == RunBackupMethod.Auto)
+        {
+            return RunAutoBackup;
         }
+
+        if (runBackupDelegate == RunBackupMethod.Schedule)
+        {
+            return thScheduleSysRunBackup;
+        }
+
+        return () => Task.CompletedTask;
+    }
+
+    private static Task<bool> CheckBackupMediaAsync()
+    {
+        return BackupController.CheckMediaAsync(ActionType.Backup, true);
     }
 
     public static async Task CommandAutoDelete()

--- a/src/BSH.MainApp/Services/ScheduledBackupService.cs
+++ b/src/BSH.MainApp/Services/ScheduledBackupService.cs
@@ -22,6 +22,7 @@ public class ScheduledBackupService : IScheduledBackupService
     private readonly IScheduleRepository scheduleRepository;
     private readonly ISchedulerAdapterFactory schedulerAdapterFactory;
     private readonly ScheduleSettingsService scheduleSettingsService;
+    private readonly MediaArrivalBackupWatch mediaArrivalWatch;
 
     private ISchedulerAdapter? schedulerService;
 
@@ -31,7 +32,8 @@ public class ScheduledBackupService : IScheduledBackupService
         IQueryManager queryManager,
         IScheduleRepository scheduleRepository,
         ISchedulerAdapterFactory schedulerAdapterFactory,
-        ScheduleSettingsService scheduleSettingsService)
+        ScheduleSettingsService scheduleSettingsService,
+        IMediaWatcherFactory mediaWatcherFactory)
     {
         this.configurationManager = configurationManager;
         this.jobService = jobService;
@@ -39,6 +41,8 @@ public class ScheduledBackupService : IScheduledBackupService
         this.scheduleRepository = scheduleRepository;
         this.schedulerAdapterFactory = schedulerAdapterFactory;
         this.scheduleSettingsService = scheduleSettingsService;
+        ArgumentNullException.ThrowIfNull(mediaWatcherFactory);
+        mediaArrivalWatch = new MediaArrivalBackupWatch(configurationManager, mediaWatcherFactory);
     }
 
     public async Task InitializeAsync()
@@ -63,6 +67,7 @@ public class ScheduledBackupService : IScheduledBackupService
     {
         StopFullAutomatedSystem();
         StopScheduleSystem();
+        mediaArrivalWatch.Stop();
     }
 
     public DateTime GetNextBackupDate()
@@ -91,6 +96,8 @@ public class ScheduledBackupService : IScheduledBackupService
         schedulerService = schedulerAdapterFactory.Create();
         schedulerService.Start();
         schedulerService.ScheduleAutoBackup(async () => await RunAutoBackup());
+
+        WatchForDueBackup(RunAutoBackup);
     }
 
     private void StopFullAutomatedSystem()
@@ -109,6 +116,8 @@ public class ScheduledBackupService : IScheduledBackupService
     {
         Log.Information("Automatic backup is scheduled and will be performed now.");
 
+        mediaArrivalWatch.Stop();
+
         // lower process priority
         Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.BelowNormal;
 
@@ -117,6 +126,10 @@ public class ScheduledBackupService : IScheduledBackupService
             if (await jobService.CreateBackupAsync("Automatisches Backup", "", false))
             {
                 await RemoveOldBackups();
+            }
+            else
+            {
+                await WatchIfMediaMissing(RunAutoBackup);
             }
         }
         finally
@@ -177,6 +190,7 @@ public class ScheduledBackupService : IScheduledBackupService
                 if (DateTime.Now.TimeOfDay > scheduleDate.TimeOfDay && DoPastBackup(DateTime.Now.Date.Add(scheduleDate.TimeOfDay), true))
                 {
                     schedulerService.ScheduleOnce(async () => await thScheduleSysRunBackup(), DateTime.Now.AddMinutes(1));
+                    WatchForDueBackup(thScheduleSysRunBackup);
                 }
 
                 schedulerService.ScheduleDaily(async () => await thScheduleSysRunBackup(), scheduleDate);
@@ -192,6 +206,7 @@ public class ScheduledBackupService : IScheduledBackupService
                     if (DateTime.Now.TimeOfDay > scheduleDate.TimeOfDay && DoPastBackup(DateTime.Now.Date.Add(scheduleDate.TimeOfDay), true))
                     {
                         schedulerService.ScheduleOnce(async () => await thScheduleSysRunBackup(), DateTime.Now.AddMinutes(1));
+                        WatchForDueBackup(thScheduleSysRunBackup);
                     }
                 }
                 else
@@ -208,6 +223,7 @@ public class ScheduledBackupService : IScheduledBackupService
                             if (DoPastBackup(DateTime.Now.Date.Add(scheduleDate.TimeOfDay), true))
                             {
                                 schedulerService.ScheduleOnce(async () => await thScheduleSysRunBackup(), DateTime.Now.AddMinutes(1));
+                                WatchForDueBackup(thScheduleSysRunBackup);
                             }
 
                             break;
@@ -233,6 +249,7 @@ public class ScheduledBackupService : IScheduledBackupService
                     if (DateTime.Now.TimeOfDay > scheduleDate.TimeOfDay && DoPastBackup(DateTime.Now.Date.Add(scheduleDate.TimeOfDay), true))
                     {
                         schedulerService.ScheduleOnce(async () => await thScheduleSysRunBackup(), DateTime.Now.AddMinutes(1));
+                        WatchForDueBackup(thScheduleSysRunBackup);
                     }
                 }
                 else
@@ -249,6 +266,7 @@ public class ScheduledBackupService : IScheduledBackupService
                             if (DoPastBackup(DateTime.Now.Date.Add(scheduleDate.TimeOfDay), true))
                             {
                                 schedulerService.ScheduleOnce(async () => await thScheduleSysRunBackup(), DateTime.Now.AddMinutes(1));
+                                WatchForDueBackup(thScheduleSysRunBackup);
                             }
 
                             break;
@@ -314,6 +332,8 @@ public class ScheduledBackupService : IScheduledBackupService
     {
         Log.Information("Scheduled backup is planned and will be performed now.");
 
+        mediaArrivalWatch.Stop();
+
         // Priorität heruntersetzen
         Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.BelowNormal;
 
@@ -330,11 +350,33 @@ public class ScheduledBackupService : IScheduledBackupService
             {
                 await RemoveOldBackupsScheduled();
             }
+            else
+            {
+                await WatchIfMediaMissing(thScheduleSysRunBackup);
+            }
         }
         finally
         {
             Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.Normal;
         }
+    }
+
+    private void WatchForDueBackup(Func<Task> runBackup)
+    {
+        mediaArrivalWatch.Start(runBackup, CheckBackupMediaAsync);
+    }
+
+    private async Task WatchIfMediaMissing(Func<Task> runBackup)
+    {
+        if (!await CheckBackupMediaAsync())
+        {
+            WatchForDueBackup(runBackup);
+        }
+    }
+
+    private Task<bool> CheckBackupMediaAsync()
+    {
+        return jobService.CheckMediaAsync(ActionType.Backup, true);
     }
 
     private async Task RemoveOldBackupsScheduled()

--- a/src/BSH.MainApp/Services/ScheduledBackupService.cs
+++ b/src/BSH.MainApp/Services/ScheduledBackupService.cs
@@ -366,12 +366,9 @@ public class ScheduledBackupService : IScheduledBackupService
         mediaArrivalWatch.Start(runBackup, CheckBackupMediaAsync);
     }
 
-    private async Task WatchIfMediaMissing(Func<Task> runBackup)
+    private Task WatchIfMediaMissing(Func<Task> runBackup)
     {
-        if (!await CheckBackupMediaAsync())
-        {
-            WatchForDueBackup(runBackup);
-        }
+        return mediaArrivalWatch.StartIfMediaMissing(runBackup, CheckBackupMediaAsync);
     }
 
     private Task<bool> CheckBackupMediaAsync()

--- a/src/BSH.Test/MediaArrivalBackupWatchTests.cs
+++ b/src/BSH.Test/MediaArrivalBackupWatchTests.cs
@@ -1,0 +1,120 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Threading.Tasks;
+using Brightbits.BSH.Engine;
+using Brightbits.BSH.Engine.Providers.Ports;
+using Brightbits.BSH.Engine.Services;
+using BSH.Test.Fakes;
+using NUnit.Framework;
+
+namespace BSH.Test;
+
+public class MediaArrivalBackupWatchTests
+{
+    [Test]
+    public void Start_WhenTargetIsFtp_DoesNotCreateMediaWatcher()
+    {
+        var factory = new FakeMediaWatcherFactory();
+        var watch = CreateWatch(MediaType.FileTransferServer, @"E:\Backups", factory);
+
+        watch.Start(() => Task.CompletedTask);
+
+        Assert.That(factory.CreateCount, Is.EqualTo(0));
+        Assert.That(factory.Watcher.StartWatchingCount, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Start_WhenTargetIsLocalVolume_StartsMediaWatcher()
+    {
+        var factory = new FakeMediaWatcherFactory();
+        var watch = CreateWatch(MediaType.LocalDevice, @"E:\Backups", factory);
+
+        watch.Start(() => Task.CompletedTask);
+
+        Assert.That(factory.CreateCount, Is.EqualTo(1));
+        Assert.That(factory.Watcher.StartWatchingCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task MatchingDriveArrival_StartsPendingBackup()
+    {
+        var factory = new FakeMediaWatcherFactory();
+        var watch = CreateWatch(MediaType.LocalDevice, @"E:\Backups", factory);
+        var backupStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var backupCalls = 0;
+
+        watch.Start(() =>
+        {
+            backupCalls++;
+            backupStarted.TrySetResult();
+            return Task.CompletedTask;
+        });
+
+        factory.Watcher.Arrive("E:");
+
+        await backupStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.That(backupCalls, Is.EqualTo(1));
+        Assert.That(factory.Watcher.StopWatchingCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task NonMatchingDriveArrival_DoesNotStartBackup()
+    {
+        var factory = new FakeMediaWatcherFactory();
+        var watch = CreateWatch(MediaType.LocalDevice, @"E:\Backups", factory);
+        var backupCalls = 0;
+
+        watch.Start(() =>
+        {
+            backupCalls++;
+            return Task.CompletedTask;
+        });
+
+        factory.Watcher.Arrive("F:");
+        await Task.Delay(100);
+
+        Assert.That(backupCalls, Is.EqualTo(0));
+        Assert.That(factory.Watcher.StopWatchingCount, Is.EqualTo(0));
+    }
+
+    private static MediaArrivalBackupWatch CreateWatch(
+        MediaType mediaType,
+        string backupFolder,
+        FakeMediaWatcherFactory factory)
+    {
+        return new MediaArrivalBackupWatch(
+            new FakeConfigurationManager
+            {
+                MediumType = mediaType,
+                BackupFolder = backupFolder
+            },
+            factory);
+    }
+
+    private sealed class FakeMediaWatcherFactory : IMediaWatcherFactory
+    {
+        public FakeMediaWatcher Watcher { get; } = new();
+        public int CreateCount { get; private set; }
+
+        public IMediaWatcher Create()
+        {
+            CreateCount++;
+            return Watcher;
+        }
+    }
+
+    private sealed class FakeMediaWatcher : IMediaWatcher
+    {
+        public event EventHandler<string> DeviceAdded;
+        public int StartWatchingCount { get; private set; }
+        public int StopWatchingCount { get; private set; }
+
+        public void StartWatching() => StartWatchingCount++;
+
+        public void StopWatching() => StopWatchingCount++;
+
+        public void Arrive(string driveLetter) => DeviceAdded?.Invoke(this, driveLetter);
+    }
+}

--- a/src/BSH.Test/MediaArrivalBackupWatchTests.cs
+++ b/src/BSH.Test/MediaArrivalBackupWatchTests.cs
@@ -79,6 +79,55 @@ public class MediaArrivalBackupWatchTests
         Assert.That(factory.Watcher.StopWatchingCount, Is.EqualTo(0));
     }
 
+    [Test]
+    public async Task StartIfMediaMissing_WhenMediaUnavailable_StartsWatcherAndMatchingDriveRunsBackup()
+    {
+        var factory = new FakeMediaWatcherFactory();
+        var watch = CreateWatch(MediaType.LocalDevice, @"E:\Backups", factory);
+        var backupStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var mediaAvailable = false;
+        var backupCalls = 0;
+
+        await watch.StartIfMediaMissing(
+            () =>
+            {
+                backupCalls++;
+                backupStarted.TrySetResult();
+                return Task.CompletedTask;
+            },
+            () => Task.FromResult(mediaAvailable));
+
+        Assert.That(factory.CreateCount, Is.EqualTo(1));
+
+        mediaAvailable = true;
+        factory.Watcher.Arrive("E:");
+
+        await backupStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.That(backupCalls, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task StartIfMediaMissing_WhenMediaAvailable_DoesNotStartWatcher()
+    {
+        var factory = new FakeMediaWatcherFactory();
+        var watch = CreateWatch(MediaType.LocalDevice, @"E:\Backups", factory);
+
+        await watch.StartIfMediaMissing(() => Task.CompletedTask, () => Task.FromResult(true));
+
+        Assert.That(factory.CreateCount, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task StartIfMediaMissing_WhenTargetIsFtp_DoesNotStartWatcher()
+    {
+        var factory = new FakeMediaWatcherFactory();
+        var watch = CreateWatch(MediaType.FileTransferServer, @"E:\Backups", factory);
+
+        await watch.StartIfMediaMissing(() => Task.CompletedTask, () => Task.FromResult(false));
+
+        Assert.That(factory.CreateCount, Is.EqualTo(0));
+    }
+
     private static MediaArrivalBackupWatch CreateWatch(
         MediaType mediaType,
         string backupFolder,

--- a/src/BSH.Test/ScheduledBackupServiceTests.cs
+++ b/src/BSH.Test/ScheduledBackupServiceTests.cs
@@ -1,0 +1,272 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Brightbits.BSH.Engine;
+using Brightbits.BSH.Engine.Contracts;
+using Brightbits.BSH.Engine.Contracts.Repo;
+using Brightbits.BSH.Engine.Models;
+using Brightbits.BSH.Engine.Providers.Ports;
+using Brightbits.BSH.Engine.Services;
+using BSH.MainApp.Contracts.Services;
+using BSH.MainApp.Services;
+using BSH.Test.Fakes;
+using NUnit.Framework;
+
+namespace BSH.Test;
+
+public class ScheduledBackupServiceTests
+{
+    [Test]
+    public async Task AutoLocalVolume_MatchingDriveArrival_StartsBackup()
+    {
+        var factory = new FakeMediaWatcherFactory();
+        var jobService = new RecordingJobService { MediaAvailable = true };
+        var service = CreateService(TaskType.Auto, MediaType.LocalDevice, jobService, factory);
+
+        await service.StartAsync();
+        Assert.That(factory.CreateCount, Is.EqualTo(1));
+
+        factory.Watcher.Arrive("E:");
+        await jobService.WaitForBackupAsync();
+
+        Assert.That(jobService.CreateBackupCalls, Is.EqualTo(1));
+        Assert.That(jobService.LastBackupTitle, Is.EqualTo("Automatisches Backup"));
+    }
+
+    [Test]
+    public async Task AutoFtp_DoesNotStartMediaWatcher()
+    {
+        var factory = new FakeMediaWatcherFactory();
+        var service = CreateService(TaskType.Auto, MediaType.FileTransferServer, new RecordingJobService(), factory);
+
+        await service.StartAsync();
+
+        Assert.That(factory.CreateCount, Is.EqualTo(0));
+        Assert.That(factory.Watcher.StartWatchingCount, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task ScheduledLocalVolume_MissingMediaAtFire_StartsBackupWhenDriveArrives()
+    {
+        var factory = new FakeMediaWatcherFactory();
+        var scheduler = new FakeSchedulerAdapter();
+        var jobService = new RecordingJobService { MediaAvailable = false };
+        var service = CreateService(
+            TaskType.Schedule,
+            MediaType.LocalDevice,
+            jobService,
+            factory,
+            scheduler,
+            schedules: [new ScheduleEntry { Type = 2, Date = DateTime.Now }]);
+
+        await service.StartAsync();
+        Assert.That(factory.CreateCount, Is.EqualTo(0));
+
+        scheduler.HourlyBackup();
+        await WaitUntil(() => factory.Watcher.StartWatchingCount == 1);
+
+        Assert.That(jobService.CreateBackupCalls, Is.EqualTo(1));
+        Assert.That(factory.CreateCount, Is.EqualTo(1));
+
+        jobService.MediaAvailable = true;
+        factory.Watcher.Arrive("E:");
+        await jobService.WaitForBackupAsync(minimumCalls: 2);
+
+        Assert.That(jobService.CreateBackupCalls, Is.EqualTo(2));
+        Assert.That(jobService.LastBackupTitle, Is.EqualTo("Automatische Sicherung"));
+    }
+
+    [Test]
+    public async Task ScheduledFtp_MissingMediaAtFire_DoesNotStartMediaWatcher()
+    {
+        var factory = new FakeMediaWatcherFactory();
+        var scheduler = new FakeSchedulerAdapter();
+        var jobService = new RecordingJobService { MediaAvailable = false };
+        var service = CreateService(
+            TaskType.Schedule,
+            MediaType.FileTransferServer,
+            jobService,
+            factory,
+            scheduler,
+            schedules: [new ScheduleEntry { Type = 2, Date = DateTime.Now }]);
+
+        await service.StartAsync();
+        scheduler.HourlyBackup();
+        await jobService.WaitForBackupAsync();
+        await Task.Delay(50);
+
+        Assert.That(factory.CreateCount, Is.EqualTo(0));
+        Assert.That(factory.Watcher.StartWatchingCount, Is.EqualTo(0));
+    }
+
+    private static ScheduledBackupService CreateService(
+        TaskType taskType,
+        MediaType mediaType,
+        RecordingJobService jobService,
+        FakeMediaWatcherFactory factory,
+        FakeSchedulerAdapter scheduler = null,
+        IReadOnlyList<ScheduleEntry> schedules = null)
+    {
+        var configuration = new FakeConfigurationManager
+        {
+            TaskType = taskType,
+            MediumType = mediaType,
+            BackupFolder = @"E:\Backups",
+            DoPastBackups = "0"
+        };
+        var scheduleRepository = new FakeScheduleRepository(schedules ?? Array.Empty<ScheduleEntry>());
+        return new ScheduledBackupService(
+            configuration,
+            jobService,
+            new StubQueryManager(),
+            scheduleRepository,
+            new FakeSchedulerAdapterFactory(scheduler ?? new FakeSchedulerAdapter()),
+            new ScheduleSettingsService(configuration, scheduleRepository),
+            factory);
+    }
+
+    private static async Task WaitUntil(Func<bool> condition)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition())
+            {
+                return;
+            }
+
+            await Task.Delay(10);
+        }
+
+        Assert.Fail("Timed out waiting for condition.");
+    }
+
+    private sealed class FakeMediaWatcherFactory : IMediaWatcherFactory
+    {
+        public FakeMediaWatcher Watcher { get; } = new();
+        public int CreateCount { get; private set; }
+
+        public IMediaWatcher Create()
+        {
+            CreateCount++;
+            return Watcher;
+        }
+    }
+
+    private sealed class FakeMediaWatcher : IMediaWatcher
+    {
+        public event EventHandler<string> DeviceAdded;
+        public int StartWatchingCount { get; private set; }
+        public int StopWatchingCount { get; private set; }
+
+        public void StartWatching() => StartWatchingCount++;
+
+        public void StopWatching() => StopWatchingCount++;
+
+        public void Arrive(string driveLetter) => DeviceAdded?.Invoke(this, driveLetter);
+    }
+
+    private sealed class FakeSchedulerAdapterFactory : ISchedulerAdapterFactory
+    {
+        private readonly ISchedulerAdapter adapter;
+
+        public FakeSchedulerAdapterFactory(ISchedulerAdapter adapter)
+        {
+            this.adapter = adapter;
+        }
+
+        public ISchedulerAdapter Create() => adapter;
+    }
+
+    private sealed class FakeSchedulerAdapter : ISchedulerAdapter
+    {
+        public Action AutoBackup { get; private set; }
+        public Action HourlyBackup { get; private set; }
+
+        public DateTime GetNextRun() => DateTime.MaxValue;
+        public void ScheduleAutoBackup(Action action) => AutoBackup = action;
+        public void ScheduleDaily(Action action, DateTime time) { }
+        public void ScheduleHourly(Action action, DateTime time) => HourlyBackup = action;
+        public void ScheduleMonthly(Action action, DateTime time) { }
+        public void ScheduleOnce(Action action, DateTime time) { }
+        public void ScheduleWeekly(Action action, DateTime time) { }
+        public void Start() { }
+        public void Stop() { }
+    }
+
+    private sealed class FakeScheduleRepository : IScheduleRepository
+    {
+        private readonly IReadOnlyList<ScheduleEntry> schedules;
+
+        public FakeScheduleRepository(IReadOnlyList<ScheduleEntry> schedules)
+        {
+            this.schedules = schedules;
+        }
+
+        public Task<bool> HasScheduleEntriesAsync() => Task.FromResult(schedules.Count > 0);
+        public Task<IReadOnlyList<ScheduleEntry>> GetSchedulesAsync() => Task.FromResult(schedules);
+        public Task ReplaceSchedulesAsync(IEnumerable<ScheduleEntry> _) => Task.CompletedTask;
+    }
+
+    private sealed class RecordingJobService : IJobService
+    {
+        public bool MediaAvailable { get; set; } = true;
+        public int CreateBackupCalls { get; private set; }
+        public string LastBackupTitle { get; private set; }
+
+        public bool IsCancellationRequested => false;
+        public void Cancel() { }
+        public Task<bool> CheckMediaAsync(ActionType action, bool silent = false) => Task.FromResult(MediaAvailable);
+
+        public Task<bool> CreateBackupAsync(string title, string description, bool statusDialog = true, bool fullBackup = false, bool shutdownPC = false, bool shutdownApp = false, string sourceFolders = "")
+        {
+            CreateBackupCalls++;
+            LastBackupTitle = title;
+            return Task.FromResult(MediaAvailable);
+        }
+
+        public Task WaitForBackupAsync(int minimumCalls = 1)
+        {
+            return WaitUntil(() => CreateBackupCalls >= minimumCalls);
+        }
+
+        public Task DeleteBackupAsync(string version, bool statusDialog = true) => Task.CompletedTask;
+        public Task DeleteBackupsAsync(List<string> versions, bool statusDialog = true) => Task.CompletedTask;
+        public Task DeleteSingleFileAsync(string fileFilter, string folderFilter, bool statusDialog = true, IReadOnlyList<int>? versionIds = null) => Task.CompletedTask;
+        public CancellationToken GetNewCancellationToken() => CancellationToken.None;
+        public Task<bool> RequestPassword() => Task.FromResult(true);
+        public Task RestoreBackupAsync(string version, List<string> files, string destination, bool statusDialog = true) => Task.CompletedTask;
+        public Task RestoreBackupAsync(string version, string file, string destination, bool statusDialog = true) => Task.CompletedTask;
+        public Task ModifyBackupAsync(bool statusDialog = true) => Task.CompletedTask;
+    }
+
+    private sealed class StubQueryManager : IQueryManager
+    {
+        public Task<string> GetBackVersionWhereFileAsync(string startVersion, string searchString) => Task.FromResult("");
+        public Task<string> GetBackVersionWhereFilesInFolderAsync(string startVersion, string path) => Task.FromResult("");
+        public string GetFileNameFromDrive(FileTableRow file) => "";
+        public Task<(string, bool)> GetFileNameFromDriveAsync(int versionId, string fileName, string filePath, string password) => Task.FromResult(("", false));
+        public Task<FileDetails> GetFileDetailsAsync(string version, string fileName, string filePath) => Task.FromResult(new FileDetails());
+        public Task<List<FileTableRow>> GetFilesByVersionAsync(string version, string path) => Task.FromResult(new List<FileTableRow>());
+        public Task<List<string>> GetFolderListAsync(string version, string path) => Task.FromResult(new List<string>());
+        public Task<string> GetFullRestoreFolderAsync(string folder, string version) => Task.FromResult("");
+        public Task<VersionDetails> GetLastBackupAsync() => Task.FromResult<VersionDetails>(null);
+        public Task<VersionDetails> GetLastFullBackupAsync() => Task.FromResult<VersionDetails>(null);
+        public Task<string> GetLocalizedPathAsync(string path) => Task.FromResult(path);
+        public Task<string> GetNextVersionWhereFileAsync(string startVersion, string searchString) => Task.FromResult("");
+        public Task<string> GetNextVersionWhereFilesInFolderAsync(string startVersion, string path) => Task.FromResult("");
+        public Task<int> GetNumberOfVersionsAsync() => Task.FromResult(0);
+        public Task<int> GetNumberOfFilesAsync() => Task.FromResult(0);
+        public Task<double> GetTotalFileSizeAsync() => Task.FromResult(0d);
+        public Task<VersionDetails> GetOldestBackupAsync() => Task.FromResult<VersionDetails>(null);
+        public Task<VersionDetails> GetVersionByIdAsync(string id) => Task.FromResult<VersionDetails>(null);
+        public List<VersionDetails> GetVersions(bool desc = true) => new();
+        public Task<List<FileTableRow>> GetVersionsByFileAsync(string fileName, string filePath) => Task.FromResult(new List<FileTableRow>());
+        public Task<List<FileTableRow>> SearchFilesByVersionAsync(string version, string searchTerm, int limit = 500) => Task.FromResult(new List<FileTableRow>());
+        public Task<bool> HasChangesOrNewAsync(string path, string versionId) => Task.FromResult(false);
+    }
+}


### PR DESCRIPTION
Auto and scheduled backups to a local volume now start when that USB target is plugged in, including when the drive was missing at the scheduled instant. FTP targets do not start a local media watcher.

Closes #611

## Test plan
- [ ] Auto + local target: leave the backup drive unplugged until a backup is due, plug it in, and confirm the backup starts
- [ ] Schedule + local target: same arrival-after-miss path
- [ ] FTP target: confirm plugging in a USB drive does not start a backup
- [ ] `dotnet test -p:Platform=x64 --filter "FullyQualifiedName~MediaArrivalBackupWatchTests|FullyQualifiedName~ScheduledBackupServiceTests"`

Made with [Cursor](https://cursor.com)