### PR TITLE
feat: browser and settings polish for beta

### DIFF
--- a/src/BSH.MainApp/Services/BrowserPreviewService.cs
+++ b/src/BSH.MainApp/Services/BrowserPreviewService.cs
@@ -58,6 +58,10 @@ public class BrowserPreviewService : IBrowserPreviewService
 
             if (string.IsNullOrEmpty(localFilePath))
             {
+                await presentationService.ShowMessageBoxAsync(
+                    "Browser_PreviewRetrieveFailed_Title".GetLocalized(),
+                    "Browser_PreviewRetrieveFailed_Text".GetLocalized(),
+                    [new UICommand("MsgBox_OK".GetLocalized())]);
                 return;
             }
 

--- a/src/BSH.MainApp/Strings/de-de/Resources.resw
+++ b/src/BSH.MainApp/Strings/de-de/Resources.resw
@@ -234,6 +234,21 @@ Diese Funktion ist derzeit nicht verfügbar, weil die Schnellvorschau nicht gefu
   <data name="Browser_Search" xml:space="preserve">
     <value>Suchen</value>
   </data>
+  <data name="Browser_Search_Empty_Text" xml:space="preserve">
+    <value>Versuchen Sie einen anderen Dateinamen oder Pfad.</value>
+  </data>
+  <data name="Browser_Search_Empty_Title" xml:space="preserve">
+    <value>Keine Suchergebnisse</value>
+  </data>
+  <data name="Browser_Search_Results" xml:space="preserve">
+    <value>Suchergebnis für "{0}"</value>
+  </data>
+  <data name="Browser_PreviewRetrieveFailed_Text" xml:space="preserve">
+    <value>Die Datei konnte vom Sicherungsmedium nicht abgerufen werden.</value>
+  </data>
+  <data name="Browser_PreviewRetrieveFailed_Title" xml:space="preserve">
+    <value>Vorschau nicht verfügbar</value>
+  </data>
   <data name="Browser_Title.Text" xml:space="preserve">
     <value>Browser</value>
   </data>

--- a/src/BSH.MainApp/Strings/en-us/Resources.resw
+++ b/src/BSH.MainApp/Strings/en-us/Resources.resw
@@ -234,6 +234,21 @@ This feature is currently not available because the quick preview could not be f
   <data name="Browser_Search" xml:space="preserve">
     <value>Search</value>
   </data>
+  <data name="Browser_Search_Empty_Text" xml:space="preserve">
+    <value>Try a different file name or path.</value>
+  </data>
+  <data name="Browser_Search_Empty_Title" xml:space="preserve">
+    <value>No search results</value>
+  </data>
+  <data name="Browser_Search_Results" xml:space="preserve">
+    <value>Search result for "{0}"</value>
+  </data>
+  <data name="Browser_PreviewRetrieveFailed_Text" xml:space="preserve">
+    <value>The file could not be retrieved from the backup medium.</value>
+  </data>
+  <data name="Browser_PreviewRetrieveFailed_Title" xml:space="preserve">
+    <value>Preview not available</value>
+  </data>
   <data name="Browser_Title.Text" xml:space="preserve">
     <value>Browser</value>
   </data>

--- a/src/BSH.MainApp/ViewModels/BrowserViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/BrowserViewModel.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using Brightbits.BSH.Engine;
 using Brightbits.BSH.Engine.Contracts;
 using Brightbits.BSH.Engine.Contracts.Services;
@@ -12,6 +13,7 @@ using BSH.MainApp.Models;
 using BSH.MainApp.ViewModels.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.WinUI;
 
 namespace BSH.MainApp.ViewModels;
 
@@ -60,6 +62,18 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
     private string searchTerms = string.Empty;
 
     [ObservableProperty]
+    private string committedSearchTerms = string.Empty;
+
+    [ObservableProperty]
+    private string searchPathLabel = string.Empty;
+
+    [ObservableProperty]
+    private bool isSearchMode;
+
+    [ObservableProperty]
+    private bool showSearchEmptyState;
+
+    [ObservableProperty]
     private bool toggleInfoPane = false;
 
     [ObservableProperty]
@@ -70,6 +84,8 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
     public ObservableCollection<BrowserFavoriteItem> Favorites { get; set; } = [];
 
     public ObservableCollection<FileOrFolderItem> Items { get; set; } = [];
+
+    public ObservableCollection<FileOrFolderItem> SelectedItems { get; } = [];
 
     public ObservableCollection<VersionDetails> Versions { get; set; } = [];
 
@@ -91,6 +107,7 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
         this.browserDialogService = browserDialogService;
         this.browserPreviewService = browserPreviewService;
         this.viewPreferencesService = viewPreferencesService;
+        SelectedItems.CollectionChanged += OnSelectedItemsChanged;
     }
 
     partial void OnToggleInfoPaneChanged(bool value)
@@ -133,11 +150,18 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
     }
 
     private bool CanUpFolder() => contentMode == BrowserContentMode.Folder && CurrentFolderPath.Count > 1;
-    private bool HasFileOrFolderSelected() => CurrentItem != null && CurrentVersion != null;
+    private bool HasFileOrFolderSelected() => CurrentVersion != null && (SelectedItems.Count > 0 || CurrentItem != null);
     private bool CanRestoreAll() => contentMode == BrowserContentMode.Folder && CurrentVersion != null && CurrentFolderPath.Count > 0;
     private bool HasVersionSelected() => CurrentVersion != null;
     private bool HasFileSelected() => CurrentItem != null && CurrentItem.IsFile;
     private bool HasUserFavoriteSelected() => CurrentFavorite?.IsUserFavorite == true;
+
+    private void OnSelectedItemsChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        RestoreFileCommand.NotifyCanExecuteChanged();
+        RestoreFileToCommand.NotifyCanExecuteChanged();
+        DeleteSelectedContentCommand.NotifyCanExecuteChanged();
+    }
 
     partial void OnSearchTermsChanged(string value)
     {
@@ -146,10 +170,14 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
             return;
         }
 
-        _ = ApplySearchTermsAsync(value);
+        if (string.IsNullOrWhiteSpace(value) && IsSearchMode)
+        {
+            _ = ClearSearchAsync();
+        }
     }
 
-    private async Task ApplySearchTermsAsync(string value)
+    [RelayCommand]
+    private async Task CommitSearch()
     {
         if (CurrentVersion == null)
         {
@@ -157,17 +185,31 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
         }
 
         var requestId = BeginContentRequest();
-        if (string.IsNullOrWhiteSpace(value))
+        if (string.IsNullOrWhiteSpace(SearchTerms))
         {
-            if (CurrentFolderPath.Count > 0)
-            {
-                await LoadFolderAsync(CurrentVersion.Id, CurrentFolderPath[^1].FullPath, requestId);
-            }
-
+            await ClearSearchAsync(requestId);
             return;
         }
 
-        await LoadSearchResultsAsync(CurrentVersion.Id, value, requestId);
+        await LoadSearchResultsAsync(CurrentVersion.Id, SearchTerms.Trim(), requestId);
+    }
+
+    private async Task ClearSearchAsync(long? requestId = null)
+    {
+        if (CurrentVersion == null)
+        {
+            ResetSearchChrome();
+            return;
+        }
+
+        if (CurrentFolderPath.Count > 0)
+        {
+            await LoadFolderAsync(CurrentVersion.Id, CurrentFolderPath[^1].FullPath, requestId ?? BeginContentRequest());
+            return;
+        }
+
+        ResetSearchChrome();
+        Items.Clear();
     }
 
     [RelayCommand(CanExecute = nameof(HasVersionSelected))]
@@ -239,8 +281,8 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
         var favorite = CurrentFavorite;
         var versionId = CurrentVersion.Id;
         var currentFolder = CurrentFolderPath[^1].FullPath;
-        var searchTerms = SearchTerms;
-        var wasSearching = contentMode == BrowserContentMode.Search && !string.IsNullOrWhiteSpace(searchTerms);
+        var searchTerms = CommittedSearchTerms;
+        var wasSearching = IsSearchMode && !string.IsNullOrWhiteSpace(searchTerms);
 
         LoadVersions();
 
@@ -308,19 +350,42 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
 
     private async Task RestoreSelectedAsync(string destination)
     {
-        if (CurrentItem == null || CurrentVersion == null)
+        if (CurrentVersion == null)
         {
             return;
         }
 
-        // RestoreJob treats a path as a single file when Path.GetFileName is non-empty.
-        // Browser folder FullPaths are slash-stripped (e.g. "source\docs"), so folder
-        // restores must be normalized to "\source\docs\" like WinForms.
-        var path = CurrentItem.IsFile
-            ? CurrentItem.FullPath + CurrentItem.Name
-            : ToFolderRestorePath(CurrentItem.FullPath);
+        var items = GetItemsToRestore();
+        if (items.Count == 0)
+        {
+            return;
+        }
 
-        await jobService.RestoreBackupAsync(CurrentVersion.Id, path, destination);
+        var paths = items.Select(ToRestorePath).ToList();
+        if (paths.Count == 1)
+        {
+            await jobService.RestoreBackupAsync(CurrentVersion.Id, paths[0], destination);
+            return;
+        }
+
+        await jobService.RestoreBackupAsync(CurrentVersion.Id, paths, destination);
+    }
+
+    private List<FileOrFolderItem> GetItemsToRestore()
+    {
+        if (SelectedItems.Count > 0)
+        {
+            return [.. SelectedItems];
+        }
+
+        return CurrentItem == null ? [] : [CurrentItem];
+    }
+
+    private static string ToRestorePath(FileOrFolderItem item)
+    {
+        return item.IsFile
+            ? item.FullPath + item.Name
+            : ToFolderRestorePath(item.FullPath);
     }
 
     private async Task RestoreCurrentFolderAsync(string destination)
@@ -641,6 +706,7 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
         }
 
         contentMode = BrowserContentMode.Folder;
+        ResetSearchChrome();
         CurrentItem = null;
         CurrentFolderPath.Clear();
         foreach (var folder in snapshot.FolderPath)
@@ -661,9 +727,32 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
         }
 
         contentMode = BrowserContentMode.Search;
+        IsSearchMode = true;
+        CommittedSearchTerms = searchTerms;
+        SearchPathLabel = FormatSearchPathLabel(searchTerms);
+        ShowSearchEmptyState = fileList.Count == 0;
         CurrentItem = null;
         ReplaceItems(fileList);
         NotifyContentCommandsChanged();
+    }
+
+    private static string FormatSearchPathLabel(string searchTerms)
+    {
+        var format = "Browser_Search_Results".GetLocalized();
+        if (string.IsNullOrEmpty(format) || !format.Contains("{0}", StringComparison.Ordinal))
+        {
+            format = "Search result for \"{0}\"";
+        }
+
+        return string.Format(format, searchTerms);
+    }
+
+    private void ResetSearchChrome()
+    {
+        IsSearchMode = false;
+        ShowSearchEmptyState = false;
+        CommittedSearchTerms = string.Empty;
+        SearchPathLabel = string.Empty;
     }
 
     private long BeginContentRequest() => Interlocked.Increment(ref contentRequestId);
@@ -698,6 +787,8 @@ public partial class BrowserViewModel : ObservableObject, INavigationAware
         UpFolderCommand.NotifyCanExecuteChanged();
         RestoreAllCommand.NotifyCanExecuteChanged();
         RestoreAllToCommand.NotifyCanExecuteChanged();
+        RestoreFileCommand.NotifyCanExecuteChanged();
+        RestoreFileToCommand.NotifyCanExecuteChanged();
         AddFolderToFavoritesCommand.NotifyCanExecuteChanged();
         NavigateToPreviousVersionCommand.NotifyCanExecuteChanged();
         NavigateToNextVersionCommand.NotifyCanExecuteChanged();

--- a/src/BSH.MainApp/ViewModels/SettingsViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/SettingsViewModel.cs
@@ -39,6 +39,7 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
     private readonly IStartupLaunchAdapter startupLaunchAdapter;
     private readonly IUpdateService updateService;
     private bool suppressEnhancedSettingsPersistence;
+    private const string RemindSpaceOffSentinel = "-1";
 
     #region Sources Settings
 
@@ -641,20 +642,21 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
 
     void InitEnhancedSettings()
     {
-        this.EnableNotificationWhenDiskspaceLow = !string.IsNullOrEmpty(this.configurationManager.RemindSpace);
-        this.NotificationWhenDiskspaceLow = int.TryParse(this.configurationManager.RemindSpace, out var diskSpace) ? diskSpace : 0;
-
-        this.EnableDirectoryLocalization = this.configurationManager.ShowLocalizedPath == "1";
-        this.EnableNotificationWhenBackupFinished = this.configurationManager.InfoBackupDone == "1";
-        this.EnableNotificationWhenBackupDeviceNotReady = this.configurationManager.Medium == "1";
-
-        this.EnableNotificationWhenBackupOutdated = !string.IsNullOrEmpty(this.configurationManager.RemindAfterDays);
-        this.NotificationWhenBackupOutdated = int.TryParse(this.configurationManager.RemindAfterDays, out var days) ? days : 0;
-
-        // Load without re-entering the persistence handlers.
         suppressEnhancedSettingsPersistence = true;
         try
         {
+            var remindSpace = this.configurationManager.RemindSpace;
+            var reminderEnabled = int.TryParse(remindSpace, out var diskSpace) && diskSpace >= 0;
+            this.NotificationWhenDiskspaceLow = reminderEnabled ? diskSpace : 0;
+            this.EnableNotificationWhenDiskspaceLow = reminderEnabled;
+
+            this.EnableDirectoryLocalization = this.configurationManager.ShowLocalizedPath == "1";
+            this.EnableNotificationWhenBackupFinished = this.configurationManager.InfoBackupDone == "1";
+            this.EnableNotificationWhenBackupDeviceNotReady = this.configurationManager.Medium == "1";
+
+            this.EnableNotificationWhenBackupOutdated = !string.IsNullOrEmpty(this.configurationManager.RemindAfterDays);
+            this.NotificationWhenBackupOutdated = int.TryParse(this.configurationManager.RemindAfterDays, out var days) ? days : 0;
+
             LaunchAtWindowsStartup = startupLaunchAdapter.IsEnabled();
         }
         finally
@@ -684,7 +686,7 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
 
     partial void OnEnableNotificationWhenDiskspaceLowChanged(bool oldValue, bool newValue)
     {
-        if (oldValue == newValue) return;
+        if (suppressEnhancedSettingsPersistence || oldValue == newValue) return;
 
         if (newValue)
         {
@@ -692,13 +694,13 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
         }
         else
         {
-            this.configurationManager.RemindSpace = string.Empty;
+            this.configurationManager.RemindSpace = RemindSpaceOffSentinel;
         }
     }
 
     partial void OnNotificationWhenDiskspaceLowChanged(int oldValue, int newValue)
     {
-        if (oldValue == newValue) return;
+        if (suppressEnhancedSettingsPersistence || oldValue == newValue) return;
         if (newValue == 0) return;
         this.configurationManager.RemindSpace = newValue.ToString();
     }

--- a/src/BSH.MainApp/ViewModels/SetupViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/SetupViewModel.cs
@@ -50,9 +50,9 @@ public partial class SetupViewModel : ObservableObject
         this.dbClientFactory = dbClientFactory;
 
         FtpPort = "21";
-        FtpEncoding = "UTF8";
+        FtpEncoding = "UTF-8";
         ImportFtpPort = "21";
-        ImportFtpEncoding = "UTF8";
+        ImportFtpEncoding = "UTF-8";
         SelectedTaskType = TaskType.Auto;
         SelectedTargetKind = MediaTargetKind.LocalDrive;
         SelectedImportSourceKind = SetupImportSourceKind.LocalMedia;
@@ -126,7 +126,7 @@ public partial class SetupViewModel : ObservableObject
     private string ftpFolder = "";
 
     [ObservableProperty]
-    private string ftpEncoding = "UTF8";
+    private string ftpEncoding = "UTF-8";
 
     [ObservableProperty]
     private bool ftpEnforceUnencrypted;
@@ -162,7 +162,7 @@ public partial class SetupViewModel : ObservableObject
     private string importFtpFolder = "";
 
     [ObservableProperty]
-    private string importFtpEncoding = "UTF8";
+    private string importFtpEncoding = "UTF-8";
 
     [ObservableProperty]
     private bool importFtpEnforceUnencrypted;

--- a/src/BSH.MainApp/ViewModels/Windows/SwitchStorageViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/Windows/SwitchStorageViewModel.cs
@@ -33,7 +33,7 @@ public partial class SwitchStorageViewModel : ObservableObject
         new(MediaTargetKind.Unc, "Setup_Target_Unc_Title".GetLocalized()),
     ];
 
-    public IReadOnlyList<string> FtpEncodings { get; } = ["ISO-8859-1", "UTF8"];
+    public IReadOnlyList<string> FtpEncodings { get; } = ["ISO-8859-1", "UTF-8"];
 
     [ObservableProperty]
     private MediaTargetOption? selectedMedium;
@@ -75,7 +75,7 @@ public partial class SwitchStorageViewModel : ObservableObject
     private string ftpFolder = string.Empty;
 
     [ObservableProperty]
-    private string ftpEncoding = "UTF8";
+    private string ftpEncoding = "UTF-8";
 
     [ObservableProperty]
     private bool ftpEnforceUnencrypted;
@@ -251,7 +251,7 @@ public partial class SwitchStorageViewModel : ObservableObject
                 FtpUser,
                 FtpPassword,
                 FtpFolder,
-                string.IsNullOrWhiteSpace(FtpEncoding) ? "UTF8" : FtpEncoding,
+                string.IsNullOrWhiteSpace(FtpEncoding) ? "UTF-8" : FtpEncoding,
                 !FtpEnforceUnencrypted,
                 0);
             storage.Open();
@@ -287,7 +287,7 @@ public partial class SwitchStorageViewModel : ObservableObject
             FtpUser,
             FtpPassword,
             FtpFolder,
-            string.IsNullOrWhiteSpace(FtpEncoding) ? "UTF8" : FtpEncoding,
+            string.IsNullOrWhiteSpace(FtpEncoding) ? "UTF-8" : FtpEncoding,
             FtpEnforceUnencrypted);
     }
 

--- a/src/BSH.MainApp/Views/BrowserPage.xaml
+++ b/src/BSH.MainApp/Views/BrowserPage.xaml
@@ -153,7 +153,7 @@
                     </Button>
                 </StackPanel>
 
-                <!-- breadcrumb bar -->
+                <!-- breadcrumb bar / search chrome -->
                 <Grid
                 Grid.Column="1"
                 HorizontalAlignment="Stretch"
@@ -167,17 +167,29 @@
                     Background="Transparent"
                     ItemsSource="{x:Bind ViewModel.CurrentFolderPath, Mode=OneWay}"
                     ItemClicked="BreadcrumbBar_ItemClicked"
-                    VerticalAlignment="Center">
+                    VerticalAlignment="Center"
+                    Visibility="{x:Bind ViewModel.IsSearchMode, Mode=OneWay, Converter={StaticResource VisibilityInvertConverter}}">
                         <BreadcrumbBar.ItemTemplate>
                             <DataTemplate x:DataType="models:FileOrFolderItem">
                                 <TextBlock Text="{x:Bind Name, Mode=OneWay}" />
                             </DataTemplate>
                         </BreadcrumbBar.ItemTemplate>
                     </BreadcrumbBar>
+                    <TextBlock
+                    VerticalAlignment="Center"
+                    TextTrimming="CharacterEllipsis"
+                    Text="{x:Bind ViewModel.SearchPathLabel, Mode=OneWay}"
+                    Visibility="{x:Bind ViewModel.IsSearchMode, Mode=OneWay}" />
                 </Grid>
 
                 <!-- search box -->
-                <TextBox x:Name="tbSearchBox" Grid.Column="2" PlaceholderText="{helpers:ResourceString Name=Browser_Search}" Text="{x:Bind ViewModel.SearchTerms, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <AutoSuggestBox
+                    x:Name="tbSearchBox"
+                    Grid.Column="2"
+                    QueryIcon="Find"
+                    PlaceholderText="{helpers:ResourceString Name=Browser_Search}"
+                    Text="{x:Bind ViewModel.SearchTerms, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                    QuerySubmitted="SearchBox_QuerySubmitted" />
             </Grid>
 
 
@@ -314,49 +326,74 @@
                     </Grid>
 
                     <!-- file and folder list -->
-                    <ScrollViewer Grid.Row="1" VerticalScrollMode="Auto">
-                        <ListView 
-                        ItemsSource="{x:Bind ViewModel.Items, Mode=OneWay}" 
-                        SelectedItem="{x:Bind ViewModel.CurrentItem, Mode=TwoWay}">
-                            <i:Interaction.Behaviors>
-                                <i:EventTriggerBehavior EventName="DoubleTapped">
-                                    <i:InvokeCommandAction Command="{x:Bind ViewModel.LoadFolderCommand}" />
-                                </i:EventTriggerBehavior>
-                            </i:Interaction.Behaviors>
-                            <ListView.HeaderTemplate>
-                                <DataTemplate>
-                                    <Grid Padding="12">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="*"/>
-                                            <ColumnDefinition Width="200"/>
-                                            <ColumnDefinition Width="100"/>
-                                        </Grid.ColumnDefinitions>
-                                        <TextBlock Text="{helpers:ResourceString Name=Browser_Column_Name}" Style="{ThemeResource CaptionTextBlockStyle}"/>
-                                        <TextBlock Grid.Column="1" Text="{helpers:ResourceString Name=Browser_Column_LastModified}" Style="{ThemeResource CaptionTextBlockStyle}"/>
-                                        <TextBlock Grid.Column="2" Text="{helpers:ResourceString Name=Browser_Column_Size}" Style="{ThemeResource CaptionTextBlockStyle}"/>
-                                    </Grid>
-                                </DataTemplate>
-                            </ListView.HeaderTemplate>
-                            <ListView.ItemTemplate>
-                                <DataTemplate x:Name="TableDataTemplate" x:DataType="models:FileOrFolderItem">
-                                    <Grid Height="30">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="*"/>
-                                            <ColumnDefinition Width="200"/>
-                                            <ColumnDefinition Width="100"/>
-                                        </Grid.ColumnDefinitions>
-                                        <StackPanel Orientation="Horizontal">
-                                            <FontIcon Visibility="{x:Bind IsFile, Mode=OneWay, Converter={StaticResource VisibilityInvertConverter}}" VerticalAlignment="Center" FontSize="16" FontFamily="Segoe MDL2 Assets" Glyph="&#xE8B7;" Margin="0,0,10,0" />
-                                            <Image Visibility="{x:Bind IsFile, Mode=OneWay}" Source="{x:Bind Icon16, Mode=OneWay}" Height="16" Width="16" Margin="0,0,10,0" />
-                                            <TextBlock Grid.Column="0" VerticalAlignment="Center" Text="{x:Bind DisplayName, Mode=OneWay}" />
-                                        </StackPanel>
-                                        <TextBlock Visibility="{x:Bind IsFile, Mode=OneWay}" Grid.Column="1" VerticalAlignment="Center" Text="{x:Bind FileDateModified, Mode=OneWay}"/>
-                                        <TextBlock Visibility="{x:Bind IsFile, Mode=OneWay}" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Right" Text="{x:Bind FileSize, Mode=OneWay, Converter={StaticResource FileSizeConverter}}"/>
-                                    </Grid>
-                                </DataTemplate>
-                            </ListView.ItemTemplate>
-                        </ListView>
-                    </ScrollViewer>
+                    <Grid Grid.Row="1">
+                        <ScrollViewer VerticalScrollMode="Auto">
+                            <ListView
+                            x:Name="FilesListView"
+                            SelectionMode="Multiple"
+                            ItemsSource="{x:Bind ViewModel.Items, Mode=OneWay}"
+                            SelectedItem="{x:Bind ViewModel.CurrentItem, Mode=TwoWay}"
+                            SelectionChanged="FilesListView_SelectionChanged"
+                            RightTapped="FilesListView_RightTapped">
+                                <i:Interaction.Behaviors>
+                                    <i:EventTriggerBehavior EventName="DoubleTapped">
+                                        <i:InvokeCommandAction Command="{x:Bind ViewModel.LoadFolderCommand}" />
+                                    </i:EventTriggerBehavior>
+                                </i:Interaction.Behaviors>
+                                <ListView.ContextFlyout>
+                                    <MenuFlyout>
+                                        <MenuFlyoutItem Command="{x:Bind ViewModel.RestoreFileCommand}" Text="{helpers:ResourceString Name=Browser_Restore}" />
+                                        <MenuFlyoutItem Command="{x:Bind ViewModel.RestoreFileToCommand}" Text="{helpers:ResourceString Name=Browser_RestoreTo}" />
+                                        <MenuFlyoutSeparator />
+                                        <MenuFlyoutItem Command="{x:Bind ViewModel.ShowFilePreviewCommand}" Text="{helpers:ResourceString Name=Browser_QuickPreview}" />
+                                        <MenuFlyoutItem Command="{x:Bind ViewModel.ShowFilePropertiesCommand}" Text="{helpers:ResourceString Name=Browser_Properties}" />
+                                        <MenuFlyoutSeparator />
+                                        <MenuFlyoutItem Command="{x:Bind ViewModel.DeleteSelectedContentCommand}" Text="{helpers:ResourceString Name=Browser_DeleteSelectedFromAllBackups}" />
+                                    </MenuFlyout>
+                                </ListView.ContextFlyout>
+                                <ListView.HeaderTemplate>
+                                    <DataTemplate>
+                                        <Grid Padding="12">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="200"/>
+                                                <ColumnDefinition Width="100"/>
+                                            </Grid.ColumnDefinitions>
+                                            <TextBlock Text="{helpers:ResourceString Name=Browser_Column_Name}" Style="{ThemeResource CaptionTextBlockStyle}"/>
+                                            <TextBlock Grid.Column="1" Text="{helpers:ResourceString Name=Browser_Column_LastModified}" Style="{ThemeResource CaptionTextBlockStyle}"/>
+                                            <TextBlock Grid.Column="2" Text="{helpers:ResourceString Name=Browser_Column_Size}" Style="{ThemeResource CaptionTextBlockStyle}"/>
+                                        </Grid>
+                                    </DataTemplate>
+                                </ListView.HeaderTemplate>
+                                <ListView.ItemTemplate>
+                                    <DataTemplate x:Name="TableDataTemplate" x:DataType="models:FileOrFolderItem">
+                                        <Grid Height="30">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="200"/>
+                                                <ColumnDefinition Width="100"/>
+                                            </Grid.ColumnDefinitions>
+                                            <StackPanel Orientation="Horizontal">
+                                                <FontIcon Visibility="{x:Bind IsFile, Mode=OneWay, Converter={StaticResource VisibilityInvertConverter}}" VerticalAlignment="Center" FontSize="16" FontFamily="Segoe MDL2 Assets" Glyph="&#xE8B7;" Margin="0,0,10,0" />
+                                                <Image Visibility="{x:Bind IsFile, Mode=OneWay}" Source="{x:Bind Icon16, Mode=OneWay}" Height="16" Width="16" Margin="0,0,10,0" />
+                                                <TextBlock Grid.Column="0" VerticalAlignment="Center" Text="{x:Bind DisplayName, Mode=OneWay}" />
+                                            </StackPanel>
+                                            <TextBlock Visibility="{x:Bind IsFile, Mode=OneWay}" Grid.Column="1" VerticalAlignment="Center" Text="{x:Bind FileDateModified, Mode=OneWay}"/>
+                                            <TextBlock Visibility="{x:Bind IsFile, Mode=OneWay}" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Right" Text="{x:Bind FileSize, Mode=OneWay, Converter={StaticResource FileSizeConverter}}"/>
+                                        </Grid>
+                                    </DataTemplate>
+                                </ListView.ItemTemplate>
+                            </ListView>
+                        </ScrollViewer>
+                        <StackPanel
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Spacing="8"
+                            Visibility="{x:Bind ViewModel.ShowSearchEmptyState, Mode=OneWay}">
+                            <TextBlock HorizontalAlignment="Center" Style="{StaticResource SubtitleTextBlockStyle}" Text="{helpers:ResourceString Name=Browser_Search_Empty_Title}" />
+                            <TextBlock HorizontalAlignment="Center" Style="{StaticResource BodyTextStyle}" Text="{helpers:ResourceString Name=Browser_Search_Empty_Text}" />
+                        </StackPanel>
+                    </Grid>
 
                     <!-- info pane -->
                     <Grid 

--- a/src/BSH.MainApp/Views/BrowserPage.xaml.cs
+++ b/src/BSH.MainApp/Views/BrowserPage.xaml.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Alexander Seeliger. All Rights Reserved.
 // Licensed under the Apache License, Version 2.0.
 
+using System.Linq;
 using BSH.MainApp.Models;
 using BSH.MainApp.ViewModels;
 
@@ -22,6 +23,35 @@ public sealed partial class BrowserPage : Page
     private async void BreadcrumbBar_ItemClicked(BreadcrumbBar sender, BreadcrumbBarItemClickedEventArgs args)
     {
         await ViewModel.LoadFolderWithParamCommand.ExecuteAsync(args.Item);
+    }
+
+    private async void SearchBox_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
+    {
+        await ViewModel.CommitSearchCommand.ExecuteAsync(null);
+    }
+
+    private void FilesListView_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        ViewModel.SelectedItems.Clear();
+        foreach (var item in FilesListView.SelectedItems.OfType<FileOrFolderItem>())
+        {
+            ViewModel.SelectedItems.Add(item);
+        }
+    }
+
+    private void FilesListView_RightTapped(object sender, RightTappedRoutedEventArgs e)
+    {
+        if (e.OriginalSource is not FrameworkElement { DataContext: FileOrFolderItem item })
+        {
+            return;
+        }
+
+        if (!FilesListView.SelectedItems.Contains(item))
+        {
+            FilesListView.SelectedItem = item;
+        }
+
+        ViewModel.CurrentItem = item;
     }
 
     private void FavoritesListView_RightTapped(object sender, RightTappedRoutedEventArgs e)

--- a/src/BSH.MainApp/Views/SettingsPages/TargetSettingsPage.xaml
+++ b/src/BSH.MainApp/Views/SettingsPages/TargetSettingsPage.xaml
@@ -128,7 +128,7 @@
                                     <TextBlock VerticalAlignment="Center" Grid.Column="0" Grid.Row="3" Text="{helpers:ResourceString Name=Settings_Target_Encoding}" />
                                     <ComboBox Grid.Column="1" Grid.Row="3" HorizontalAlignment="Stretch" SelectedValue="{Binding FtpRemoteEncoding, Mode=TwoWay}">
                                         <x:String>ISO-8859-1</x:String>
-                                        <x:String>UTF8</x:String>
+                                        <x:String>UTF-8</x:String>
                                     </ComboBox>
 
                                     <CheckBox Grid.Column="1" Grid.Row="4" Content="{helpers:ResourceString Name=Settings_Target_EnforceUnencrypted}" IsChecked="{Binding FtpRemoteEnforceUnencrypted, Mode=TwoWay}" />

--- a/src/BSH.Test/BrowserPreviewServiceTests.cs
+++ b/src/BSH.Test/BrowserPreviewServiceTests.cs
@@ -126,7 +126,7 @@ public class BrowserPreviewServiceTests
     }
 
     [Test]
-    public async Task PreviewFileAsync_WhenRetrievedPathIsEmpty_DoesNotLaunch()
+    public async Task PreviewFileAsync_WhenRetrievedPathIsEmpty_ShowsErrorAndDoesNotLaunch()
     {
         var queryManager = new PreviewQueryManager
         {
@@ -139,7 +139,9 @@ public class BrowserPreviewServiceTests
         await service.PreviewFileAsync("2", "report.txt", @"\source\docs\");
 
         Assert.That(host.ShownFiles, Is.Empty);
-        Assert.That(presentation.MessageBoxes, Is.Empty);
+        Assert.That(presentation.MessageBoxes, Has.Count.EqualTo(1));
+        Assert.That(presentation.MessageBoxes[0].Title, Is.Null.Or.Empty.Or.EqualTo("Browser_PreviewRetrieveFailed_Title"));
+        Assert.That(presentation.MessageBoxes[0].Content, Is.Null.Or.Empty.Or.EqualTo("Browser_PreviewRetrieveFailed_Text"));
     }
 
     [Test]

--- a/src/BSH.Test/BrowserViewModelTests.cs
+++ b/src/BSH.Test/BrowserViewModelTests.cs
@@ -291,6 +291,61 @@ public class BrowserViewModelTests
         Assert.That(jobService.RestoreCalls.Single(), Is.EqualTo(("2", @"\source\docs\", "")));
     }
 
+    [Test]
+    public async Task RestoreFileCommand_RestoresSeveralSelectedFilesAndFoldersInOneJob()
+    {
+        var jobService = new BrowserJobService();
+        var viewModel = CreateViewModel(jobService: jobService);
+        viewModel.CurrentVersion = Version("2");
+        viewModel.SelectedItems.Add(new FileOrFolderItem { Name = "report.txt", FullPath = @"\source\docs\", IsFile = true });
+        viewModel.SelectedItems.Add(new FileOrFolderItem { Name = "notes", FullPath = @"source\notes", IsFile = false });
+
+        await viewModel.RestoreFileCommand.ExecuteAsync(null);
+
+        Assert.That(jobService.BatchRestoreCalls, Has.Count.EqualTo(1));
+        Assert.That(jobService.BatchRestoreCalls[0].Version, Is.EqualTo("2"));
+        Assert.That(jobService.BatchRestoreCalls[0].Destination, Is.EqualTo(""));
+        Assert.That(jobService.BatchRestoreCalls[0].Files, Is.EqualTo(new[] { @"\source\docs\report.txt", @"\source\notes\" }));
+        Assert.That(jobService.SingleRestoreCalls, Is.Empty);
+    }
+
+    [Test]
+    public async Task SearchTermsChange_DoesNotQueryUntilSearchIsCommitted()
+    {
+        var queryManager = new BrowserQueryManager();
+        var viewModel = CreateViewModel(queryManager);
+        viewModel.CurrentVersion = Version("2");
+        viewModel.CurrentFolderPath.Add(new FileOrFolderItem { Name = "docs", FullPath = @"source\docs", IsFile = false });
+
+        viewModel.SearchTerms = "report";
+        await Task.Delay(50);
+
+        Assert.That(queryManager.SearchCalls, Is.Empty);
+
+        await viewModel.CommitSearchCommand.ExecuteAsync(null);
+
+        Assert.That(queryManager.SearchCalls.Single(), Is.EqualTo(("2", "report")));
+        Assert.That(viewModel.IsSearchMode, Is.True);
+        Assert.That(viewModel.CommittedSearchTerms, Is.EqualTo("report"));
+        Assert.That(viewModel.SearchPathLabel, Does.Contain("report"));
+    }
+
+    [Test]
+    public async Task CommitSearch_WhenNoFilesMatch_ShowsSearchEmptyState()
+    {
+        var queryManager = new BrowserQueryManager { SearchResults = [] };
+        var viewModel = CreateViewModel(queryManager);
+        viewModel.CurrentVersion = Version("2");
+        viewModel.SearchTerms = "missing-file";
+
+        await viewModel.CommitSearchCommand.ExecuteAsync(null);
+
+        Assert.That(viewModel.IsSearchMode, Is.True);
+        Assert.That(viewModel.ShowSearchEmptyState, Is.True);
+        Assert.That(viewModel.Items, Is.Empty);
+        Assert.That(viewModel.SearchPathLabel, Does.Contain("missing-file"));
+    }
+
     private static BrowserViewModel CreateViewModel(
         BrowserQueryManager? queryManager = null,
         BrowserJobService? jobService = null,
@@ -361,7 +416,14 @@ public class BrowserViewModelTests
         }
 
         public Task<List<FileTableRow>> GetVersionsByFileAsync(string fileName, string filePath) => Task.FromResult(new List<FileTableRow>());
-        public Task<List<FileTableRow>> SearchFilesByVersionAsync(string version, string searchTerm, int limit = 500) => Task.FromResult(new List<FileTableRow>());
+        public List<FileTableRow> SearchResults { get; set; } = [];
+        public List<(string Version, string SearchTerm)> SearchCalls { get; } = [];
+
+        public Task<List<FileTableRow>> SearchFilesByVersionAsync(string version, string searchTerm, int limit = 500)
+        {
+            SearchCalls.Add((version, searchTerm));
+            return Task.FromResult(SearchResults);
+        }
         public Task<bool> HasChangesOrNewAsync(string path, string versionId) => Task.FromResult(false);
     }
 
@@ -370,6 +432,8 @@ public class BrowserViewModelTests
         public List<(string FileFilter, string FolderFilter, IReadOnlyList<int>? VersionIds)> DeleteSingleCalls { get; } = [];
         public List<List<string>> DeleteBackupsCalls { get; } = [];
         public List<(string Version, string File, string Destination)> RestoreCalls { get; } = [];
+        public List<(string Version, string File, string Destination)> SingleRestoreCalls { get; } = [];
+        public List<(string Version, IReadOnlyList<string> Files, string Destination)> BatchRestoreCalls { get; } = [];
         public bool IsCancellationRequested => false;
         public void Cancel() { }
         public Task<bool> CheckMediaAsync(ActionType action, bool silent = false) => Task.FromResult(true);
@@ -385,6 +449,7 @@ public class BrowserViewModelTests
         public Task<bool> RequestPassword() => Task.FromResult(true);
         public Task RestoreBackupAsync(string version, List<string> files, string destination, bool statusDialog = true)
         {
+            BatchRestoreCalls.Add((version, files, destination));
             foreach (var file in files)
             {
                 RestoreCalls.Add((version, file, destination));
@@ -395,6 +460,7 @@ public class BrowserViewModelTests
 
         public Task RestoreBackupAsync(string version, string file, string destination, bool statusDialog = true)
         {
+            SingleRestoreCalls.Add((version, file, destination));
             RestoreCalls.Add((version, file, destination));
             return Task.CompletedTask;
         }

--- a/src/BSH.Test/SettingsViewModelTests.cs
+++ b/src/BSH.Test/SettingsViewModelTests.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Threading.Tasks;
+using BSH.MainApp.Contracts.Services;
+using BSH.MainApp.ViewModels;
+using BSH.Test.Fakes;
+using NUnit.Framework;
+
+namespace BSH.Test;
+
+public class SettingsViewModelTests
+{
+    [Test]
+    public void MigratedWinFormsOffSentinel_LeavesLowDiskReminderDisabled()
+    {
+        var configuration = new FakeConfigurationManager { RemindSpace = "-1" };
+        var viewModel = CreateViewModel(configuration);
+
+        viewModel.OnNavigatedTo(null);
+
+        Assert.That(viewModel.EnableNotificationWhenDiskspaceLow, Is.False);
+        Assert.That(viewModel.NotificationWhenDiskspaceLow, Is.GreaterThanOrEqualTo(0));
+        Assert.That(configuration.RemindSpace, Is.EqualTo("-1"));
+    }
+
+    [Test]
+    public void TurningOffLowDiskReminder_StoresWinFormsOffSentinel()
+    {
+        var configuration = new FakeConfigurationManager { RemindSpace = "10" };
+        var viewModel = CreateViewModel(configuration);
+
+        viewModel.OnNavigatedTo(null);
+        Assert.That(viewModel.EnableNotificationWhenDiskspaceLow, Is.True);
+
+        viewModel.EnableNotificationWhenDiskspaceLow = false;
+
+        Assert.That(configuration.RemindSpace, Is.EqualTo("-1"));
+    }
+
+    private static SettingsViewModel CreateViewModel(FakeConfigurationManager configuration)
+    {
+        return new SettingsViewModel(
+            configuration,
+            presentationService: null!,
+            jobService: null!,
+            queryManager: null!,
+            backupTargetService: null!,
+            switchStorageService: null!,
+            orchestrationService: null!,
+            new StubStartupLaunchAdapter(),
+            new StubUpdateService());
+    }
+
+    private sealed class StubStartupLaunchAdapter : IStartupLaunchAdapter
+    {
+        public bool IsEnabled() => false;
+
+        public bool TrySetEnabled(bool enabled) => true;
+    }
+
+    private sealed class StubUpdateService : IUpdateService
+    {
+        public Task InitializeAsync(Action onApplicationExitRequested) => Task.CompletedTask;
+
+        public Task CheckAsync(bool notifyWhenUpToDate) => Task.CompletedTask;
+
+        public Task MaybeCheckOnStartupAsync() => Task.CompletedTask;
+
+        public Task<bool> GetAutoSearchEnabledAsync() => Task.FromResult(true);
+
+        public Task SetAutoSearchEnabledAsync(bool enabled) => Task.CompletedTask;
+
+        public Task<bool> GetDownloadBetaAsync() => Task.FromResult(false);
+
+        public Task SetDownloadBetaAsync(bool enabled) => Task.CompletedTask;
+
+        public Task<string> ResetUniqueUserIdAsync() => Task.FromResult(string.Empty);
+    }
+}

--- a/src/BSH.Test/SetupViewModelTests.cs
+++ b/src/BSH.Test/SetupViewModelTests.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using BSH.MainApp.ViewModels;
+using BSH.Test.Fakes;
+using NUnit.Framework;
+
+namespace BSH.Test;
+
+public class SetupViewModelTests
+{
+    [Test]
+    public void NewFtpConfiguration_DefaultsToUtf8NoBomEncoding()
+    {
+        var viewModel = new SetupViewModel(
+            new FakeConfigurationManager(),
+            setupService: null!,
+            orchestrationService: null!,
+            jobService: null!,
+            navigationService: null!,
+            presentationService: null!);
+
+        Assert.That(viewModel.FtpEncoding, Is.EqualTo("UTF-8"));
+        Assert.That(viewModel.ImportFtpEncoding, Is.EqualTo("UTF-8"));
+    }
+}


### PR DESCRIPTION
The WinUI backup browser can restore several selected files or folders in one job, offers a file-list context menu, and searches only when the user presses Enter or the search action. Preview now reports when a blob cannot be retrieved, new FTP configs store UTF-8 so the engine uses no-BOM encoding, and turning off the low-disk reminder uses the WinForms `-1` sentinel so migrated configs display correctly.

Closes #614

## Test plan
- [ ] Select several files and folders in the browser and restore them in one job
- [ ] Right-click a file and use restore, preview, properties, and delete
- [ ] Type a search without pressing Enter (list should not change), then press Enter; empty results show the search empty state and the path chrome shows the query
- [ ] Preview a file that cannot be retrieved from the medium and confirm an error is shown
- [ ] Create a new FTP configuration and confirm encoding is UTF-8
- [ ] Turn off the low-disk reminder and confirm a WinForms-migrated `-1` config stays off
- [ ] `dotnet test -p:Platform=x64 --filter "FullyQualifiedName~BrowserViewModelTests|FullyQualifiedName~BrowserPreviewServiceTests|FullyQualifiedName~SettingsViewModelTests|FullyQualifiedName~SetupViewModelTests"`

Made with [Cursor](https://cursor.com)