### PR TITLE
fix: persist FTP, encryption mode, and media-type apply

### DIFF
--- a/src/BSH.Engine/Services/MediaTargetApplier.cs
+++ b/src/BSH.Engine/Services/MediaTargetApplier.cs
@@ -70,6 +70,20 @@ public static class MediaTargetApplier
     }
 
     /// <summary>
+    /// Sets MediumType to LocalDevice with no folder and clears UNC credentials and FTP fields.
+    /// </summary>
+    public static void ApplyEmptyLocalTarget(IConfigurationManager configurationManager)
+    {
+        ArgumentNullException.ThrowIfNull(configurationManager);
+
+        configurationManager.MediumType = MediaType.LocalDevice;
+        configurationManager.BackupFolder = "";
+        configurationManager.MediaVolumeSerial = "";
+        ClearUncCredentials(configurationManager);
+        ClearFtpFields(configurationManager);
+    }
+
+    /// <summary>
     /// Sets BackupFolder + MediaVolumeSerial and clears UNC credentials and FTP fields (LocalDevice).
     /// </summary>
     public static void ApplyLocalTarget(

--- a/src/BSH.MainApp/ViewModels/SettingsViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/SettingsViewModel.cs
@@ -39,6 +39,7 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
     private readonly IStartupLaunchAdapter startupLaunchAdapter;
     private readonly IUpdateService updateService;
     private bool suppressEnhancedSettingsPersistence;
+    private bool suppressTargetSettingsPersistence;
 
     #region Sources Settings
 
@@ -192,9 +193,37 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
 
     private void InitTargetSettings()
     {
-        // selected media type
-        this.SelectedMediaType = this.configurationManager.MediumType;
+        suppressTargetSettingsPersistence = true;
+        try
+        {
+            // selected media type
+            this.SelectedMediaType = this.configurationManager.MediumType;
+            UpdateTargetVisibility();
 
+            // local device
+            this.LocalDevicePath = this.configurationManager.BackupFolder;
+            this.LocalUNCUser = this.configurationManager.UNCUsername;
+            this.LocalUNCPassword = DecryptConfigurationPassword(this.configurationManager.UNCPassword);
+
+            // ftp remote
+            this.FtpRemoteHost = this.configurationManager.FtpHost;
+            this.FtpRemotePort = string.IsNullOrEmpty(this.configurationManager.FtpPort) ? 21 : int.Parse(this.configurationManager.FtpPort);
+            this.FtpRemoteUser = this.configurationManager.FtpUser;
+            this.FtpRemotePassword = this.configurationManager.FtpPass;
+            this.FtpRemotePath = this.configurationManager.FtpFolder;
+            this.FtpRemoteEncoding = this.configurationManager.FtpCoding;
+
+            // FtpStorage treats mode "3" as encrypted (AutoConnect); anything else is plain FTP.
+            this.FtpRemoteEnforceUnencrypted = this.configurationManager.FtpEncryptionMode != "3";
+        }
+        finally
+        {
+            suppressTargetSettingsPersistence = false;
+        }
+    }
+
+    private void UpdateTargetVisibility()
+    {
         if (SelectedMediaType == MediaType.LocalDevice)
         {
             this.FtpRemoteVisibility = Visibility.Collapsed;
@@ -205,22 +234,11 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
             this.FtpRemoteVisibility = Visibility.Visible;
             this.LocalDeviceVisibility = Visibility.Collapsed;
         }
+    }
 
-        // local device
-        this.LocalDevicePath = this.configurationManager.BackupFolder;
-        this.LocalUNCUser = this.configurationManager.UNCUsername;
-        this.LocalUNCPassword = DecryptConfigurationPassword(this.configurationManager.UNCPassword);
-
-        // ftp remote
-        this.FtpRemoteHost = this.configurationManager.FtpHost;
-        this.FtpRemotePort = string.IsNullOrEmpty(this.configurationManager.FtpPort) ? 21 : int.Parse(this.configurationManager.FtpPort);
-        this.FtpRemoteUser = this.configurationManager.FtpUser;
-        this.FtpRemotePassword = this.configurationManager.FtpPass;
-        this.FtpRemotePath = this.configurationManager.FtpFolder;
-        this.FtpRemoteEncoding = this.configurationManager.FtpCoding;
-
-        // FtpStorage treats mode "3" as encrypted (AutoConnect); anything else is plain FTP.
-        this.FtpRemoteEnforceUnencrypted = this.configurationManager.FtpEncryptionMode != "3";
+    public (string Host, int Port, string User, string Password, string Path, string Encoding) GetDisplayedFtpConnectionValues()
+    {
+        return (FtpRemoteHost, FtpRemotePort, FtpRemoteUser, FtpRemotePassword, FtpRemotePath, FtpRemoteEncoding);
     }
 
     public static string GetMediaTypeDisplayName(MediaType mediaType)
@@ -238,8 +256,8 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
     [RelayCommand(CanExecute = nameof(CanExecuteCheckFtpRemote))]
     public async Task CheckFtpRemote()
     {
-        // check FTP
-        var profile = FtpStorage.CheckConnection(FtpRemoteHost, FtpRemotePort, FtpRemoteUser, FtpRemotePassword, FtpRemotePath, FtpRemoteEncoding);
+        var probe = GetDisplayedFtpConnectionValues();
+        var profile = FtpStorage.CheckConnection(probe.Host, probe.Port, probe.User, probe.Password, probe.Path, probe.Encoding);
 
         if (profile)
         {
@@ -314,18 +332,8 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
         await this.jobService.DeleteBackupsAsync(versions);
 
         SelectedMediaType = newValue;
-        this.configurationManager.MediumType = newValue;
-
-        if (newValue == MediaType.LocalDevice)
-        {
-            this.FtpRemoteVisibility = Visibility.Collapsed;
-            this.LocalDeviceVisibility = Visibility.Visible;
-        }
-        else
-        {
-            this.FtpRemoteVisibility = Visibility.Visible;
-            this.LocalDeviceVisibility = Visibility.Collapsed;
-        }
+        ApplyCurrentBackupTarget();
+        UpdateTargetVisibility();
     }
 
     partial void OnLocalUNCUserChanged(string? oldValue, string newValue)
@@ -349,46 +357,115 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
     partial void OnFtpRemoteHostChanged(string? oldValue, string newValue)
     {
         if (oldValue == null || oldValue == newValue) return;
-        this.configurationManager.FtpHost = newValue;
+        PersistFtpTargetIfSelected();
         CheckFtpRemoteCommand.NotifyCanExecuteChanged();
     }
 
     partial void OnFtpRemotePortChanged(int oldValue, int newValue)
     {
         if (oldValue == newValue) return;
-        this.configurationManager.FtpPort = newValue.ToString();
+        PersistFtpTargetIfSelected();
     }
 
     partial void OnFtpRemoteUserChanged(string? oldValue, string newValue)
     {
         if (oldValue == null || oldValue == newValue) return;
-        this.configurationManager.FtpUser = newValue;
+        PersistFtpTargetIfSelected();
         CheckFtpRemoteCommand.NotifyCanExecuteChanged();
     }
 
     partial void OnFtpRemotePasswordChanged(string? oldValue, string newValue)
     {
         if (oldValue == null || oldValue == newValue) return;
-        this.configurationManager.FtpPass = newValue;
+        PersistFtpTargetIfSelected();
         CheckFtpRemoteCommand.NotifyCanExecuteChanged();
     }
 
     partial void OnFtpRemotePathChanged(string? oldValue, string newValue)
     {
         if (oldValue == null || oldValue == newValue) return;
-        this.configurationManager.FtpFolder = newValue;
+        PersistFtpTargetIfSelected();
     }
 
     partial void OnFtpRemoteEncodingChanged(string? oldValue, string newValue)
     {
         if (oldValue == null || oldValue == newValue) return;
-        this.configurationManager.FtpCoding = newValue;
+        PersistFtpTargetIfSelected();
     }
 
     partial void OnFtpRemoteEnforceUnencryptedChanged(bool oldValue, bool newValue)
     {
         if (oldValue == newValue) return;
-        this.configurationManager.FtpEncryptionMode = newValue ? "0" : "3";
+        PersistFtpTargetIfSelected();
+    }
+
+    private void PersistFtpTargetIfSelected()
+    {
+        if (suppressTargetSettingsPersistence || SelectedMediaType != MediaType.FileTransferServer)
+        {
+            return;
+        }
+
+        ApplyFtpTargetFromPage();
+    }
+
+    private void ApplyCurrentBackupTarget()
+    {
+        if (suppressTargetSettingsPersistence || SelectedMediaType == MediaType.Unset)
+        {
+            return;
+        }
+
+        if (SelectedMediaType == MediaType.FileTransferServer)
+        {
+            ApplyFtpTargetFromPage();
+            return;
+        }
+
+        ApplyLocalTargetFromPage();
+    }
+
+    private void ApplyFtpTargetFromPage()
+    {
+        MediaTargetApplier.ApplyFtpTarget(
+            this.configurationManager,
+            FtpRemoteHost,
+            FtpRemotePort <= 0 ? "21" : FtpRemotePort.ToString(),
+            FtpRemoteUser,
+            FtpRemotePassword,
+            NormalizeFtpFolder(FtpRemotePath),
+            FtpRemoteEncoding,
+            encryptionMode: FtpRemoteEnforceUnencrypted ? "0" : "3",
+            sslProtocols: "0");
+    }
+
+    private void ApplyLocalTargetFromPage()
+    {
+        if (MediaTargetApplier.IsUncPath(LocalDevicePath))
+        {
+            MediaTargetApplier.ApplyUncTarget(
+                this.configurationManager,
+                LocalDevicePath,
+                LocalUNCUser,
+                LocalUNCPassword);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(LocalDevicePath))
+        {
+            MediaTargetApplier.ApplyEmptyLocalTarget(this.configurationManager);
+            return;
+        }
+
+        MediaTargetApplier.ApplyLocalTarget(
+            this.configurationManager,
+            LocalDevicePath,
+            MediaTargetApplier.ResolveVolumeSerial(LocalDevicePath));
+    }
+
+    private static string NormalizeFtpFolder(string? path)
+    {
+        return string.IsNullOrEmpty(path) ? "" : FtpStorage.GetFtpPath(path);
     }
 
     public void UseLocalPath(string folderPath)
@@ -467,20 +544,23 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(DisableEncryptionCommand))]
+    [NotifyPropertyChangedFor(nameof(CanSelectNonEncryptionMode))]
     private ModeType modeType = ModeType.Unset;
 
     [ObservableProperty]
     private bool waitForDevice;
 
+    public bool CanSelectNonEncryptionMode => ModeType != ModeType.Encryption;
+
     private void InitOptionsSettings()
     {
-        if (this.configurationManager.Compression == 1)
-        {
-            this.ModeType = ModeType.Compression;
-        }
-        else if (this.configurationManager.Encrypt == 1)
+        if (this.configurationManager.Encrypt == 1)
         {
             this.ModeType = ModeType.Encryption;
+        }
+        else if (this.configurationManager.Compression == 1)
+        {
+            this.ModeType = ModeType.Compression;
         }
         else
         {
@@ -512,6 +592,15 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
             return;
         }
 
+        if (oldValue == ModeType.Encryption && newValue != ModeType.Encryption)
+        {
+            await DisableEncryption();
+            if (this.configurationManager.Encrypt == 1)
+            {
+                return;
+            }
+        }
+
         if (newValue == ModeType.Compression)
         {
             ModeType = newValue;
@@ -530,6 +619,7 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
             ModeType = newValue;
             this.configurationManager.EncryptPassMD5 = Hash.GetMD5Hash(password);
             this.configurationManager.Encrypt = 1;
+            this.configurationManager.Compression = 0;
         }
         else
         {
@@ -542,7 +632,7 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
     [RelayCommand(CanExecute = nameof(CanDisableEncryption))]
     private async Task DisableEncryption()
     {
-        if (!await this.jobService.CheckMediaAsync(ActionType.Delete))
+        if (!await this.jobService.CheckMediaAsync(ActionType.Restore))
         {
             return;
         }
@@ -832,6 +922,7 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
 
     public void OnNavigatedFrom()
     {
+        ApplyCurrentBackupTarget();
     }
 
     public void OnNavigatedTo(object parameter)

--- a/src/BSH.MainApp/ViewModels/SettingsViewModel.cs
+++ b/src/BSH.MainApp/ViewModels/SettingsViewModel.cs
@@ -396,7 +396,64 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
     partial void OnFtpRemoteEnforceUnencryptedChanged(bool oldValue, bool newValue)
     {
         if (oldValue == newValue) return;
+
+        // Disabling FTP encryption (enforce unencrypted) must delete backups first.
+        if (newValue)
+        {
+            return;
+        }
+
         PersistFtpTargetIfSelected();
+    }
+
+    public async Task ChangeFtpRemoteEnforceUnencryptedAsync(bool enforceUnencrypted)
+    {
+        var currentlyUnencrypted = this.configurationManager.FtpEncryptionMode != "3";
+        if (enforceUnencrypted == currentlyUnencrypted && FtpRemoteEnforceUnencrypted == enforceUnencrypted)
+        {
+            return;
+        }
+
+        if (enforceUnencrypted)
+        {
+            if (!await TryDeleteAllBackupsWithMediaCheckAsync())
+            {
+                RevertFtpRemoteEnforceUnencrypted(false);
+                return;
+            }
+
+            FtpRemoteEnforceUnencrypted = true;
+            PersistFtpTargetIfSelected();
+            return;
+        }
+
+        FtpRemoteEnforceUnencrypted = false;
+        PersistFtpTargetIfSelected();
+    }
+
+    private void RevertFtpRemoteEnforceUnencrypted(bool enforceUnencrypted)
+    {
+        suppressTargetSettingsPersistence = true;
+        try
+        {
+            FtpRemoteEnforceUnencrypted = enforceUnencrypted;
+        }
+        finally
+        {
+            suppressTargetSettingsPersistence = false;
+        }
+    }
+
+    private async Task<bool> TryDeleteAllBackupsWithMediaCheckAsync()
+    {
+        if (!await this.jobService.CheckMediaAsync(ActionType.Delete))
+        {
+            return false;
+        }
+
+        var versions = this.queryManager.GetVersions().Select(x => x.Id).ToList();
+        await this.jobService.DeleteBackupsAsync(versions);
+        return true;
     }
 
     private void PersistFtpTargetIfSelected()
@@ -632,6 +689,19 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
     [RelayCommand(CanExecute = nameof(CanDisableEncryption))]
     private async Task DisableEncryption()
     {
+        if (this.configurationManager.MediumType == MediaType.FileTransferServer)
+        {
+            if (!await TryDeleteAllBackupsWithMediaCheckAsync())
+            {
+                return;
+            }
+
+            this.configurationManager.Encrypt = 0;
+            this.configurationManager.EncryptPassMD5 = "";
+            InitOptionsSettings();
+            return;
+        }
+
         if (!await this.jobService.CheckMediaAsync(ActionType.Restore))
         {
             return;

--- a/src/BSH.MainApp/Views/SettingsPages/OptionsSettingsPage.xaml
+++ b/src/BSH.MainApp/Views/SettingsPages/OptionsSettingsPage.xaml
@@ -48,6 +48,7 @@
                                 <StackPanel Margin="-12,0,0,0" Orientation="Vertical">
                                     <RadioButton x:Name="RegularCopyRadioButton"
                                                  IsChecked="{Binding ModeType, Mode=OneWay, Converter={StaticResource EnumComparisonConverter}, ConverterParameter={StaticResource ModeType_RegularCopy}}"
+                                                 IsEnabled="{Binding CanSelectNonEncryptionMode}"
                                                  Checked="ModeTypeRadioButton_Checked"
                                                  Content="{helpers:ResourceString Name=Settings_Options_NoCompressionOrEncryption}" />
                                 </StackPanel>
@@ -59,6 +60,7 @@
                                 <StackPanel Margin="-12,0,0,0" Orientation="Vertical">
                                     <RadioButton x:Name="CompressionRadioButton"
                                                  IsChecked="{Binding ModeType, Mode=OneWay, Converter={StaticResource EnumComparisonConverter}, ConverterParameter={StaticResource ModeType_Compression}}"
+                                                 IsEnabled="{Binding CanSelectNonEncryptionMode}"
                                                  Checked="ModeTypeRadioButton_Checked"
                                                  Content="{helpers:ResourceString Name=Settings_Options_Compress}" />
                                     <TextBlock Margin="29,0,0,0" TextWrapping="WrapWholeWords"

--- a/src/BSH.MainApp/Views/SettingsPages/TargetSettingsPage.xaml
+++ b/src/BSH.MainApp/Views/SettingsPages/TargetSettingsPage.xaml
@@ -131,7 +131,12 @@
                                         <x:String>UTF8</x:String>
                                     </ComboBox>
 
-                                    <CheckBox Grid.Column="1" Grid.Row="4" Content="{helpers:ResourceString Name=Settings_Target_EnforceUnencrypted}" IsChecked="{Binding FtpRemoteEnforceUnencrypted, Mode=TwoWay}" />
+                                    <CheckBox x:Name="FtpEnforceUnencryptedCheckBox"
+                                              Grid.Column="1"
+                                              Grid.Row="4"
+                                              Content="{helpers:ResourceString Name=Settings_Target_EnforceUnencrypted}"
+                                              IsChecked="{Binding FtpRemoteEnforceUnencrypted, Mode=OneWay}"
+                                              Click="FtpEnforceUnencryptedCheckBox_Click" />
 
                                     <Button Grid.Column="1" Grid.Row="5" Command="{Binding CheckFtpRemoteCommand}">
                                         <StackPanel Orientation="Horizontal" Spacing="8">

--- a/src/BSH.MainApp/Views/SettingsPages/TargetSettingsPage.xaml
+++ b/src/BSH.MainApp/Views/SettingsPages/TargetSettingsPage.xaml
@@ -113,17 +113,17 @@
                                     </Grid.RowDefinitions>
 
                                     <TextBlock VerticalAlignment="Center" Grid.Column="0" Grid.Row="0" Text="{helpers:ResourceString Name=Settings_Target_Server}" />
-                                    <TextBox Grid.Column="1" Text="{Binding FtpRemoteHost}" />
+                                    <TextBox Grid.Column="1" Text="{Binding FtpRemoteHost, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                                     <TextBlock VerticalAlignment="Center" Grid.Column="2" Grid.Row="0" Text="{helpers:ResourceString Name=Settings_Target_Port}" />
-                                    <NumberBox Grid.Column="3" Grid.Row="0" Value="{Binding FtpRemotePort}" />
+                                    <NumberBox Grid.Column="3" Grid.Row="0" Value="{Binding FtpRemotePort, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
                                     <TextBlock VerticalAlignment="Center" Grid.Column="0" Grid.Row="1" Text="{helpers:ResourceString Name=Settings_Target_Username}" />
-                                    <TextBox Grid.Column="1" Grid.Row="1"  Text="{Binding FtpRemoteUser}" />
+                                    <TextBox Grid.Column="1" Grid.Row="1" Text="{Binding FtpRemoteUser, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                                     <TextBlock VerticalAlignment="Center" Grid.Column="2" Grid.Row="1" Text="{helpers:ResourceString Name=Settings_Target_Password}" />
-                                    <PasswordBox Grid.Column="3" Grid.Row="1" Password="{Binding FtpRemotePassword}" />
+                                    <PasswordBox Grid.Column="3" Grid.Row="1" Password="{Binding FtpRemotePassword, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
                                     <TextBlock VerticalAlignment="Center" Grid.Column="0" Grid.Row="2" Text="{helpers:ResourceString Name=Settings_Target_Path}" />
-                                    <TextBox Grid.Column="1" Grid.ColumnSpan="3" Grid.Row="2"  Text="{Binding FtpRemotePath}" />
+                                    <TextBox Grid.Column="1" Grid.ColumnSpan="3" Grid.Row="2" Text="{Binding FtpRemotePath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
                                     <TextBlock VerticalAlignment="Center" Grid.Column="0" Grid.Row="3" Text="{helpers:ResourceString Name=Settings_Target_Encoding}" />
                                     <ComboBox Grid.Column="1" Grid.Row="3" HorizontalAlignment="Stretch" SelectedValue="{Binding FtpRemoteEncoding, Mode=TwoWay}">

--- a/src/BSH.MainApp/Views/SettingsPages/TargetSettingsPage.xaml.cs
+++ b/src/BSH.MainApp/Views/SettingsPages/TargetSettingsPage.xaml.cs
@@ -28,4 +28,21 @@ public sealed partial class TargetSettingsPage : Page
         await viewModel.ChangeSelectedMediaTypeAsync(mediaType);
         MediaTypeComboBox.SelectedItem = viewModel.SelectedMediaType;
     }
+
+    private async void FtpEnforceUnencryptedCheckBox_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+    {
+        if (DataContext is not SettingsViewModel viewModel)
+        {
+            return;
+        }
+
+        var requested = FtpEnforceUnencryptedCheckBox.IsChecked == true;
+        if (requested == viewModel.FtpRemoteEnforceUnencrypted)
+        {
+            return;
+        }
+
+        await viewModel.ChangeFtpRemoteEnforceUnencryptedAsync(requested);
+        FtpEnforceUnencryptedCheckBox.IsChecked = viewModel.FtpRemoteEnforceUnencrypted;
+    }
 }

--- a/src/BSH.Test/MediaTargetApplierTests.cs
+++ b/src/BSH.Test/MediaTargetApplierTests.cs
@@ -95,6 +95,41 @@ public class MediaTargetApplierTests
     }
 
     [Test]
+    public void ApplyEmptyLocalTarget_ClearsFolderSerialUncAndFtpFields()
+    {
+        var configuration = new FakeConfigurationManager
+        {
+            MediumType = MediaType.FileTransferServer,
+            BackupFolder = @"E:\OldBackups",
+            MediaVolumeSerial = "1234567890",
+            UNCUsername = "old-user",
+            UNCPassword = "old-password",
+            FtpHost = "ftp.old",
+            FtpUser = "ftp-user",
+            FtpPass = "ftp-pass",
+            FtpFolder = "/old",
+            FtpCoding = "UTF8",
+            FtpEncryptionMode = "3",
+            FtpSslProtocols = "0",
+        };
+
+        MediaTargetApplier.ApplyEmptyLocalTarget(configuration);
+
+        Assert.That(configuration.MediumType, Is.EqualTo(MediaType.LocalDevice));
+        Assert.That(configuration.BackupFolder, Is.EqualTo(""));
+        Assert.That(configuration.MediaVolumeSerial, Is.EqualTo(""));
+        Assert.That(configuration.UNCUsername, Is.EqualTo(""));
+        Assert.That(configuration.UNCPassword, Is.EqualTo(""));
+        Assert.That(configuration.FtpHost, Is.EqualTo(""));
+        Assert.That(configuration.FtpUser, Is.EqualTo(""));
+        Assert.That(configuration.FtpPass, Is.EqualTo(""));
+        Assert.That(configuration.FtpFolder, Is.EqualTo(""));
+        Assert.That(configuration.FtpCoding, Is.EqualTo(""));
+        Assert.That(configuration.FtpEncryptionMode, Is.EqualTo(""));
+        Assert.That(configuration.FtpSslProtocols, Is.EqualTo(""));
+    }
+
+    [Test]
     public void ApplyLocalTarget_SetsFolderSerialAndClearsUncCredentials()
     {
         var configuration = new FakeConfigurationManager

--- a/src/BSH.Test/SettingsViewModelTests.cs
+++ b/src/BSH.Test/SettingsViewModelTests.cs
@@ -132,10 +132,11 @@ public class SettingsViewModelTests
     }
 
     [Test]
-    public async Task TurningEncryptionOff_RunsMediaCheckPasswordAndDecryptJob()
+    public async Task TurningEncryptionOff_OnLocal_RunsMediaCheckPasswordAndDecryptJob()
     {
         var configuration = new FakeConfigurationManager
         {
+            MediumType = MediaType.LocalDevice,
             Encrypt = 1,
             EncryptPassMD5 = "existing-hash"
         };
@@ -150,8 +151,115 @@ public class SettingsViewModelTests
             Assert.That(harness.JobService.CheckMediaCalls, Is.EqualTo(new[] { ActionType.Restore }));
             Assert.That(harness.JobService.RequestPasswordCallCount, Is.EqualTo(1));
             Assert.That(harness.JobService.ModifyBackupCalls, Is.EqualTo(1));
+            Assert.That(harness.JobService.DeleteBackupsCalls, Is.Empty);
             Assert.That(configuration.Encrypt, Is.EqualTo(0));
             Assert.That(harness.ViewModel.ModeType, Is.EqualTo(ModeType.RegularCopy));
+        });
+    }
+
+    [Test]
+    public async Task TurningEncryptionOff_OnFtp_DeletesAllBackupsWithoutDecryptJob()
+    {
+        var configuration = new FakeConfigurationManager
+        {
+            MediumType = MediaType.FileTransferServer,
+            Encrypt = 1,
+            EncryptPassMD5 = "existing-hash",
+            FtpHost = "ftp.example.com",
+            FtpEncryptionMode = "3"
+        };
+        var harness = CreateHarness(configuration);
+        harness.QueryManager.Versions =
+        [
+            new VersionDetails { Id = "1" },
+            new VersionDetails { Id = "2" }
+        ];
+        harness.ViewModel.OnNavigatedTo(null);
+
+        await harness.ViewModel.DisableEncryptionCommand.ExecuteAsync(null);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(harness.JobService.CheckMediaCalls, Is.EqualTo(new[] { ActionType.Delete }));
+            Assert.That(harness.JobService.RequestPasswordCallCount, Is.EqualTo(0));
+            Assert.That(harness.JobService.ModifyBackupCalls, Is.EqualTo(0));
+            Assert.That(harness.JobService.DeleteBackupsCalls, Has.Count.EqualTo(1));
+            Assert.That(harness.JobService.DeleteBackupsCalls[0], Is.EqualTo(new[] { "1", "2" }));
+            Assert.That(configuration.Encrypt, Is.EqualTo(0));
+            Assert.That(configuration.EncryptPassMD5, Is.EqualTo(""));
+            Assert.That(harness.ViewModel.ModeType, Is.EqualTo(ModeType.RegularCopy));
+        });
+    }
+
+    [Test]
+    public async Task TurningEncryptionOff_OnFtp_WhenMediaCheckFails_KeepsEncryption()
+    {
+        var configuration = new FakeConfigurationManager
+        {
+            MediumType = MediaType.FileTransferServer,
+            Encrypt = 1,
+            EncryptPassMD5 = "existing-hash"
+        };
+        var harness = CreateHarness(configuration);
+        harness.QueryManager.Versions = [new VersionDetails { Id = "1" }];
+        harness.JobService.CheckMediaResult = false;
+        harness.ViewModel.OnNavigatedTo(null);
+
+        await harness.ViewModel.DisableEncryptionCommand.ExecuteAsync(null);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(harness.JobService.CheckMediaCalls, Is.EqualTo(new[] { ActionType.Delete }));
+            Assert.That(harness.JobService.DeleteBackupsCalls, Is.Empty);
+            Assert.That(harness.JobService.ModifyBackupCalls, Is.EqualTo(0));
+            Assert.That(configuration.Encrypt, Is.EqualTo(1));
+            Assert.That(configuration.EncryptPassMD5, Is.EqualTo("existing-hash"));
+            Assert.That(harness.ViewModel.ModeType, Is.EqualTo(ModeType.Encryption));
+        });
+    }
+
+    [Test]
+    public async Task EnforcingUnencryptedFtp_DeletesAllBackups()
+    {
+        var configuration = CreateFtpConfiguration();
+        var harness = CreateHarness(configuration);
+        harness.QueryManager.Versions =
+        [
+            new VersionDetails { Id = "10" },
+            new VersionDetails { Id = "11" }
+        ];
+        harness.ViewModel.OnNavigatedTo(null);
+
+        await harness.ViewModel.ChangeFtpRemoteEnforceUnencryptedAsync(true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(harness.JobService.CheckMediaCalls, Is.EqualTo(new[] { ActionType.Delete }));
+            Assert.That(harness.JobService.DeleteBackupsCalls, Has.Count.EqualTo(1));
+            Assert.That(harness.JobService.DeleteBackupsCalls[0], Is.EqualTo(new[] { "10", "11" }));
+            Assert.That(harness.JobService.ModifyBackupCalls, Is.EqualTo(0));
+            Assert.That(configuration.FtpEncryptionMode, Is.EqualTo("0"));
+            Assert.That(harness.ViewModel.FtpRemoteEnforceUnencrypted, Is.True);
+        });
+    }
+
+    [Test]
+    public async Task EnforcingUnencryptedFtp_WhenMediaCheckFails_DoesNotDeleteOrPersist()
+    {
+        var configuration = CreateFtpConfiguration();
+        var harness = CreateHarness(configuration);
+        harness.QueryManager.Versions = [new VersionDetails { Id = "10" }];
+        harness.JobService.CheckMediaResult = false;
+        harness.ViewModel.OnNavigatedTo(null);
+
+        await harness.ViewModel.ChangeFtpRemoteEnforceUnencryptedAsync(true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(harness.JobService.CheckMediaCalls, Is.EqualTo(new[] { ActionType.Delete }));
+            Assert.That(harness.JobService.DeleteBackupsCalls, Is.Empty);
+            Assert.That(configuration.FtpEncryptionMode, Is.EqualTo("3"));
+            Assert.That(harness.ViewModel.FtpRemoteEnforceUnencrypted, Is.False);
         });
     }
 

--- a/src/BSH.Test/SettingsViewModelTests.cs
+++ b/src/BSH.Test/SettingsViewModelTests.cs
@@ -1,0 +1,463 @@
+// Copyright (c) Alexander Seeliger. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Brightbits.BSH.Engine;
+using Brightbits.BSH.Engine.Contracts;
+using Brightbits.BSH.Engine.Jobs;
+using Brightbits.BSH.Engine.Models;
+using Brightbits.BSH.Engine.Security;
+using Brightbits.BSH.Engine.Storage;
+using BSH.MainApp.Contracts.Services;
+using BSH.MainApp.Models;
+using BSH.MainApp.ViewModels;
+using BSH.MainApp.ViewModels.Windows;
+using BSH.Test.Fakes;
+using Microsoft.UI.Xaml.Controls;
+using NUnit.Framework;
+using Windows.UI.Popups;
+
+namespace BSH.Test;
+
+[TestFixture]
+public class SettingsViewModelTests
+{
+    [Test]
+    public void FtpFields_PersistAndReloadAcrossNavigation()
+    {
+        var configuration = CreateFtpConfiguration();
+        var harness = CreateHarness(configuration);
+        harness.ViewModel.OnNavigatedTo(null);
+
+        harness.ViewModel.FtpRemoteHost = "ftp.page.example";
+        harness.ViewModel.FtpRemotePort = 2121;
+        harness.ViewModel.FtpRemoteUser = "page-user";
+        harness.ViewModel.FtpRemotePassword = "page-secret";
+        harness.ViewModel.FtpRemotePath = @"backups\home";
+        harness.ViewModel.OnNavigatedFrom();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(configuration.FtpHost, Is.EqualTo("ftp.page.example"));
+            Assert.That(configuration.FtpPort, Is.EqualTo("2121"));
+            Assert.That(configuration.FtpUser, Is.EqualTo("page-user"));
+            Assert.That(configuration.FtpPass, Is.EqualTo("page-secret"));
+            Assert.That(configuration.FtpFolder, Is.EqualTo(FtpStorage.GetFtpPath(@"backups\home")));
+        });
+
+        var reloaded = CreateHarness(configuration).ViewModel;
+        reloaded.OnNavigatedTo(null);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(reloaded.FtpRemoteHost, Is.EqualTo("ftp.page.example"));
+            Assert.That(reloaded.FtpRemotePort, Is.EqualTo(2121));
+            Assert.That(reloaded.FtpRemoteUser, Is.EqualTo("page-user"));
+            Assert.That(reloaded.FtpRemotePassword, Is.EqualTo("page-secret"));
+            Assert.That(reloaded.FtpRemotePath, Is.EqualTo(FtpStorage.GetFtpPath(@"backups\home")));
+        });
+    }
+
+    [Test]
+    public void FtpTestConnection_UsesDisplayedFields_NotStaleStoredCredentials()
+    {
+        var configuration = CreateFtpConfiguration();
+        var harness = CreateHarness(configuration);
+        harness.ViewModel.OnNavigatedTo(null);
+
+        harness.ViewModel.FtpRemoteHost = "ftp.page.example";
+        harness.ViewModel.FtpRemotePort = 2121;
+        harness.ViewModel.FtpRemoteUser = "page-user";
+        harness.ViewModel.FtpRemotePassword = "page-secret";
+        harness.ViewModel.FtpRemotePath = "/page-path";
+        harness.ViewModel.FtpRemoteEncoding = "ISO-8859-1";
+
+        configuration.FtpHost = "ftp.stale.example";
+        configuration.FtpPort = "21";
+        configuration.FtpUser = "stale-user";
+        configuration.FtpPass = "stale-secret";
+        configuration.FtpFolder = "/stale-path";
+        configuration.FtpCoding = "UTF8";
+
+        var probe = harness.ViewModel.GetDisplayedFtpConnectionValues();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(probe.Host, Is.EqualTo("ftp.page.example"));
+            Assert.That(probe.Port, Is.EqualTo(2121));
+            Assert.That(probe.User, Is.EqualTo("page-user"));
+            Assert.That(probe.Password, Is.EqualTo("page-secret"));
+            Assert.That(probe.Path, Is.EqualTo("/page-path"));
+            Assert.That(probe.Encoding, Is.EqualTo("ISO-8859-1"));
+            Assert.That(configuration.FtpHost, Is.EqualTo("ftp.stale.example"));
+        });
+    }
+
+    [Test]
+    public void Options_WhenEncryptAndCompressionAreBothSet_ShowsEncryption()
+    {
+        var configuration = new FakeConfigurationManager
+        {
+            Encrypt = 1,
+            Compression = 1
+        };
+        var harness = CreateHarness(configuration);
+        harness.ViewModel.OnNavigatedTo(null);
+
+        Assert.That(harness.ViewModel.ModeType, Is.EqualTo(ModeType.Encryption));
+        Assert.That(harness.ViewModel.CanSelectNonEncryptionMode, Is.False);
+    }
+
+    [Test]
+    public async Task RegularOrCompress_WhileEncrypted_DoesNotClearEncryptWithoutDecryptJob()
+    {
+        var configuration = new FakeConfigurationManager { Encrypt = 1, Compression = 0 };
+        var harness = CreateHarness(configuration);
+        harness.JobService.RequestPasswordResult = false;
+        harness.ViewModel.OnNavigatedTo(null);
+
+        await harness.ViewModel.ChangeModeTypeAsync(ModeType.RegularCopy);
+        await harness.ViewModel.ChangeModeTypeAsync(ModeType.Compression);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(configuration.Encrypt, Is.EqualTo(1));
+            Assert.That(configuration.Compression, Is.EqualTo(0));
+            Assert.That(harness.ViewModel.ModeType, Is.EqualTo(ModeType.Encryption));
+            Assert.That(harness.JobService.ModifyBackupCalls, Is.EqualTo(0));
+        });
+    }
+
+    [Test]
+    public async Task TurningEncryptionOff_RunsMediaCheckPasswordAndDecryptJob()
+    {
+        var configuration = new FakeConfigurationManager
+        {
+            Encrypt = 1,
+            EncryptPassMD5 = "existing-hash"
+        };
+        var harness = CreateHarness(configuration);
+        harness.JobService.ClearEncryptionOnModify = true;
+        harness.ViewModel.OnNavigatedTo(null);
+
+        await harness.ViewModel.DisableEncryptionCommand.ExecuteAsync(null);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(harness.JobService.CheckMediaCalls, Is.EqualTo(new[] { ActionType.Restore }));
+            Assert.That(harness.JobService.RequestPasswordCallCount, Is.EqualTo(1));
+            Assert.That(harness.JobService.ModifyBackupCalls, Is.EqualTo(1));
+            Assert.That(configuration.Encrypt, Is.EqualTo(0));
+            Assert.That(harness.ViewModel.ModeType, Is.EqualTo(ModeType.RegularCopy));
+        });
+    }
+
+    [Test]
+    public async Task TurningEncryptionOn_ClearsCompression_AndShowsEncryption()
+    {
+        var configuration = new FakeConfigurationManager { Compression = 1, Encrypt = 0 };
+        var harness = CreateHarness(configuration);
+        harness.PresentationService.Password = "secret";
+        harness.ViewModel.OnNavigatedTo(null);
+
+        await harness.ViewModel.ChangeModeTypeAsync(ModeType.Encryption);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(configuration.Encrypt, Is.EqualTo(1));
+            Assert.That(configuration.Compression, Is.EqualTo(0));
+            Assert.That(configuration.EncryptPassMD5, Is.EqualTo(Hash.GetMD5Hash("secret")));
+            Assert.That(harness.ViewModel.ModeType, Is.EqualTo(ModeType.Encryption));
+        });
+    }
+
+    [Test]
+    public async Task SwitchingLocalToFtp_AppliesFtpTargetAndClearsLocalPath()
+    {
+        var configuration = new FakeConfigurationManager
+        {
+            MediumType = MediaType.LocalDevice,
+            BackupFolder = @"D:\Backups",
+            MediaVolumeSerial = "ABCDEF12",
+            FtpHost = "",
+            FtpPort = "",
+            FtpUser = "",
+            FtpPass = "",
+            FtpFolder = ""
+        };
+        var harness = CreateHarness(configuration);
+        harness.QueryManager.Versions =
+        [
+            new VersionDetails { Id = "1" },
+            new VersionDetails { Id = "2" }
+        ];
+        harness.ViewModel.OnNavigatedTo(null);
+
+        harness.ViewModel.FtpRemoteHost = "ftp.example.com";
+        harness.ViewModel.FtpRemotePort = 21;
+        harness.ViewModel.FtpRemoteUser = "ftp-user";
+        harness.ViewModel.FtpRemotePassword = "ftp-pass";
+        harness.ViewModel.FtpRemotePath = "/backups";
+
+        await harness.ViewModel.ChangeSelectedMediaTypeAsync(MediaType.FileTransferServer);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(configuration.MediumType, Is.EqualTo(MediaType.FileTransferServer));
+            Assert.That(configuration.BackupFolder, Is.EqualTo(""));
+            Assert.That(configuration.MediaVolumeSerial, Is.EqualTo(""));
+            Assert.That(configuration.FtpHost, Is.EqualTo("ftp.example.com"));
+            Assert.That(configuration.FtpUser, Is.EqualTo("ftp-user"));
+            Assert.That(harness.JobService.DeleteBackupsCalls, Has.Count.EqualTo(1));
+            Assert.That(harness.JobService.DeleteBackupsCalls[0], Is.EqualTo(new[] { "1", "2" }));
+        });
+    }
+
+    [Test]
+    public async Task SwitchingFtpToLocal_AppliesLocalTargetAndClearsFtpFields()
+    {
+        var configuration = new FakeConfigurationManager
+        {
+            MediumType = MediaType.FileTransferServer,
+            BackupFolder = "",
+            FtpHost = "ftp.old",
+            FtpPort = "21",
+            FtpUser = "ftp-user",
+            FtpPass = "ftp-pass",
+            FtpFolder = "/old",
+            FtpCoding = "UTF8",
+            FtpEncryptionMode = "3",
+            FtpSslProtocols = "0"
+        };
+        var harness = CreateHarness(configuration);
+        harness.ViewModel.OnNavigatedTo(null);
+        harness.ViewModel.LocalDevicePath = @"D:\Backups";
+
+        await harness.ViewModel.ChangeSelectedMediaTypeAsync(MediaType.LocalDevice);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(configuration.MediumType, Is.EqualTo(MediaType.LocalDevice));
+            Assert.That(configuration.BackupFolder, Is.EqualTo(@"D:\Backups"));
+            Assert.That(configuration.FtpHost, Is.EqualTo(""));
+            Assert.That(configuration.FtpUser, Is.EqualTo(""));
+            Assert.That(configuration.FtpPass, Is.EqualTo(""));
+            Assert.That(configuration.FtpFolder, Is.EqualTo(""));
+            Assert.That(configuration.FtpCoding, Is.EqualTo(""));
+            Assert.That(configuration.FtpEncryptionMode, Is.EqualTo(""));
+        });
+    }
+
+    [Test]
+    public void OnNavigatedFrom_WhenFtpTarget_ClearsLeftoverLocalPath()
+    {
+        var configuration = CreateFtpConfiguration();
+        configuration.BackupFolder = @"D:\Leftover";
+        configuration.MediaVolumeSerial = "ABCDEF12";
+        var harness = CreateHarness(configuration);
+        harness.ViewModel.OnNavigatedTo(null);
+        harness.ViewModel.OnNavigatedFrom();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(configuration.MediumType, Is.EqualTo(MediaType.FileTransferServer));
+            Assert.That(configuration.BackupFolder, Is.EqualTo(""));
+            Assert.That(configuration.MediaVolumeSerial, Is.EqualTo(""));
+            Assert.That(configuration.FtpHost, Is.EqualTo("ftp.stored.example"));
+        });
+    }
+
+    private static FakeConfigurationManager CreateFtpConfiguration() => new()
+    {
+        MediumType = MediaType.FileTransferServer,
+        FtpHost = "ftp.stored.example",
+        FtpPort = "21",
+        FtpUser = "stored-user",
+        FtpPass = "stored-secret",
+        FtpFolder = "/stored",
+        FtpCoding = "UTF8",
+        FtpEncryptionMode = "3"
+    };
+
+    private static SettingsHarness CreateHarness(FakeConfigurationManager configuration)
+    {
+        var presentation = new SettingsPresentationService();
+        var jobService = new SettingsJobService(configuration);
+        var queryManager = new SettingsQueryManager();
+        var viewModel = new SettingsViewModel(
+            configuration,
+            presentation,
+            jobService,
+            queryManager,
+            new SettingsBackupTargetService(),
+            new SettingsSwitchStorageService(),
+            new SettingsOrchestrationService(),
+            new SettingsStartupLaunchAdapter(),
+            new SettingsUpdateService());
+
+        return new SettingsHarness(viewModel, presentation, jobService, queryManager);
+    }
+
+    private sealed record SettingsHarness(
+        SettingsViewModel ViewModel,
+        SettingsPresentationService PresentationService,
+        SettingsJobService JobService,
+        SettingsQueryManager QueryManager);
+
+    private sealed class SettingsPresentationService : IPresentationService
+    {
+        public ContentDialogResult MessageBoxResult { get; set; } = ContentDialogResult.Primary;
+        public string? Password { get; set; }
+
+        public Task CloseBackupBrowserWindowAsync() => Task.CompletedTask;
+        public Task CloseMainWindowAsync() => Task.CompletedTask;
+        public Task<TaskCompleteAction> CloseStatusWindowAsync() => Task.FromResult(TaskCompleteAction.NoAction);
+        public Task OpenCurrentEventLogAsync() => Task.CompletedTask;
+        public Task OpenHelpSupportAsync() => Task.CompletedTask;
+        public Task<(string? password, bool persist)> RequestPasswordAsync() => Task.FromResult((Password, false));
+        public Task<RequestOverwriteResult> RequestOverwriteAsync(FileTableRow localFile, FileTableRow remoteFile) => Task.FromResult(RequestOverwriteResult.None);
+        public Task ResetConfigurationAsync() => Task.CompletedTask;
+        public Task ShowAboutWindowAsync() => Task.CompletedTask;
+        public Task ShowBackupBrowserWindowAsync() => Task.CompletedTask;
+        public Task ShowCompressionExclusionsWindowAsync() => Task.CompletedTask;
+        public Task<(bool, NewBackupViewModel)> ShowCreateBackupWindowAsync() => Task.FromResult((false, new NewBackupViewModel()));
+        public Task<(bool, EditBackupViewModel)> ShowEditBackupWindowAsync(EditBackupViewModel backupViewModel) => Task.FromResult((false, backupViewModel));
+        public Task<bool> ShowDeleteBackupWindowAsync() => Task.FromResult(false);
+        public Task ShowErrorInsufficientDiskSpaceAsync() => Task.CompletedTask;
+        public Task ShowFileExceptionsAsync(IReadOnlyCollection<FileExceptionEntry> files) => Task.CompletedTask;
+        public Task ShowMainWindowAsync() => Task.CompletedTask;
+        public Task ShowStatusWindowAsync() => Task.CompletedTask;
+        public Task<ContentDialogResult> ShowMessageBoxAsync(string title, string content, IList<IUICommand>? commands, uint defaultCommandIndex = 0, uint cancelCommandIndex = 1) => Task.FromResult(MessageBoxResult);
+        public Task ShowExcludeFileFolderWindowAsync() => Task.CompletedTask;
+        public Task ShowScheduleEditorWindowAsync() => Task.CompletedTask;
+        public Task<bool> ShowSwitchStorageWindowAsync() => Task.FromResult(false);
+    }
+
+    private sealed class SettingsJobService : IJobService
+    {
+        private readonly FakeConfigurationManager configuration;
+
+        public SettingsJobService(FakeConfigurationManager configuration)
+        {
+            this.configuration = configuration;
+        }
+
+        public List<ActionType> CheckMediaCalls { get; } = [];
+        public List<List<string>> DeleteBackupsCalls { get; } = [];
+        public int RequestPasswordCallCount { get; private set; }
+        public int ModifyBackupCalls { get; private set; }
+        public bool CheckMediaResult { get; set; } = true;
+        public bool RequestPasswordResult { get; set; } = true;
+        public bool ClearEncryptionOnModify { get; set; }
+
+        public bool IsCancellationRequested => false;
+        public void Cancel() { }
+        public Task<bool> CheckMediaAsync(ActionType action, bool silent = false)
+        {
+            CheckMediaCalls.Add(action);
+            return Task.FromResult(CheckMediaResult);
+        }
+
+        public Task<bool> CreateBackupAsync(string title, string description, bool statusDialog = true, bool fullBackup = false, bool shutdownPC = false, bool shutdownApp = false, string sourceFolders = "") => Task.FromResult(true);
+        public Task DeleteBackupAsync(string version, bool statusDialog = true) => Task.CompletedTask;
+        public Task DeleteBackupsAsync(List<string> versions, bool statusDialog = true)
+        {
+            DeleteBackupsCalls.Add(versions);
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteSingleFileAsync(string fileFilter, string folderFilter, bool statusDialog = true, IReadOnlyList<int>? versionIds = null) => Task.CompletedTask;
+        public CancellationToken GetNewCancellationToken() => CancellationToken.None;
+        public Task<bool> RequestPassword()
+        {
+            RequestPasswordCallCount++;
+            return Task.FromResult(RequestPasswordResult);
+        }
+
+        public Task RestoreBackupAsync(string version, List<string> files, string destination, bool statusDialog = true) => Task.CompletedTask;
+        public Task RestoreBackupAsync(string version, string file, string destination, bool statusDialog = true) => Task.CompletedTask;
+        public Task ModifyBackupAsync(bool statusDialog = true)
+        {
+            ModifyBackupCalls++;
+            if (ClearEncryptionOnModify)
+            {
+                configuration.Encrypt = 0;
+                configuration.EncryptPassMD5 = "";
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class SettingsQueryManager : IQueryManager
+    {
+        public List<VersionDetails> Versions { get; set; } = [];
+
+        public Task<string> GetBackVersionWhereFileAsync(string startVersion, string searchString) => Task.FromResult("");
+        public Task<string> GetBackVersionWhereFilesInFolderAsync(string startVersion, string path) => Task.FromResult("");
+        public string GetFileNameFromDrive(FileTableRow file) => "";
+        public Task<(string, bool)> GetFileNameFromDriveAsync(int versionId, string fileName, string filePath, string password) => Task.FromResult(("", false));
+        public Task<FileDetails> GetFileDetailsAsync(string version, string fileName, string filePath) => Task.FromResult(new FileDetails());
+        public Task<List<FileTableRow>> GetFilesByVersionAsync(string version, string path) => Task.FromResult(new List<FileTableRow>());
+        public Task<List<string>> GetFolderListAsync(string version, string path) => Task.FromResult(new List<string>());
+        public Task<string> GetFullRestoreFolderAsync(string folder, string version) => Task.FromResult("");
+        public Task<VersionDetails> GetLastBackupAsync() => Task.FromResult<VersionDetails>(null);
+        public Task<VersionDetails> GetLastFullBackupAsync() => Task.FromResult<VersionDetails>(null);
+        public Task<string> GetLocalizedPathAsync(string path) => Task.FromResult(path);
+        public Task<string> GetNextVersionWhereFileAsync(string startVersion, string searchString) => Task.FromResult("");
+        public Task<string> GetNextVersionWhereFilesInFolderAsync(string startVersion, string path) => Task.FromResult("");
+        public Task<int> GetNumberOfVersionsAsync() => Task.FromResult(Versions.Count);
+        public Task<int> GetNumberOfFilesAsync() => Task.FromResult(0);
+        public Task<double> GetTotalFileSizeAsync() => Task.FromResult(0d);
+        public Task<VersionDetails> GetOldestBackupAsync() => Task.FromResult<VersionDetails>(null);
+        public Task<VersionDetails> GetVersionByIdAsync(string id) => Task.FromResult<VersionDetails>(null);
+        public List<VersionDetails> GetVersions(bool desc = true) => Versions;
+        public Task<List<FileTableRow>> GetVersionsByFileAsync(string fileName, string filePath) => Task.FromResult(new List<FileTableRow>());
+        public Task<List<FileTableRow>> SearchFilesByVersionAsync(string version, string searchTerm, int limit = 500) => Task.FromResult(new List<FileTableRow>());
+        public Task<bool> HasChangesOrNewAsync(string path, string versionId) => Task.FromResult(false);
+    }
+
+    private sealed class SettingsBackupTargetService : IBackupTargetService
+    {
+        public Task<BackupTargetMoveResult> MoveExistingBackupDataAsync(string currentFolderPath, string newFolderPath) => Task.FromResult(BackupTargetMoveResult.Succeeded);
+    }
+
+    private sealed class SettingsSwitchStorageService : ISwitchStorageService
+    {
+        public bool LocalTargetContainsBackupData(string driveRoot) => false;
+        public bool UncTargetContainsBackupData(string uncPath) => false;
+        public void SyncDatabaseToCurrentMedium(string databaseFile) { }
+        public Task SwitchToLocalAsync(string driveRoot, string? mediaVolumeSerial, string databaseFile) => Task.CompletedTask;
+        public Task SwitchToUncAsync(SwitchStorageUncTarget unc, string databaseFile) => Task.CompletedTask;
+        public Task SwitchToFtpAsync(SwitchStorageFtpTarget ftp, string databaseFile) => Task.CompletedTask;
+    }
+
+    private sealed class SettingsOrchestrationService : IOrchestrationService
+    {
+        public Task InitializeAsync() => Task.CompletedTask;
+        public Task StartAsync(bool turnOn = false) => Task.CompletedTask;
+        public Task StopAsync(bool turnOff = false) => Task.CompletedTask;
+        public Task RefreshAutomationAsync() => Task.CompletedTask;
+    }
+
+    private sealed class SettingsStartupLaunchAdapter : IStartupLaunchAdapter
+    {
+        public bool IsEnabled() => false;
+        public bool TrySetEnabled(bool enabled) => true;
+    }
+
+    private sealed class SettingsUpdateService : IUpdateService
+    {
+        public Task InitializeAsync(Action onApplicationExitRequested) => Task.CompletedTask;
+        public Task CheckAsync(bool notifyWhenUpToDate) => Task.CompletedTask;
+        public Task MaybeCheckOnStartupAsync() => Task.CompletedTask;
+        public Task<bool> GetAutoSearchEnabledAsync() => Task.FromResult(true);
+        public Task SetAutoSearchEnabledAsync(bool enabled) => Task.CompletedTask;
+        public Task<bool> GetDownloadBetaAsync() => Task.FromResult(false);
+        public Task SetDownloadBetaAsync(bool enabled) => Task.CompletedTask;
+        public Task<string> ResetUniqueUserIdAsync() => Task.FromResult("");
+    }
+}


### PR DESCRIPTION
WinUI Settings now persist FTP host, port, user, password, and path, and Test Connection uses those page values instead of stale stored credentials. Encryption can no longer be cleared by picking Regular or Compress; turning it off runs the decrypt job (media check and password), and turning it on clears compression so Options shows Encryption. Switching Local and FTP applies the new medium through the shared target applier so leftover local paths or empty FTP fields are not left behind.

Closes #609

## Test plan
- [ ] Edit FTP host, port, user, password, and path on Settings, then navigate away and restart — values remain
- [ ] Test Connection uses the values shown on the page, not previously stored credentials
- [ ] With encryption on, Regular/Compress cannot silently mark archives as unencrypted
- [ ] Turn Off encryption prompts for media and password and decrypts existing backups
- [ ] Turn encryption on while compression is selected — Options shows Encryption, not Compress
- [ ] Switch Local ↔ FTP after confirming version deletion — engine no longer keeps the previous medium's path or empty FTP fields

Made with [Cursor](https://cursor.com)